### PR TITLE
docs: PRD v1.3 / 基本設計書 v1.1 へ改訂 — プロトタイプ反映

### DIFF
--- a/docs/design/00-index.md
+++ b/docs/design/00-index.md
@@ -4,8 +4,8 @@
 |---|---|
 | プロダクト名 | TRAKON |
 | 発行元 | 株式会社おさまるカンパニー |
-| ドキュメント版 | **v1.1（非会員URL共有 Phase 0 化）** |
-| 発行日 | 2026-05-09 |
+| ドキュメント版 | **v1.1（非会員URL Phase 0 化 + プロトタイプ反映）** |
+| 発行日 | 2026-05-24 |
 | ステータス | **v1.1 確定**（全6章） |
 | 本書の位置づけ | 基本原則 > PRD > **本基本設計書** > 実装仕様書 |
 | 上位ドキュメント | [TRAKON PRD v1.3](../prd/trakon-prd.md) |
@@ -24,7 +24,8 @@
 | v0.5 | 2026-05-09 | 第4章「画面・コンポーネント設計」v1.0 確定（Data Router + TQ集約 / RHF+zodResolver / date-fns / Lucide / **モーダルはURL同期** / CSS Grid 縦型カレンダー / 楽観更新 Phase 0 から / 祝日 FE直接 / accent 仮確定 / i18n はjaのみ集約）。Phase 0 必須画面 SC-01,02,03,04,06,07,08,10,11 を §4.4 で詳細化、Ball Holder 楽観更新責務を §4.7 で定義。 | — |
 | v0.6 | 2026-05-09 | 第5章「セキュリティ実装設計」v1.0 確定（FE トークン localStorage + CSP厳格化 / Resend 自前送信 / パスワード Phase 0 8文字英数記号、HIBP は Phase 1 / ロックアウト Phase 1 / レート制限 Phase 1 / CSP は Phase 0 unsafe-inline 許容 / 監査ログは同期トランザクション / サインイン失敗は区別なし / 規約は同意チェックのみ / Sentry は PII scrub）。多層防御 7層・OWASP Top 10 対策・招待トークン自前管理を §5.3〜§5.7 で定義。 | — |
 | v1.0 | 2026-05-09 | 第6章「インフラ・デプロイ・運用」v1.0 確定（dev+prod 2環境 / Supabase CLI ローカル / 仮ドメイン → 商用前に本確定 / Sentry 1プロジェクト + env タグ / Phase 0 はレビュースキップ可 / 復元テスト Phase 1 から / ログは既定保管 + audit_logs のみ DB 長期 / Better Stack Uptime / app_user + app_migrator 分離 / **Production デプロイは GitHub Release 公開がトリガ**）。全6章 v1.0 確定により基本設計書 v1.0 完成。 | — |
-| v1.1 | 2026-05-09 | PRD v1.3 改訂（非会員URL共有を Phase 1 → Phase 0 へ前倒し）に追従。FR-SHARE-01〜06、SR-AUTH-08、UC-23、SC-16、`share_links` テーブルを Phase 0 スコープに取り込み、第1〜6章の Phase 区切り・テーブル定義・エンドポイント一覧・画面ツリー・認可ガード・監査ログ記録対象を更新。組織レベル統制（FR-ORG-04, 05、FR-SHARE-07、SR-AUTH-09、`organizations` / `organization_settings`）は Phase 2 維持。 | — |
+| v1.1a | 2026-05-09 | **PRD v1.3 改訂（非会員URL共有を Phase 1 → Phase 0 へ前倒し）に追従**。FR-SHARE-01〜06、SR-AUTH-08、UC-23、SC-16、`share_links` テーブルを Phase 0 スコープに取り込み、第1〜6章の Phase 区切り・テーブル定義・エンドポイント一覧・画面ツリー・認可ガード・監査ログ記録対象を更新。組織レベル統制（FR-ORG-04, 05、FR-SHARE-07、SR-AUTH-09、`organizations` / `organization_settings`）は Phase 2 維持。 | — |
+| v1.1b | 2026-05-24 | **Figma Make プロトタイプ反映による全章改訂**。① Google/Microsoft OAuth（FR-AUTH-10、Phase 0 から）／② 新規登録項目拡充（full_name + display_name、Magic-link 風サインアップ、FR-AUTH-11）／③ 後続紐付け自動 TOSS（plans.successor_plan_id、FR-SCH-17、FR-BALL-13、UC-25）／④ ダッシュボード階層ビュー（プロジェクト×メンバー×今日、SC-09 改訂、Phase 0 へ繰り上げ）／⑤ カテゴリ必須（plans.category 6値、FR-SCH-18）／⑥ メンバーかんばん SC-17 新規（DnD = TOSS、UC-26）／⑦ oauth_identities テーブル新規。PRD v1.3、02-database v1.1、03-api v1.1、04-frontend v1.1、05-security v1.1、06-infrastructure v1.1 を同期反映。v1.1a と統合し **v1.1 として確定**。 | — |
 
 ---
 
@@ -36,9 +37,9 @@ PRD で「**何を・誰に・なぜ作るか**」が確定した内容を、**�
 ┌──────────────────────────────────────────┐
 │  TRAKON 基本原則 v1.0（思想・判断基準の最上位）│
 ├──────────────────────────────────────────┤
-│  TRAKON PRD v1.3（要件定義）                │
+│  TRAKON PRD v1.3（要件定義：非会員URL前倒し + プロトタイプ反映）│
 ├──────────────────────────────────────────┤
-│  TRAKON 基本設計書（本書）                   │ ← ココ
+│  TRAKON 基本設計書 v1.1（本書）              │ ← ココ
 │   - 構成・スタック・スキーマ・API・画面・運用 │
 ├──────────────────────────────────────────┤
 │  実装仕様書 ／ コードベース                  │
@@ -66,12 +67,12 @@ PRD で「**何を・誰に・なぜ作るか**」が確定した内容を、**�
 | 順 | ファイル | 領域 | ステータス |
 |---|---|---|---|
 | 0 | [00-index.md](00-index.md) | 全章のINDEX・改訂履歴・前提整理 | Draft（随時更新） |
-| 1 | [01-architecture.md](01-architecture.md) | システム構成・スタック詳細・拡張戦略 | **v1.1 確定（2026-05-09）** |
-| 2 | [02-database.md](02-database.md) | テーブル定義・制約・インデックス・マイグレーション | **v1.1 確定（2026-05-09）** |
-| 3 | [03-api.md](03-api.md) | REST エンドポイント・OpenAPI・認可ガード・エラーモデル | **v1.1 確定（2026-05-09）** |
-| 4 | [04-frontend.md](04-frontend.md) | 画面ツリー・ルーティング・状態管理・モーダル制御 | **v1.1 確定（2026-05-09）** |
-| 5 | [05-security.md](05-security.md) | 認証・認可・監査・添付・XSS/CSRF・トークン管理 | **v1.1 確定（2026-05-09）** |
-| 6 | [06-infrastructure.md](06-infrastructure.md) | Vercel/Supabase 構成・環境分離・CI/CD・バックアップ・監視 | **v1.1 確定（2026-05-09）** |
+| 1 | [01-architecture.md](01-architecture.md) | システム構成・スタック詳細・拡張戦略 | **v1.0 確定（2026-05-09）** ※v1.1 で変更なし |
+| 2 | [02-database.md](02-database.md) | テーブル定義・制約・インデックス・マイグレーション | **v1.1 確定（2026-05-24）** |
+| 3 | [03-api.md](03-api.md) | REST エンドポイント・OpenAPI・認可ガード・エラーモデル | **v1.1 確定（2026-05-24）** |
+| 4 | [04-frontend.md](04-frontend.md) | 画面ツリー・ルーティング・状態管理・モーダル制御 | **v1.1 確定（2026-05-24）** |
+| 5 | [05-security.md](05-security.md) | 認証・認可・監査・添付・XSS/CSRF・トークン管理 | **v1.1 確定（2026-05-24）** |
+| 6 | [06-infrastructure.md](06-infrastructure.md) | Vercel/Supabase 構成・環境分離・CI/CD・バックアップ・監視 | **v1.1 確定（2026-05-24）** |
 
 > ステータス凡例：未着手 / Draft（たたき台） / Review中 / **v1.x 確定** / Phase 1 拡張
 
@@ -91,3 +92,18 @@ PRD で「**何を・誰に・なぜ作るか**」が確定した内容を、**�
 ## 用語
 
 PRD §1.3 と §13.3 を参照。本書で新たに定義する用語は各章の冒頭で明示する。
+
+### v1.1 で整理した用語（プロトタイプ反映に伴う追加・統一）
+
+| 用語 | 採用方針 | 注意 |
+|---|---|---|
+| 予定 / Plan / Ball / Task | **「予定（plan）」が物理テーブル名・正規用語、「ボール」は責任の概念**として両者を併用。**「タスク」はプロトタイプ UI 用語で、設計書では「予定」に統一**（PRD v1.3 §1.3 用語集に明記） | プロトタイプの「today's task」は本設計書では「今日の予定」と読み替え |
+| 制作物 / 納品物 / item / deliverable | **「制作物（project_items）」を物理／設計用語として維持**、URL も `/items/` 維持。プロトタイプの「deliverable」は画面表示文言レベルの言い換え | データモデル・API は変更なし。画面表示は「制作物」/「納品物」の選択肢があるが、Phase 0 は「制作物」で統一 |
+| メンバー | プロジェクト参加者（`project_members`）の通称、横軸／カンバン列の単位 | ユーザー（`users`）とは区別（メンバーは特定プロジェクト内、ユーザーは横断アカウント） |
+| カテゴリ | 予定の作業種別（`plans.category`、6 値 CHECK） | wireframe / design / coding / review / meeting / other |
+| 後続紐付け | 1 つの予定（先行）に対し 1 つの後続予定を紐付ける関係（`plans.successor_plan_id`、1対1、UNIQUE） | 先行完了で後続を **system actor の自動 TOSS** で受領状態に遷移（FR-BALL-13、UC-25） |
+| Magic-link サインアップ | メール先行 → 認証リンク押下 → 詳細入力 → 自動ログインの2段階フロー | UC-01 改訂、SC-01 で 7 状態統合 |
+| OAuth | Google / Microsoft の外部 ID 連携。Phase 0 から提供 | 同一メール 1 認証手段制約（FR-AUTH-12） |
+| メンバーかんばん | プロジェクト参加メンバーごとの予定を状態別かんばんで表示（SC-17、`/projects/:projectId/members`） | DnD で TOSS / 完了。SC-11 参加者管理とは別タブで併設 |
+
+> **本書の判断**：用語の物理レイヤー（DB・API・コード）は **既存命名を維持**し、画面表示文言は柔軟に運用。プロトタイプとの命名差分は実装時の翻訳テーブル（`packages/shared/i18n/messages.ja.ts`）で吸収する。

--- a/docs/design/02-database.md
+++ b/docs/design/02-database.md
@@ -3,10 +3,10 @@
 | 項目 | 内容 |
 |---|---|
 | 章番号 | 02 |
-| ステータス | **v1.0 確定** |
-| 確定日 | 2026-05-09 |
-| 上位ドキュメント | [TRAKON PRD v1.2](../prd/trakon-prd.md) ／ [01-architecture.md](01-architecture.md) |
-| 主参照 PRD 節 | §8（データモデル概要）、§4.1.4〜4.1.6（予定／ボール要件）、§9.5（データ保護）、§9.6（監査ログ） |
+| ステータス | **v1.1 確定**（v1.0: 2026-05-09 / v1.1: 2026-05-24 プロトタイプ反映） |
+| 確定日 | 2026-05-24 |
+| 上位ドキュメント | [TRAKON PRD v1.3](../prd/trakon-prd.md) ／ [01-architecture.md](01-architecture.md) |
+| 主参照 PRD 節 | §8（データモデル概要）、§4.1.1（FR-AUTH-10〜12）、§4.1.4（FR-SCH-17, 18）、§4.1.5（FR-BALL-13）、§9.5（データ保護）、§9.6（監査ログ） |
 
 ---
 
@@ -110,12 +110,14 @@ erDiagram
     users ||--o{ project_members : "user_id (招待受諾後)"
     users ||--o{ projects : "created_by"
     users ||--o{ audit_logs : "actor_user_id"
+    users ||--o{ oauth_identities : "user_id (v1.1)"
     projects ||--o{ project_members : "project_id"
     projects ||--o{ project_items : "project_id"
     projects ||--o{ invitations : "project_id"
     projects ||--o{ share_links : "project_id"
     project_items ||--o{ plans : "item_id"
     plans ||--o{ ball_events : "plan_id"
+    plans }o--|| plans : "successor_plan_id (v1.1)"
     project_members ||--o{ plans : "from_member_id / to_member_id"
     project_members ||--o{ ball_events : "actor_member_id"
     project_members ||--o{ invitations : "invited_member_id"
@@ -126,10 +128,21 @@ erDiagram
         uuid id PK
         uuid auth_user_id "Supabase auth.users.id"
         text email
-        text display_name
+        text full_name "v1.1 本名"
+        text display_name "v1.1 表示名"
+        text primary_auth_method "v1.1 password/google/microsoft (CHECK)"
         timestamptz created_at
         timestamptz updated_at
         timestamptz deleted_at "Phase1〜"
+    }
+    oauth_identities {
+        uuid id PK
+        uuid user_id FK
+        text provider "google/microsoft (CHECK)"
+        text provider_user_id "OAuth subject"
+        text email
+        timestamptz created_at
+        timestamptz updated_at
     }
     projects {
         uuid id PK
@@ -177,12 +190,14 @@ erDiagram
         uuid item_id FK
         text plan_type "toss(P0) / shared/solo(P1) (CHECK)"
         text title
+        text category "v1.1 wireframe/design/coding/review/meeting/other (CHECK, NOT NULL)"
         date scheduled_date
         date due_date
         date end_date
         uuid from_member_id FK
         uuid to_member_id FK
         uuid owner_member_id "Phase1〜 共同/単独"
+        uuid successor_plan_id "v1.1 FK self, NULL可, UNIQUE"
         text location_or_url "Phase1〜"
         text status "active/completed/canceled (CHECK)"
         text memo
@@ -196,7 +211,9 @@ erDiagram
         uuid id PK
         uuid plan_id FK
         text event_type "tossed/completed(P0) +canceled/returned/retossed(P1)"
-        uuid actor_member_id FK
+        uuid actor_member_id "v1.1 NULL可"
+        uuid actor_user_id "v1.1 NULL可 (system actor対応)"
+        text source "v1.1 human/auto_chain (CHECK, NOT NULL)"
         timestamptz occurred_at
         text note
     }
@@ -266,14 +283,16 @@ erDiagram
 
 ### 2.4.1. users — アプリ側のユーザー本体
 
-**司る機能**：UC-01 アカウント作成・ログイン／FR-AUTH-01〜05／SR-AUTH-01〜04。**Supabase Auth `auth.users`（UUID）と 1:1 で紐付くアプリ DB の本体テーブル**。プロジェクトの永続参加・編集を行う全ロールが必ず1行を持つ。非会員URL閲覧者（Phase 0、§2.4 share_links）は本テーブルに行を持たない。
+**司る機能**：UC-01 アカウント作成・ログイン／UC-24 OAuth ログイン／FR-AUTH-01〜05, 10〜12／SR-AUTH-01〜04, 10。**Supabase Auth `auth.users`（UUID）と 1:1 で紐付くアプリ DB の本体テーブル**。プロジェクトの永続参加・編集を行う全ロールが必ず1行を持つ。非会員URL閲覧者（Phase 0、§2.4 share_links）は本テーブルに行を持たない。
 
 | カラム | 型 | NULL | 既定 | 説明 |
 |---|---|:---:|---|---|
 | id | uuid | × | uuidv7 | アプリ内 PK |
 | auth_user_id | uuid | × | — | Supabase `auth.users.id`。**ユニーク制約必須** |
 | email | text | × | — | ログインID。Supabase Auth と同期（`auth.users.email` のキャッシュ）。ユニーク |
-| display_name | text | × | — | 表示名 |
+| **full_name** | text | × | — | **本名**（招待・請求書類用、v1.1 追加、FR-AUTH-11）|
+| **display_name** | text | × | — | **表示名・ハンドル**（画面表示・チップ、v1.1 で本名と分離）|
+| **primary_auth_method** | text | × | 'password' | **'password' / 'google' / 'microsoft'**（CHECK、同一メール1認証手段制約、v1.1 追加、FR-AUTH-12）|
 | created_at | timestamptz | × | now() | |
 | updated_at | timestamptz | × | now() | DBトリガで更新 |
 | deleted_at | timestamptz | ○ | NULL | 論理削除（Phase 1〜） |
@@ -281,6 +300,9 @@ erDiagram
 **制約**：
 - `uq_users_auth_user_id`（auth_user_id ユニーク）
 - `uq_users_email`（email ユニーク、deleted_at IS NULL のみ → 部分インデックス）
+- `ck_users_primary_auth_method` CHECK (primary_auth_method IN ('password','google','microsoft'))
+- `ck_users_full_name_length` CHECK (char_length(full_name) BETWEEN 1 AND 100)
+- `ck_users_display_name_length` CHECK (char_length(display_name) BETWEEN 1 AND 50)
 - インデックス：`idx_users_auth_user_id`（JWT 検証時の高速参照）
 
 **Phase 1 拡張**：
@@ -290,6 +312,37 @@ erDiagram
 **Phase 0 留意**：
 - パスワードハッシュは Supabase Auth が `auth.users.encrypted_password` に保持、本テーブルには持たせない
 - 招待受諾フロー（FR-AUTH-02）：`invitations.token_hash` 検証 → Supabase Auth でユーザー作成 → アプリ DB の `users` 行作成 → `project_members.user_id` を埋める、の順
+- **OAuth サインアップフロー（v1.1、UC-24）**：FE が Supabase Auth `signInWithOAuth` → コールバック → BE `/auth/me/sync` で users 行 INSERT（primary_auth_method = 'google' or 'microsoft'）、oauth_identities INSERT
+- **Magic-link サインアップフロー（v1.1、UC-01 改訂）**：FE がメール入力 → Supabase Auth Magic-link 送信 → リンク押下後に詳細入力（full_name / display_name / password）→ `/auth/me/complete-signup` で users 行 INSERT + Supabase Auth `updateUser({ password })` で恒久パスワード設定
+
+---
+
+### 2.4.X. oauth_identities — OAuth 連携（v1.1 新規、✅ Phase 0）
+
+**司る機能**：FR-AUTH-10, 12／UC-24 OAuth サインアップ／SR-AUTH-10。Supabase Auth が管理する `auth.identities` の補完情報をアプリ DB 側にミラー。**Phase 0 では 1 user = 1 identity 制約**（同一メール 1 認証手段、FR-AUTH-12）。
+
+| カラム | 型 | NULL | 既定 | 説明 |
+|---|---|:---:|---|---|
+| id | uuid | × | uuidv7 | PK |
+| user_id | uuid | × | — | FK → users.id |
+| provider | text | × | — | 'google' / 'microsoft'（CHECK）|
+| provider_user_id | text | × | — | OAuth プロバイダの subject（プロバイダ内一意）|
+| email | text | × | — | OAuth から取得したメール（users.email と一致）|
+| created_at | timestamptz | × | now() | |
+| updated_at | timestamptz | × | now() | DBトリガで更新 |
+
+**制約**：
+- `ck_oauth_identities_provider` CHECK (provider IN ('google','microsoft'))
+- `uq_oauth_identities_provider_provider_user_id`（provider, provider_user_id）UNIQUE
+- `uq_oauth_identities_user_id_provider`（user_id, provider）UNIQUE — Phase 0 の1ユーザー1プロバイダ制約に追加で、Phase 1+ でも「同一ユーザーが同じプロバイダ identity を二重登録不可」
+- `fk_oauth_identities_user_id` FK → users(id) ON DELETE CASCADE
+
+**インデックス**：
+- `idx_oauth_identities_provider_provider_user_id`（OAuth コールバック時の identity 検索用、UNIQUE と兼用）
+- `idx_oauth_identities_user_id`（ユーザー詳細画面用）
+
+**Phase 1+ 拡張**：
+- 1 ユーザーが複数プロバイダ連携可能になった場合、`uq_oauth_identities_user_id_provider` を維持しつつアプリ側 `users.primary_auth_method` の意味を再定義（複数 identity リンク UI 提供時）
 
 ---
 
@@ -392,12 +445,14 @@ erDiagram
 | item_id | uuid | × | — | FK → project_items.id |
 | plan_type | text | × | 'toss' | 'toss'（P0）／+'shared','solo'（P1）（CHECK） |
 | title | text | × | — | 予定名 |
+| **category** | text | × | — | **'wireframe' / 'design' / 'coding' / 'review' / 'meeting' / 'other'**（CHECK、NOT NULL、v1.1 追加、FR-SCH-18） |
 | scheduled_date | date | × | — | 予定日（TOSS／共同）／開始予定日（単独） |
 | due_date | date | ○ | NULL | 期日（TOSS 用、任意） |
 | end_date | date | ○ | NULL | 終了予定日（共同／単独 用、任意） |
 | from_member_id | uuid | ○ | NULL | TOSS の FROM。Phase 1 で plan_type='toss' のとき NOT NULL 相当 |
 | to_member_id | uuid | ○ | NULL | TOSS の TO。同上 |
 | owner_member_id | uuid | ○ | NULL | Phase 1〜（共同／単独 の主担当者） |
+| **successor_plan_id** | uuid | ○ | NULL | **後続予定の FK (self、UNIQUE、v1.1 追加、FR-SCH-17)**。Phase 0 では同一プロジェクト内に限定 |
 | location_or_url | text | ○ | NULL | Phase 1〜（共同予定用） |
 | status | text | × | 'active' | 'active' / 'completed' / 'canceled'（CHECK） |
 | memo | text | ○ | NULL | |
@@ -410,44 +465,64 @@ erDiagram
 **制約**：
 - `ck_plans_plan_type` CHECK (plan_type IN ('toss'))  ← **Phase 0 のチェック式。Phase 1 で `('toss','shared','solo')` に ALTER**
 - `ck_plans_status` CHECK (status IN ('active','completed','canceled'))
+- `ck_plans_category` CHECK (category IN ('wireframe','design','coding','review','meeting','other')) ← **v1.1、enum 拡張は ALTER で対応**
 - `ck_plans_toss_members` CHECK (
     plan_type <> 'toss' OR
     (from_member_id IS NOT NULL AND to_member_id IS NOT NULL AND from_member_id <> to_member_id)
   ) ← TOSS は FROM/TO 必須かつ別人
+- `uq_plans_successor_plan_id` UNIQUE (successor_plan_id) — **後続は1つの先行からのみ指される（v1.1）**
+- `ck_plans_no_self_successor` CHECK (successor_plan_id IS NULL OR successor_plan_id <> id) ← 自己参照防止（深い循環はアプリ層で）
 - `fk_plans_item_id` FK → project_items(id) ON DELETE CASCADE
 - `fk_plans_from_member_id` FK → project_members(id) ON DELETE RESTRICT
 - `fk_plans_to_member_id` FK → project_members(id) ON DELETE RESTRICT
+- `fk_plans_successor_plan_id` FK → plans(id) ON DELETE SET NULL — 後続が削除された場合は紐付け解除のみ
 - Phase 1 で `ck_plans_owner_required` を追加（共同／単独 では owner_member_id NOT NULL）
+
+**循環参照防止**：
+- 単純な自己参照（A → A）は `ck_plans_no_self_successor` で DB 拒否
+- 長い循環（A → B → … → A）はアプリ層（サービス層）で **後続紐付け／更新時に再帰検出して 409 を返す**（議論ポイント §2.10-11 で確定）
 
 **インデックス**：
 - `idx_plans_item_id_scheduled_date`（縦型カレンダー描画クエリ用）
 - `idx_plans_from_member_id`、`idx_plans_to_member_id`、`idx_plans_owner_member_id`（参加者列ごとの取得用）
-- `idx_plans_status_scheduled_date`（ダッシュボード用、Phase 1 で活用）
+- `idx_plans_status_scheduled_date`（ダッシュボード用）
+- `idx_plans_successor_plan_id`（**v1.1、後続自動 TOSS の SELECT FOR UPDATE 用**）
+- `idx_plans_category`（**v1.1、カテゴリでのフィルタ・色分け用**）
 - 部分インデックス：`idx_plans_active` ON plans(scheduled_date) WHERE status = 'active' AND deleted_at IS NULL
 
 ---
 
 ### 2.4.6. ball_events — ボール責任移動履歴
 
-**司る機能**：FR-BALL-04〜10／UC-08 TOSS実行／UC-09 TOSS取消／UC-10 差し戻し／UC-11 再TOSS／UC-12 予定完了。**追記専用、物理削除しない**。Ball Holder 導出のソース・オブ・トゥルース。
+**司る機能**：FR-BALL-04〜10, 13／UC-08 TOSS実行／UC-09 TOSS取消／UC-10 差し戻し／UC-11 再TOSS／UC-12 予定完了／**UC-25 後続自動 TOSS 連鎖**。**追記専用、物理削除しない**。Ball Holder 導出のソース・オブ・トゥルース。**v1.1 で `source` 列を追加（human / auto_chain）、`actor_user_id` を NULL 許容化**（system actor 対応、FR-BALL-13）。
 
 | カラム | 型 | NULL | 既定 | 説明 |
 |---|---|:---:|---|---|
 | id | uuid | × | uuidv7 | |
 | plan_id | uuid | × | — | FK → plans.id |
 | event_type | text | × | — | 'tossed' / 'completed'（P0）／+'canceled' / 'returned' / 'retossed'（P1）（CHECK） |
-| actor_member_id | uuid | × | — | 実行者（FK → project_members.id） |
+| actor_member_id | uuid | ○ | NULL | 実行者（FK → project_members.id）。**v1.1 で NULL 許容化**（system actor 時は NULL）|
+| **actor_user_id** | uuid | ○ | NULL | **実行ユーザー（FK → users.id、v1.1 追加、system actor 時は NULL）** |
+| **source** | text | × | 'human' | **'human' / 'auto_chain'**（CHECK、NOT NULL、v1.1 追加、FR-BALL-13）|
 | occurred_at | timestamptz | × | now() | 実行日時 |
 | note | text | ○ | NULL | 差し戻し理由など |
 
 **制約**：
 - `ck_be_event_type` CHECK (event_type IN ('tossed','completed'))  ← **Phase 0、Phase 1 で拡張**
+- `ck_be_source` CHECK (source IN ('human','auto_chain'))
+- `ck_be_actor_consistency` CHECK (
+    (source = 'human' AND actor_member_id IS NOT NULL AND actor_user_id IS NOT NULL)
+    OR
+    (source = 'auto_chain' AND actor_member_id IS NULL AND actor_user_id IS NULL)
+  ) ← **v1.1：human なら actor 必須、auto_chain なら actor NULL（system actor）**
 - `fk_be_plan_id` FK → plans(id) ON DELETE RESTRICT（plans の物理削除時にこちらを残すため、plans の MVP 物理削除はアプリ側で関連 ball_events 削除を伴う）
 - `fk_be_actor_member_id` FK → project_members(id) ON DELETE RESTRICT
-- **Append-only 強制**（§2.6 で詳述）
+- `fk_be_actor_user_id` FK → users(id) ON DELETE SET NULL
+- **Append-only 強制**（§2.7 で詳述）
 
 **インデックス**：
 - `idx_be_plan_id_occurred_at_desc`（最新イベント取得・Ball Holder 導出用）
+- `idx_be_source`（**v1.1：自動連鎖イベントの分析・監査用**）
 
 ---
 
@@ -581,6 +656,20 @@ erDiagram
 
 > 詳細は章5「セキュリティ実装設計」で扱う。
 
+### 2.5.3. OAuth（Google / Microsoft）の紐付け（v1.1 追加、Phase 0 から）
+
+| 観点 | 方針 |
+|---|---|
+| Supabase Auth 設定 | プロバイダ（Google / Microsoft）を Supabase ダッシュボードで有効化、Client ID/Secret 登録（章6 §6.6.1）。**PKCE フロー必須**（章5 §5.3 OAuth セクション） |
+| `auth.identities` テーブル | Supabase Auth が `auth.users` と `auth.identities` を自動管理。アプリ DB の `oauth_identities` テーブル（§2.4.X）はその**ミラー**として保持 |
+| ユーザー作成順（OAuth 初回） | ① FE が `signInWithOAuth({ provider })` → ② プロバイダ同意・コールバック → ③ Supabase Auth が `auth.users` + `auth.identities` 作成 → ④ FE が BE `POST /auth/me/sync` → ⑤ BE が users 行作成（`primary_auth_method='google' or 'microsoft'`、`full_name` は OAuth `user_metadata.full_name` から取得、`display_name` は full_name で初期化）+ oauth_identities INSERT |
+| **同一メール 1 認証手段制約**（FR-AUTH-12） | BE `/auth/me/sync` で `users` 検索時、既存 `users.email` がある場合に `primary_auth_method` を比較。不一致なら **409 SAME_EMAIL_DIFFERENT_PROVIDER** を返す（詳細は章5 §5.3）|
+| OAuth メール変更時 | Supabase Auth の `auth.users.email` 更新 → Webhook 経由で `users.email` と `oauth_identities.email` を同期（v1.1 議論ポイント §2.10-13） |
+| ユーザー削除時 | Supabase Auth 側削除 → `users.deleted_at` 設定、`oauth_identities` は CASCADE で削除 |
+| Phase 1+ 複数プロバイダ連携 | `users.primary_auth_method` の制約を緩和し、`oauth_identities` を複数行許容に拡張。初回作成時のプロバイダを記録する別カラム（`signup_provider`）の追加を検討 |
+
+> 詳細な OAuth セキュリティ仕様（PKCE、state、コールバック検証、ブランド統制メール）は章5 §5.3 を参照。
+
 ---
 
 ## 2.6. Ball Holder 導出戦略
@@ -660,7 +749,7 @@ CREATE TRIGGER trg_ball_events_no_update BEFORE UPDATE OR DELETE ON ball_events
 
 ---
 
-## 2.8. インデックス戦略（Phase 0）
+## 2.8. インデックス戦略（Phase 0、v1.1 追加分含む）
 
 クエリパターンを起点に必要最小限を定義。Phase 1 でクエリ追加時に追従。
 
@@ -672,9 +761,13 @@ CREATE TRIGGER trg_ball_events_no_update BEFORE UPDATE OR DELETE ON ball_events
 | 特定参加者列の予定取得 | SC-06 描画 | `idx_plans_from_member_id`, `idx_plans_to_member_id` |
 | ボール詳細の最新イベント | SC-08 | `idx_be_plan_id_occurred_at_desc` |
 | ユーザー認証時の `users` 取得 | 全API ミドルウェア | `idx_users_auth_user_id` |
+| **OAuth コールバックの identity 検索（v1.1）** | **POST /auth/oauth/:provider/callback** | `idx_oauth_identities_provider_provider_user_id` |
+| **ダッシュボード（自分／全員の今日のタスク、v1.1 Phase 0 へ繰り上げ）** | **GET /users/me/dashboard** | `idx_plans_status_scheduled_date` + 部分インデックス `idx_plans_active` |
+| **後続自動 TOSS の連鎖元検索（v1.1）** | **POST .../plans/:id/complete 内部処理** | `idx_plans_successor_plan_id` |
+| **カテゴリでのフィルタ・色分け（v1.1）** | **GET /items/:id/plans レスポンス描画** | `idx_plans_category` |
 | 監査ログの時系列参照 | （Phase 1〜） | `idx_al_occurred_at_desc`, `brin_al_occurred_at` |
 
-> Phase 0 で**作らない**もの：ダッシュボード集計用インデックス（Phase 1 で SC-09 実装時に追加）、全文検索インデックス（FR 対象外）。
+> Phase 0 で**作らない**もの：複合プロジェクト集計用マテリアライズドビュー（Phase 1 末で計測ベース判断）、全文検索インデックス（FR 対象外）。
 
 ---
 
@@ -715,6 +808,17 @@ PR ごとに Supabase Branch DB を作成し、Prisma migrate を流す：
 | M007 (Phase 1) | 論理削除へ移行（`plans.deleted_at` をアプリで参照開始）、Prisma middleware 適用 | 中（既存物理削除コードの撤去） |
 | M008 (Phase 2) | `organizations` テーブル追加 + `projects.organization_id` 既存データの組織割当 + NOT NULL 化 | 高（データ移行スクリプト必要） |
 
+**v1.1（2026-05-24）プロトタイプ反映マイグレーション（Phase 0 範囲、M001 と同時に初回投入）**：
+
+| マイグレーション | 内容 | リスク |
+|---|---|---|
+| M001a | `users.full_name`（NOT NULL）/ `display_name`（NOT NULL）に分離、`primary_auth_method`（CHECK）追加 | 低（初回投入） |
+| M001b | `oauth_identities` テーブル新規作成 | 低 |
+| M001c | `plans.category`（NOT NULL, CHECK 6値）追加 | 低 |
+| M001d | `plans.successor_plan_id`（FK self, UNIQUE）追加、`ck_plans_no_self_successor` | 低 |
+| M001e | `ball_events.source`（NOT NULL, CHECK）追加、`actor_user_id`（NULL可）追加、`actor_member_id` を NULL 許容化、`ck_be_actor_consistency` | 低 |
+| M001f | 追加インデックス：`idx_oauth_identities_provider_provider_user_id`, `idx_plans_successor_plan_id`, `idx_plans_category`, `idx_plans_status_scheduled_date`, `idx_plans_active`, `idx_be_source` | 低 |
+
 ---
 
 ## 2.10. 議論ポイントの確定結果
@@ -731,6 +835,10 @@ PR ごとに Supabase Branch DB を作成し、Prisma migrate を流す：
 | 8 | タイムゾーン | **DB は UTC、アプリで JST 変換** | サーバ・クライアント双方で JST 表示、サーバ側「本日」「3日以内」も JST 暦日で判定 |
 | 9 | users.email 同期 | **Supabase Auth → アプリの片方向（Supabase が真）** | Supabase の email 変更を webhook/定期ジョブで反映、双方向同期は採用しない |
 | 10 | project_members.user_id NULL | **NULL 許容（招待中行を同テーブル保持）** | 名刺記載のみ・招待中・受諾済みを一元管理、横軸表示と受諾フローがシンプル |
+| 11 | 後続紐付け（successor_plan_id）の循環参照防止（v1.1） | **DB CHECK で自己参照のみ拒否、長い循環はアプリ層（サービス層）で再帰検出して 409** | DB の CHECK で深い循環は判定不可。アプリ層で `INSERT/PATCH successor` 時にトポロジカルチェック |
+| 12 | 後続紐付けの範囲（v1.1） | **Phase 0 は同一プロジェクト内に限定**（アプリ層で validation） | プロトタイプ UI は同制作物配下から選択。異プロジェクト跨ぎは Phase 1+ の議論 |
+| 13 | OAuth プロバイダのメール変更ハンドリング（v1.1） | **Webhook 経由で users.email / oauth_identities.email を片方向同期**（Supabase Auth が真） | 章9 §2.5.3 と整合、プロバイダ変更を能動検知 |
+| 14 | ball_events 'auto_chain' での actor 整合性（v1.1） | **`ck_be_actor_consistency` CHECK で human ⇒ actor 必須、auto_chain ⇒ actor NULL** | 監査上「人間 actor」と「system actor」を明確分離、改ざんミスを DB 層で防ぐ |
 
 ---
 
@@ -759,6 +867,7 @@ PR ごとに Supabase Branch DB を作成し、Prisma migrate を流す：
 ### PRD 整合メモ（PRD 改訂提案）
 
 - **新規追加候補**：PRD §8.2 に **`invitations` テーブル**を明示すべき。FR-AUTH-02 の物理化として PRD への追記を提案（本基本設計書の章末リストとして起票）
+- **v1.1 反映**：PRD v1.3 で `oauth_identities` テーブル定義 / `users.full_name` `users.display_name` `users.primary_auth_method` / `plans.successor_plan_id` `plans.category` / `ball_events.source` `ball_events.actor_user_id` を §8.2 に追記済み（同期完了）
 
 ---
 
@@ -768,4 +877,5 @@ PR ごとに Supabase Branch DB を作成し、Prisma migrate を流す：
 |---|---|---|
 | 2026-05-09 | Draft（たたき台） | §2.10 議論ポイント10項目を未確定で起稿 |
 | 2026-05-09 | **v1.0 確定** | §2.10 全10論点を AskUserQuestion で確定（全て推奨案＝たたき台どおり） |
-| 2026-05-09 | **v1.1 確定** | PRD v1.3 改訂（非会員URL共有 Phase 0 化）に追従。§2.3.1 ER 図に `share_links` を追加、§2.4.9 share_links テーブル定義を新設、§2.4.7 audit_logs に `share_link_id`／`share_*` アクションを Phase 0 から有効化、§2.9.3 マイグレーション計画から `share_links` を M001 に統合、§2.11 Phase 1+ 持ち越しから `share_links` を除外。 |
+| 2026-05-09 | **v1.1 確定**（非会員URL前倒し） | PRD v1.3 改訂（非会員URL共有 Phase 0 化）に追従。§2.3.1 ER 図に `share_links` を追加、§2.4.9 share_links テーブル定義を新設、§2.4.7 audit_logs に `share_link_id`／`share_*` アクションを Phase 0 から有効化、§2.9.3 マイグレーション計画から `share_links` を M001 に統合、§2.11 Phase 1+ 持ち越しから `share_links` を除外。 |
+| 2026-05-24 | **v1.1 確定**（プロトタイプ反映） | users 拡張（full_name/display_name 分離、primary_auth_method）／oauth_identities 新規／plans 拡張（successor_plan_id, category）／ball_events 拡張（source, actor_user_id NULL化、ck_be_actor_consistency）／インデックス追加（OAuth/successor/category/ダッシュボード）／§2.5.3 OAuth 紐付け方針新設／§2.10 に論点 11〜14 追加／M001a〜f マイグレーション。 |

--- a/docs/design/03-api.md
+++ b/docs/design/03-api.md
@@ -3,10 +3,10 @@
 | 項目 | 内容 |
 |---|---|
 | 章番号 | 03 |
-| ステータス | **v1.0.1 確定** |
-| 確定日 | 2026-05-09 |
-| 上位ドキュメント | [TRAKON PRD v1.2](../prd/trakon-prd.md) ／ [01-architecture.md](01-architecture.md) ／ [02-database.md](02-database.md) |
-| 主参照 PRD 節 | §4.1（FR）／§6 UC-01〜08, 12, 15, 16／§7 SC-01〜04, 06〜08, 10, 11／§9.4（ロール別マトリクス） |
+| ステータス | **v1.1 確定**（v1.0.1: 2026-05-09 / v1.1: 2026-05-24 プロトタイプ反映） |
+| 確定日 | 2026-05-24 |
+| 上位ドキュメント | [TRAKON PRD v1.3](../prd/trakon-prd.md) ／ [01-architecture.md](01-architecture.md) ／ [02-database.md](02-database.md) |
+| 主参照 PRD 節 | §4.1（FR、v1.3 で追加された FR-AUTH-10〜12, FR-SCH-17〜18, FR-BALL-13, FR-DASH 改訂）／§6 UC-01〜08, 12, 15, 16, 24, 25, 26／§7 SC-01, 03〜04, 06〜11, 17／§9.4（ロール別マトリクス） |
 
 ---
 
@@ -240,10 +240,14 @@ flowchart TB
 | エンドポイント | 未認証 | 認証済み一般 | プロジェクト参加 | ディレクター | 備考 |
 |---|:---:|:---:|:---:|:---:|---|
 | `GET /healthz` | ✅ | ✅ | ✅ | ✅ | |
+| `POST /auth/oauth/:provider/start` **(v1.1)** | ✅ | ✅ | — | — | PKCE state 生成、redirect URL 返却 |
+| `POST /auth/oauth/:provider/callback` **(v1.1)** | ✅ | ✅ | — | — | code+state 検証、Supabase Auth セッション確立 |
+| `POST /auth/me/complete-signup` **(v1.1)** | ❌ | ✅ | — | — | Magic-link 後の詳細入力（full_name/display_name/password） |
 | `GET /invitations/:token` | ✅ | ✅ | — | — | トークンが認可代わり |
 | `POST /invitations/:token/accept` | ✅ | ✅ | — | — | 同上＋JWT で users 紐付け |
-| `POST /auth/me/sync`（初回ユーザー作成） | ❌ | ✅ | — | — | JWT は要、users 行は未存在 |
+| `POST /auth/me/sync`（初回ユーザー作成） | ❌ | ✅ | — | — | JWT は要、users 行は未存在。**v1.1 で OAuth プロバイダの初回登録も同 EP 経由** |
 | `GET /auth/me` | ❌ | ✅ | — | — | |
+| `GET /users/me/dashboard` **(v1.1)** | ❌ | ✅ | — | — | 自分が見える全プロジェクトの「今日のタスク」階層ビュー |
 | `GET /projects` | ❌ | ✅ | — | — | 自分が参加するもののみ |
 | `POST /projects` | ❌ | ✅ | — | — | Phase 2 で組織制限（PRD §9.4 注記 ※1） |
 | `GET /projects/:projectId` | ❌ | ❌ | ✅ | ✅ | |
@@ -262,14 +266,15 @@ flowchart TB
 | `GET /projects/:projectId/items/:itemId/plans/:planId` | ❌ | ❌ | ✅ | ✅ | |
 | `PATCH /projects/:projectId/items/:itemId/plans/:planId` | ❌ | ❌ | ✅※own | ✅ | own = from/to のいずれか or owner |
 | `DELETE /projects/:projectId/items/:itemId/plans/:planId` | ❌ | ❌ | ✅※own | ✅ | Phase 0 物理削除 |
-| `POST /projects/:projectId/items/:itemId/plans/:planId/toss` | ❌ | ❌ | ✅※holder | ✅※override | 現 Ball Holder のみ実行可（ディレクターは override 可） |
-| `POST /projects/:projectId/items/:itemId/plans/:planId/complete` | ❌ | ❌ | ✅※holder | ✅※override | 同上 |
-| `GET /projects/:projectId/share-links` | ❌ | ❌ | ❌ | ✅ | FR-SHARE-01／SC-16 一覧 |
-| `POST /projects/:projectId/share-links` | ❌ | ❌ | ❌ | ✅ | FR-SHARE-01, 02／SC-16 発行 |
-| `DELETE /projects/:projectId/share-links/:shareLinkId` | ❌ | ❌ | ❌ | ✅ | FR-SHARE-03／SC-16 個別失効 |
-| `GET /share/:token` | ✅ | ✅ | — | — | トークンが認可代わり／FR-SHARE-01, 04, 05／UC-23 |
-| `POST /share/:token/plans/:planId/toss` | ✅ | ✅ | — | — | 非会員URL経由のボール操作（スコープ判定）／FR-SHARE-05／UC-23 |
-| `POST /share/:token/plans/:planId/complete` | ✅ | ✅ | — | — | 同上 |
+| `POST /projects/:projectId/items/:itemId/plans/:planId/toss` | ❌ | ❌ | ✅※holder | ✅※override | 現 Ball Holder のみ実行可（ディレクターは override 可）。**v1.1：カンバン DnD（UC-26）からも呼ばれる** |
+| `POST /projects/:projectId/items/:itemId/plans/:planId/complete` | ❌ | ❌ | ✅※holder | ✅※override | 同上。**v1.1：successor_plan_id があれば自動 TOSS を連鎖（UC-25、FR-BALL-13）** |
+| `PATCH /projects/:projectId/items/:itemId/plans/:planId/successor` **(v1.1 プロトタイプ反映)** | ❌ | ❌ | ✅※own | ✅ | 後続予定の紐付け設定／解除（FR-SCH-17） |
+| `GET /projects/:projectId/share-links` **(v1.1 非会員URL前倒し)** | ❌ | ❌ | ❌ | ✅ | FR-SHARE-01／SC-16 一覧 |
+| `POST /projects/:projectId/share-links` **(v1.1)** | ❌ | ❌ | ❌ | ✅ | FR-SHARE-01, 02／SC-16 発行 |
+| `DELETE /projects/:projectId/share-links/:shareLinkId` **(v1.1)** | ❌ | ❌ | ❌ | ✅ | FR-SHARE-03／SC-16 個別失効 |
+| `GET /share/:token` **(v1.1)** | ✅ | ✅ | — | — | トークンが認可代わり／FR-SHARE-01, 04, 05／UC-23 |
+| `POST /share/:token/plans/:planId/toss` **(v1.1)** | ✅ | ✅ | — | — | 非会員URL経由のボール操作（スコープ判定）／FR-SHARE-05／UC-23 |
+| `POST /share/:token/plans/:planId/complete` **(v1.1)** | ✅ | ✅ | — | — | 同上 |
 
 > 凡例：✅ 許可／❌ 拒否（401 or 403／親リソース未参加なら 404）／✅※own（自分が当事者）／✅※holder（現 Ball Holder）／✅※override（ディレクターは追加権限あり）／`/share/:token` 系はトークン自体が認可、有効期限・個別失効・スコープ・対象 plan が share_link.scope に整合することを `requireShareToken` ミドルウェアが検証（章5 §5.x）
 
@@ -280,8 +285,12 @@ flowchart TB
 | カテゴリ | メソッド | パス | 関連 UC | 関連 SC |
 |---|---|---|---|---|
 | Health | GET | `/healthz` | — | — |
-| Auth | POST | `/auth/me/sync` | UC-01 | SC-01 |
+| Auth | POST | `/auth/oauth/:provider/start` **(v1.1)** | UC-24 | SC-01 |
+| Auth | POST | `/auth/oauth/:provider/callback` **(v1.1)** | UC-24 | SC-01 |
+| Auth | POST | `/auth/me/sync` | UC-01, 24 | SC-01 |
+| Auth | POST | `/auth/me/complete-signup` **(v1.1)** | UC-01 | SC-01 |
 | Auth | GET | `/auth/me` | UC-01 | SC-01, 全画面ヘッダ |
+| Dashboard | GET | `/users/me/dashboard` **(v1.1)** | UC-13 相当 | SC-09 |
 | Invitations | GET | `/invitations/:token` | UC-03 | SC-02 |
 | Invitations | POST | `/invitations/:token/accept` | UC-03 | SC-02 |
 | Projects | GET | `/projects` | — | SC-03 |
@@ -302,16 +311,17 @@ flowchart TB
 | Plans | GET | `/projects/:projectId/items/:itemId/plans/:planId` | UC-08 | SC-08 ボール詳細 |
 | Plans | PATCH | `/projects/:projectId/items/:itemId/plans/:planId` | UC-05 | SC-07, SC-08 |
 | Plans | DELETE | `/projects/:projectId/items/:itemId/plans/:planId` | — | SC-08（MVP物理削除：FR-BALL-12） |
-| Ball Actions | POST | `/projects/:projectId/items/:itemId/plans/:planId/toss` | UC-08 | SC-08 |
-| Ball Actions | POST | `/projects/:projectId/items/:itemId/plans/:planId/complete` | UC-12 | SC-08 |
-| Share Links | GET | `/projects/:projectId/share-links` | UC-23 | SC-16 |
-| Share Links | POST | `/projects/:projectId/share-links` | UC-23 | SC-16 |
-| Share Links | DELETE | `/projects/:projectId/share-links/:shareLinkId` | UC-23 | SC-16 |
-| Share Access | GET | `/share/:token` | UC-23 | （非会員URL閲覧画面） |
-| Share Access | POST | `/share/:token/plans/:planId/toss` | UC-23 | （非会員URL閲覧画面） |
-| Share Access | POST | `/share/:token/plans/:planId/complete` | UC-23 | （非会員URL閲覧画面） |
+| Ball Actions | POST | `/projects/:projectId/items/:itemId/plans/:planId/toss` | UC-08, UC-26 | SC-08, SC-17 |
+| Ball Actions | POST | `/projects/:projectId/items/:itemId/plans/:planId/complete` | UC-12, UC-25 | SC-08 |
+| Plans | PATCH | `/projects/:projectId/items/:itemId/plans/:planId/successor` **(v1.1 プロトタイプ反映)** | UC-25（紐付け管理） | SC-07 |
+| Share Links | GET | `/projects/:projectId/share-links` **(v1.1 非会員URL前倒し)** | UC-23 | SC-16 |
+| Share Links | POST | `/projects/:projectId/share-links` **(v1.1)** | UC-23 | SC-16 |
+| Share Links | DELETE | `/projects/:projectId/share-links/:shareLinkId` **(v1.1)** | UC-23 | SC-16 |
+| Share Access | GET | `/share/:token` **(v1.1)** | UC-23 | （非会員URL閲覧画面） |
+| Share Access | POST | `/share/:token/plans/:planId/toss` **(v1.1)** | UC-23 | （非会員URL閲覧画面） |
+| Share Access | POST | `/share/:token/plans/:planId/complete` **(v1.1)** | UC-23 | （非会員URL閲覧画面） |
 
-> v1.1 改訂注：`Share Links` / `Share Access` 6本は v1.0 まで §3.9 Phase 1 で予告していたが、PRD v1.3 で Phase 0 へ前倒しされたため Phase 0 必須として正式採番。詳細仕様は §3.6.9 を参照。
+> **v1.1 改訂注**：`Share Links` / `Share Access` 6本は v1.0 まで §3.9 Phase 1 で予告していたが、PRD v1.3 で Phase 0 へ前倒しされたため Phase 0 必須として正式採番。詳細仕様は §3.6.9（非会員URL前倒し改訂）を参照。
 
 ---
 
@@ -334,10 +344,76 @@ flowchart TB
 
 ### 3.6.2. Auth
 
+#### `POST /api/v1/auth/oauth/:provider/start` （v1.1 新規、UC-24）
+
+OAuth フロー開始：BE が PKCE `code_verifier` 生成 → `code_challenge` を返し、FE は Supabase Auth `signInWithOAuth` をその challenge 付きで呼ぶ。
+
+**認可**：未認証可。
+
+**パスパラメータ**：`provider`（'google' / 'microsoft'）
+
+**リクエスト**：
+```typescript
+{ redirectTo: string }   // FE が処理後に戻るアプリ内 URL（同一オリジン必須）
+```
+
+**レスポンス（200）**：
+```typescript
+{
+  data: {
+    authorizeUrl: string,  // FE が遷移する Supabase Auth の URL
+    state: string,         // CSRF 対策、callback で検証
+  }
+}
+```
+
+**処理**：
+1. PKCE `code_verifier` / `code_challenge` をサーバ側で生成
+2. `state` を uuidv7 で生成、短期 KV/メモリに保管（5分 TTL）
+3. Supabase Auth の authorize URL を組み立てて返す
+
+**エラー**：400 (`INVALID_REDIRECT`：同一オリジン外)、400 (`UNSUPPORTED_PROVIDER`)。
+
+> 詳細な OAuth セキュリティ仕様は章5 §5.3 を参照。
+
+---
+
+#### `POST /api/v1/auth/oauth/:provider/callback` （v1.1 新規、UC-24）
+
+OAuth コールバック：Supabase Auth から戻ってきた `code` + `state` を検証し、セッション確立。
+
+**認可**：未認証可。
+
+**リクエスト**：
+```typescript
+{ code: string, state: string }
+```
+
+**処理**：
+1. `state` を KV から取得・整合性確認
+2. Supabase Auth `exchangeCodeForSession` を呼ぶ
+3. JWT + refresh_token を Cookie or レスポンスで返す
+4. 続いて FE が `POST /auth/me/sync` を呼ぶ（既存フロー）
+
+**レスポンス（200）**：
+```typescript
+{
+  data: {
+    accessToken: string,
+    refreshToken: string,
+    expiresAt: number,
+  }
+}
+```
+
+**エラー**：400 (`INVALID_STATE`)、401 (`OAUTH_EXCHANGE_FAILED`)。
+
+---
+
 #### `POST /api/v1/auth/me/sync`
 
 Supabase Auth で signUp / signIn 完了後、FE が **初回呼び出し**するエンドポイント。
-アプリ DB の `users` 行を作成（または存在確認）し、`audit_logs` に `login` を記録。
+アプリ DB の `users` 行を作成（または存在確認）し、`audit_logs` に `login` を記録。**v1.1 で OAuth 経由の初回登録もこのエンドポイントで処理する**（`primary_auth_method` を OAuth provider 名で設定、`oauth_identities` INSERT）。
 
 **認可**：JWT 必須（users 行は未存在の場合あり）。
 
@@ -350,7 +426,10 @@ Supabase Auth で signUp / signIn 完了後、FE が **初回呼び出し**す�
     id: string,           // users.id
     authUserId: string,
     email: string,
-    displayName: string,
+    fullName: string | null,        // v1.1 OAuth 経由なら provider から取得、Magic-link 経由は complete-signup までは null
+    displayName: string | null,     // v1.1 同上
+    primaryAuthMethod: 'password' | 'google' | 'microsoft',  // v1.1
+    requiresProfileCompletion: boolean,  // v1.1：full_name/display_name 未設定なら true（FE は create-account 画面へ）
     createdAt: string,
   }
 }
@@ -359,11 +438,43 @@ Supabase Auth で signUp / signIn 完了後、FE が **初回呼び出し**す�
 **処理**：
 1. JWT から `auth_user_id` 抽出
 2. `users WHERE auth_user_id = ?` で検索
-3. 存在しない場合：`auth.users` から `email` / `raw_user_meta_data.display_name` を取り、`users` INSERT
-4. `audit_logs` に `action='login'` を記録（result='success'）
+3. 存在しない場合：
+   - `auth.users` から `email` / `raw_user_meta_data`（OAuth の場合は `name` / `picture`）を取得
+   - **同一メールが別 `primary_auth_method` で既登録の場合：409 SAME_EMAIL_DIFFERENT_PROVIDER**（FR-AUTH-12）
+   - `users` INSERT（`primary_auth_method` = JWT の `app_metadata.provider` から判定）
+   - OAuth 経由なら `oauth_identities` INSERT
+   - **`requiresProfileCompletion = (full_name IS NULL OR display_name IS NULL)`** → Magic-link 経由は true（次に complete-signup を呼ぶ必要あり）、OAuth 経由で full_name/display_name 取得済みなら false
+4. `audit_logs` に `action='login'` を記録
 5. ユーザー情報を返す
 
-**エラー**：401 (`AUTH_INVALID`)。
+**エラー**：401 (`AUTH_INVALID`)、**409 (`SAME_EMAIL_DIFFERENT_PROVIDER`)**。
+
+---
+
+#### `POST /api/v1/auth/me/complete-signup` （v1.1 新規、UC-01 改訂）
+
+Magic-link でメール認証完了後、詳細情報（`full_name` / `display_name` / `password`）を入力するエンドポイント。
+
+**認可**：JWT 必須、`users.full_name IS NULL OR users.display_name IS NULL` の状態のみ実行可。
+
+**リクエスト**：
+```typescript
+{
+  fullName: string,     // 1〜100文字
+  displayName: string,  // 1〜50文字
+  password: string,     // 8文字以上、英数記号混在
+}
+```
+
+**処理**（同一トランザクション）：
+1. JWT 検証、users 行取得
+2. `users.full_name` / `display_name` を更新
+3. Supabase Auth `updateUser({ password })` を Admin SDK 経由で実行（恒久パスワード設定）
+4. `audit_logs` に `action='complete_signup'` を記録（Phase 1 で正式記録、Phase 0 は最低限の login のみ）
+
+**レスポンス（200）**：完了後の `users` 情報
+
+**エラー**：400（バリデーション）、409 `ALREADY_COMPLETED`（既に full_name/display_name 設定済み）。
 
 ---
 
@@ -379,11 +490,62 @@ Supabase Auth で signUp / signIn 完了後、FE が **初回呼び出し**す�
   data: {
     id: string,
     email: string,
-    displayName: string,
+    fullName: string,                                                 // v1.1
+    displayName: string,                                              // v1.1
+    primaryAuthMethod: 'password' | 'google' | 'microsoft',           // v1.1
     projectCount: number,
   }
 }
 ```
+
+---
+
+#### `GET /api/v1/users/me/dashboard` （v1.1 新規、SC-09）
+
+ダッシュボード階層ビュー用データ取得。自分が見られる全プロジェクト × メンバー × 「今日のタスク」階層構造で返す。
+
+**認可**：JWT 必須。
+
+**クエリ**：（なし、Phase 0）
+
+**処理**：
+1. `users.id` を起点に、参加プロジェクト一覧を取得
+2. 各プロジェクトの `project_members` を取得
+3. 各 plan を取得（`status='active' AND startDate <= today <= endDate`、JST 暦日基準）
+4. プロジェクト → メンバー（Ball Holder 単位） → 予定カード の階層構造に整形
+
+**レスポンス（200）**：
+```typescript
+{
+  data: {
+    today: string,             // YYYY-MM-DD（JST 基準）
+    summary: {
+      todayTaskCount: number,
+      overdueCount: number,    // status='active' && endDate < today
+    },
+    projects: Array<{
+      id: string,
+      name: string,
+      colorHex: string,        // プロジェクトのブランドカラー（Phase 0 は固定生成）
+      memberTasks: Array<{
+        member: { id: string, name: string, organizationName: string },
+        tasks: Array<{
+          planId: string,
+          itemId: string,
+          itemName: string,    // 制作物名
+          title: string,
+          category: 'wireframe' | 'design' | 'coding' | 'review' | 'meeting' | 'other',
+          startDate: string,
+          endDate: string,
+          isOverdue: boolean,
+        }>,
+      }>,
+    }>,
+  }
+}
+```
+
+**パフォーマンス**：N+1 回避のため、`plans + project_members + project_items + projects` を1〜2 クエリで取得。`idx_plans_status_scheduled_date` と `idx_plans_active` を使用。
 
 ---
 
@@ -770,6 +932,7 @@ Supabase Auth で signUp / signIn 完了後、FE が **初回呼び出し**す�
     id: string,
     planType: 'toss',                // Phase 0
     title: string,
+    category: 'wireframe' | 'design' | 'coding' | 'review' | 'meeting' | 'other',  // v1.1
     scheduledDate: string,
     dueDate: string | null,
     fromMember: { id: string, name: string, organizationName: string },
@@ -777,7 +940,8 @@ Supabase Auth で signUp / signIn 完了後、FE が **初回呼び出し**す�
     status: 'active' | 'completed' | 'canceled',
     ballHolder: { id: string, name: string, organizationName: string },  // 導出値
     ballState: 'ready' | 'tossed' | 'completed',                         // 導出値
-    latestEvent: { eventType: string, occurredAt: string } | null,
+    latestEvent: { eventType: string, occurredAt: string, source: 'human' | 'auto_chain' } | null,  // v1.1 source 追加
+    successorPlanId: string | null,                                       // v1.1
     memo: string | null,
     createdAt: string,
     updatedAt: string,
@@ -803,19 +967,24 @@ Supabase Auth で signUp / signIn 完了後、FE が **初回呼び出し**す�
 {
   planType: 'toss',                 // Phase 0 は固定
   title: string,
+  category: 'wireframe' | 'design' | 'coding' | 'review' | 'meeting' | 'other',  // v1.1 必須（FR-SCH-18）
   scheduledDate: string,            // YYYY-MM-DD
   dueDate?: string,
   fromMemberId: string,
   toMemberId: string,               // fromMemberId と異なる必須
+  successorPlanId?: string,         // v1.1 任意（FR-SCH-17）。同一プロジェクト内の plan のみ許容
   memo?: string,
 }
 ```
 
 **処理**：
 - バリデーション（章2 `ck_plans_toss_members` 同等の事前チェック）
+- `successorPlanId` 指定時：(a) 同一プロジェクト内に属するか確認、(b) `UNIQUE successor_plan_id` 制約に従い既に他 plan の successor になっていないか確認、(c) 循環参照チェック（§2.4.5）
 - `plans` INSERT（`status='active'`、Ball Holder = `fromMemberId`、`ball_events` はまだ作成しない）
 
 **レスポンス（201）**：作成された plan（GET と同形式）
+
+**エラー**：400 (`VALIDATION_ERROR`)、422 (`SUCCESSOR_OUT_OF_PROJECT` / `SUCCESSOR_ALREADY_USED` / `CIRCULAR_SUCCESSOR`)。
 
 ---
 
@@ -849,11 +1018,36 @@ Supabase Auth で signUp / signIn 完了後、FE が **初回呼び出し**す�
 
 **認可**：プロジェクト参加者で、当該 plan の from/to のいずれか（or ディレクター）。
 
-**リクエスト**：`{ title?, scheduledDate?, dueDate?, memo? }`（Phase 0）
+**リクエスト**：`{ title?, category?, scheduledDate?, dueDate?, memo? }`（Phase 0）
 
 **ビジネスルール**：
 - `status === 'completed'` の予定は編集不可（422 `STATE_INVALID`）
 - TOSS 後（`ball_events.event_type='tossed'` 存在）に from/to の変更は不可（422）
+- successor_plan_id の変更は `PATCH .../successor`（後述、v1.1）で別エンドポイント
+
+---
+
+#### `PATCH /api/v1/projects/:projectId/items/:itemId/plans/:planId/successor` （v1.1 新規）
+
+後続予定の紐付け設定／解除（FR-SCH-17）。
+
+**認可**：プロジェクト参加者で、当該 plan の from/to のいずれか（or ディレクター）。
+
+**リクエスト**：
+```typescript
+{ successorPlanId: string | null }    // null で紐付け解除
+```
+
+**処理**：
+1. `successorPlanId` が指定された場合：
+   - 同一プロジェクト内に属するか確認
+   - `UNIQUE` 制約により他 plan の successor になっていないか確認
+   - 循環参照チェック（自己参照は `ck_plans_no_self_successor` で DB 拒否、長い循環はアプリ層）
+2. `plans.successor_plan_id` を更新
+
+**レスポンス（200）**：更新後の plan
+
+**エラー**：404、403、422 (`SUCCESSOR_OUT_OF_PROJECT` / `SUCCESSOR_ALREADY_USED` / `CIRCULAR_SUCCESSOR` / `SELF_SUCCESSOR`)。
 
 ---
 
@@ -865,6 +1059,7 @@ Supabase Auth で signUp / signIn 完了後、FE が **初回呼び出し**す�
 
 **ビジネスルール**：
 - TOSS 後の plan の削除は警告のみ（FE 確認モーダル）
+- **削除対象 plan を successor として参照している先行 plan があれば、その `successor_plan_id` を NULL にセット**（DB の `ON DELETE SET NULL`、v1.1）
 
 ---
 
@@ -877,22 +1072,26 @@ TOSS 実行。
 **認可**：現 Ball Holder ＝ `plans.from_member_id`（TOSS 未実行）かつ JWT ユーザーが当該 member。
 あるいはプロジェクトディレクター（override）。
 
-**リクエスト**：（ボディなし）
+**リクエスト**（v1.1 でカンバン UI からの呼び出しを想定し、to_member 指定をサポート）：
+```typescript
+{ toMemberId?: string }   // 任意。指定された場合は plans.to_member_id を更新してから TOSS。SC-17 カンバンの別メンバー DnD で使用
+```
 
 **処理**（同一トランザクション）：
 1. `plans` を SELECT FOR UPDATE
 2. 状態確認：
    - `status === 'active'` であること
    - 既に `event_type='tossed'` の `ball_events` が存在しないこと（多重 TOSS 防止）
-3. `ball_events` INSERT (`event_type='tossed'`, `actor_member_id=currentMember.id`, `occurred_at=now()`)
-4. `audit_logs` に `action='toss'` を記録
+3. `toMemberId` 指定時：`to_member_id` を更新（同プロジェクト内 member であることを検証）
+4. `ball_events` INSERT (`event_type='tossed'`, `source='human'`, `actor_member_id=currentMember.id`, `actor_user_id=currentUser.id`, `occurred_at=now()`)
+5. `audit_logs` に `action='toss'` を記録
 
 **レスポンス（200）**：
 ```typescript
 {
   data: {
     plan: { /* 更新後の plan、ballHolder は to_member に切替 */ },
-    event: { /* 作成された ball_events */ },
+    event: { /* 作成された ball_events（source 含む） */ },
   }
 }
 ```
@@ -901,23 +1100,43 @@ TOSS 実行。
 - 403 `FORBIDDEN`（権限なし）
 - 409 `ALREADY_TOSSED`（既に TOSS 済み）
 - 422 `PLAN_NOT_ACTIVE`（completed/canceled 状態）
+- 422 `INVALID_TO_MEMBER`（toMemberId が同プロジェクト外）
 
 ---
 
 #### `POST /api/v1/projects/:projectId/items/:itemId/plans/:planId/complete`
 
-予定完了。
+予定完了。**v1.1：`successor_plan_id` が設定されていれば、同一トランザクション内で後続予定に対し system actor の自動 TOSS を実行する**（FR-BALL-13、UC-25）。
 
 **認可**：現 Ball Holder（or ディレクター）。
 
-**処理**：
-1. `plans` を SELECT FOR UPDATE
+**処理**（同一トランザクション）：
+1. `plans[A]` を SELECT FOR UPDATE
 2. 状態確認：`status === 'active'` であること
-3. `ball_events` INSERT (`event_type='completed'`)
-4. `plans.status = 'completed'`、`completed_at = now()` に更新
-5. `audit_logs` に `action='complete'` を記録
+3. `ball_events` INSERT (`plan=A`, `event_type='completed'`, `source='human'`, `actor_member_id=currentMember.id`, `actor_user_id=currentUser.id`)
+4. `plans[A].status = 'completed'`、`completed_at = now()`
+5. **`plans[A].successor_plan_id = B` の場合**：
+   - `plans[B]` を SELECT FOR UPDATE
+   - `B.status === 'active'` なら：
+     - `ball_events` INSERT (`plan=B`, `event_type='tossed'`, `source='auto_chain'`, `actor_member_id=NULL`, `actor_user_id=NULL`)
+     - B の Ball Holder = `B.to_member` に切り替わる（導出ロジックで自動）
+   - `B.status` が 'completed' / 'canceled' なら：スキップ（連鎖中断）
+6. `audit_logs` に `action='complete'`（A）を記録
+7. Phase 1 で `action='auto_toss'`（B）も記録、Phase 0 は最低限のみ
 
-**レスポンス（200）**：plan + event
+**レスポンス（200）**：
+```typescript
+{
+  data: {
+    plan: { /* A の plan、status='completed' */ },
+    event: { /* A の completed event */ },
+    autoTossed?: {                                // v1.1：自動連鎖が起きた場合のみ
+      plan: { /* B の plan、ballHolder は B.to_member */ },
+      event: { /* B の tossed event、source='auto_chain' */ },
+    },
+  }
+}
+```
 
 **エラー**：403、409 `ALREADY_COMPLETED`、422。
 
@@ -1131,7 +1350,8 @@ type Plan = {
 
 type BallEvent = {
   eventType: 'tossed' | 'completed' | 'canceled' | 'returned' | 'retossed';
-  actorMemberId: string;
+  actorMemberId: string | null;       // v1.1：auto_chain では null
+  source: 'human' | 'auto_chain';     // v1.1 追加
 };
 
 type BallHolderResult = {
@@ -1146,8 +1366,11 @@ export function deriveBallHolder(plan: Plan, latestEvent: BallEvent | null): Bal
 | latestEvent | 返り値 |
 |---|---|
 | null | { memberId: plan.fromMemberId, state: 'ready' } |
-| 'tossed' | { memberId: plan.toMemberId, state: 'tossed' } |
+| 'tossed' (source='human') | { memberId: plan.toMemberId, state: 'tossed' } |
+| 'tossed' (source='auto_chain', v1.1) | { memberId: plan.toMemberId, state: 'tossed' } — 自動 TOSS の結果も同じ Ball Holder 切替 |
 | 'completed' | { memberId: plan.toMemberId, state: 'completed' } |
+
+> `source` は導出結果（memberId / state）に影響しない（同じ TOSS イベントとして扱う）。ただし FE の表示で「自動連鎖」アイコンを出すなどには活用できる。
 
 **Phase 1 で拡張**：'returned' / 'retossed' / 'canceled' / shared / solo 対応。テストは状態遷移網羅。
 
@@ -1195,6 +1418,9 @@ export function deriveBallHolder(plan: Plan, latestEvent: BallEvent | null): Bal
 | 9 | 警告の返し方 | **レスポンスボディの `warnings` 配列** | 多件警告・構造化データを乗せやすい、FE 型生成と相性◎ |
 | 10 | 楽観的ロック | **Phase 0 では実装しない（最後勝ち）** | 同一ボール多人数同時編集ケースが少ない。Phase 1 でコメント・差し戻し追加時に再検討 |
 | 11 | URL 階層の表現方針 | **データ上の所有関係を完全に URL に反映**（深さ上限なし） | 認可ミドルウェアの階層チェーン化、未参加リソースの 404 集約、子リソース追加時の素直な配置に有利 |
+| 12 | カンバン DnD の API マッピング（v1.1） | **既存 TOSS / 完了 API に集約**、専用 EP を作らない | UC-26 整合。`POST .../toss { toMemberId }` で別メンバー DnD を表現、状態列 DnD は `complete` / `cancel-toss`（Phase 1）を呼ぶ |
+| 13 | 自動 TOSS 連鎖の実行方式（v1.1） | **complete API 内の同一トランザクション**で連鎖、follow-up job 不採用 | FR-BALL-13 と整合。Phase 0 で Inngest 未導入、トランザクション整合性が最優先。Phase 1 で連鎖長が伸びる場合は再評価 |
+| 14 | OAuth コールバックの方式（v1.1） | **専用 EP（callback）+ Supabase Auth `exchangeCodeForSession`** で確立、`/auth/me/sync` で users 同期 | Supabase Auth の標準コールバック処理を BE 経由で扱うことで PKCE/state 検証を一元化 |
 
 ---
 
@@ -1230,4 +1456,5 @@ export function deriveBallHolder(plan: Plan, latestEvent: BallEvent | null): Bal
 | 2026-05-09 | Draft（たたき台） | §3.10 議論ポイント10項目を未確定で起稿 |
 | 2026-05-09 | **v1.0 確定** | §3.10 全10論点を AskUserQuestion で確定（全て推奨案＝たたき台どおり） |
 | 2026-05-09 | **v1.0.1 確定** | URL 階層の表現方針を改訂：「ネスト深さ最大2階層」の縛りを撤回し、データ所有関係を完全に URL に反映する方針へ更新（plans 系・items 詳細・ball actions・Phase 1 系のパスを完全階層化）。§3.10 に論点11として記録。 |
-| 2026-05-09 | **v1.1 確定** | PRD v1.3 改訂（非会員URL共有 Phase 0 化）に追従。§3.5 Phase 0 必須エンドポイントに Share Links（GET/POST/DELETE）と Share Access（GET /share/:token、POST /share/:token/plans/:planId/{toss,complete}）を追加、§3.6.9〜10 に詳細仕様を新設、§3.4 認可マトリクスに share-link 行を追加、§3.2.3 未認証許容エンドポイントに `/share/:token` を追加、§3.9 から share 関連 4行を削除、§3.11 PRD 整合チェックと Phase 1+ 持ち越しを更新。 |
+| 2026-05-09 | **v1.1 確定**（非会員URL前倒し） | PRD v1.3 改訂（非会員URL共有 Phase 0 化）に追従。§3.5 Phase 0 必須エンドポイントに Share Links（GET/POST/DELETE）と Share Access（GET /share/:token、POST /share/:token/plans/:planId/{toss,complete}）を追加、§3.6.9〜10 に詳細仕様を新設、§3.4 認可マトリクスに share-link 行を追加、§3.2.3 未認証許容エンドポイントに `/share/:token` を追加、§3.9 から share 関連 4行を削除、§3.11 PRD 整合チェックと Phase 1+ 持ち越しを更新。 |
+| 2026-05-24 | **v1.1 確定**（プロトタイプ反映） | OAuth start/callback EP 追加 / complete-signup 追加 / GET /users/me/dashboard 追加 / PATCH .../successor 追加 / POST .../toss に toMemberId 追加 / POST .../complete に自動連鎖追加 / GET .../plans レスポンスに category, successorPlanId, source 追加 / 認可マトリクス更新 / deriveBallHolder の BallEvent に source 追加 / §3.10 論点 12〜14 追加。 |

--- a/docs/design/04-frontend.md
+++ b/docs/design/04-frontend.md
@@ -3,10 +3,10 @@
 | 項目 | 内容 |
 |---|---|
 | 章番号 | 04 |
-| ステータス | **v1.0 確定** |
-| 確定日 | 2026-05-09 |
-| 上位ドキュメント | [TRAKON PRD v1.2](../prd/trakon-prd.md) ／ [01-architecture.md](01-architecture.md) ／ [03-api.md](03-api.md) |
-| 主参照 PRD 節 | §7（SC-01〜SC-16）／§4.4（UXR）／§13.1（画面遷移図）／§2.6（3層構造）／NFR-UX-01〜03、NFR-A11Y-01、NFR-MOBILE-01 |
+| ステータス | **v1.1 確定**（v1.0: 2026-05-09 / v1.1: 2026-05-24 プロトタイプ反映） |
+| 確定日 | 2026-05-24 |
+| 上位ドキュメント | [TRAKON PRD v1.3](../prd/trakon-prd.md) ／ [01-architecture.md](01-architecture.md) ／ [03-api.md](03-api.md) |
+| 主参照 PRD 節 | §7（SC-01〜SC-17、v1.3 で SC-09 改訂・SC-17 新規）／§4.1.1（FR-AUTH-10〜12）／§4.1.4（FR-SCH-17, 18）／§4.1.7（FR-DASH 改訂）／§4.4（UXR）／§13.1（画面遷移図）／§2.6（3層構造）／NFR-UX-01〜03、NFR-A11Y-01、NFR-MOBILE-01 |
 
 ---
 
@@ -153,40 +153,45 @@ PRD §4.4 UXR-05「煽らず・濁さず・逃げない言葉遣い」を全画�
 
 ## 4.3. ルーティングと画面ツリー
 
-### 4.3.1. URL 構造（Phase 0）
+### 4.3.1. URL 構造（Phase 0、v1.1 更新）
 
 | URL | 画面 | 認証 | コンポーネント |
 |---|---|:---:|---|
-| `/login` | SC-01 ログイン | ❌ | `LoginPage` |
-| `/signup` | SC-01 サインアップ | ❌ | `SignupPage` |
-| `/forgot-password` | SC-01 パスワード再発行（要求） | ❌ | `ForgotPasswordPage` |
+| `/login` | SC-01 ログイン（**7 状態統合：login / signup / email-sent / create-account / password-reset-*** ） | ❌ | `LoginPage` |
 | `/invitations/:token` | SC-02 招待受諾 | ❌ | `InvitationAcceptPage` |
-| `/share/:token` | 非会員URL閲覧（プロジェクト／制作物／ボール スコープ） | ❌ | `GuestSharePage` |
-| `/` | ルート（→ `/projects` にリダイレクト） | ✅ | — |
+| `/share/:token` **(v1.1 非会員URL前倒し)** | 非会員URL閲覧（プロジェクト／制作物／ボール スコープ） | ❌ | `GuestSharePage` |
+| `/auth/oauth/:provider/callback` **(v1.1 プロトタイプ反映)** | OAuth コールバック | ❌ | `OAuthCallbackPage`（最小、`POST /auth/oauth/:provider/callback` → `/auth/me/sync` → ダッシュボード遷移） |
+| `/` | ルート（→ **`/dashboard`** にリダイレクト、v1.1 で変更） | ✅ | — |
+| **`/dashboard`** **(v1.1 Phase 0 必須)** | **SC-09 ダッシュボード（階層ビュー、ログイン直後の起点）** | ✅ | **`DashboardPage`** |
 | `/projects` | SC-03 プロジェクト一覧 | ✅ | `ProjectListPage` |
 | `/projects/new` | SC-04 プロジェクト新規作成 | ✅ | `ProjectNewPage` |
-| `/projects/:projectId` | SC-06 各制作物画面（プロジェクト直下、最初の制作物にリダイレクト） | ✅ | `ProjectShellPage` |
+| `/projects/:projectId` | プロジェクト直下、最初の制作物にリダイレクト | ✅ | `ProjectShellPage` |
 | `/projects/:projectId/items/:itemId` | SC-06 各制作物画面（縦型スケジュール） | ✅ | `ItemSchedulePage` |
 | `/projects/:projectId/edit` | SC-10 プロジェクト編集 | ✅ | `ProjectEditPage` |
-| `/projects/:projectId/members` | SC-11 参加者管理 | ✅ | `ProjectMembersPage` |
-| `/projects/:projectId/share-links` | SC-16 非会員URL 発行・管理 | ✅ | `ShareLinkAdminPage`（ディレクターのみ） |
+| **`/projects/:projectId/members`** **(v1.1 役割変更)** | **SC-17 メンバーかんばん（既定）／SC-11 参加者管理（タブで切替）** | ✅ | **`MemberKanbanPage`**（タブで `ProjectMembersManagePage` に切替） |
+| `/projects/:projectId/members?tab=manage` **(v1.1)** | SC-11 参加者管理 | ✅ | `ProjectMembersManagePage` |
+| `/projects/:projectId/share-links` **(v1.1 非会員URL前倒し)** | SC-16 非会員URL 発行・管理 | ✅ | `ShareLinkAdminPage`（ディレクターのみ） |
 | `/account` | アカウント基本情報 | ✅ | `AccountPage`（最小） |
 | `*` | 404 | — | `NotFoundPage` |
 
-> Phase 1 で予約（URL は確保するが Phase 0 では空 or リダイレクト）：`/dashboard`（SC-09）。
+> Phase 1 で予約：ダッシュボードの「進行判定フィルター」タブ（FR-DASH-08）。
+>
+> **v1.1 ルーティング方針変更点（プロトタイプ反映）**：① SC-01 ログイン関連 7 状態を **`/login` に統合**（プロトタイプ仕様、`useSearchParams` で screen 切替）／② `/dashboard` を **Phase 0 必須化** し、`/` リダイレクト先を変更／③ `/projects/:projectId/members` の既定タブを **メンバーかんばん（SC-17）** に変更、SC-11 参加者管理は `?tab=manage` で切替。
+>
+> **v1.1 ルーティング方針変更点（非会員URL前倒し）**：④ `/share/:token` を Phase 0 公開ルートに追加／⑤ `/projects/:projectId/share-links` を Phase 0 ディレクター画面として追加。
 
-### 4.3.2. ルートツリー
+### 4.3.2. ルートツリー（v1.1 更新）
 
 ```
 RootLayout（グローバルヘッダー）
 ├── 公開ルート
-│   ├── /login → LoginPage
-│   ├── /signup → SignupPage
-│   ├── /forgot-password → ForgotPasswordPage
+│   ├── /login → LoginPage（7 状態統合：useSearchParams で切替）
 │   ├── /invitations/:token → InvitationAcceptPage
-│   └── /share/:token → GuestSharePage（非会員URL閲覧／FR-SHARE、Phase 0）
+│   ├── /share/:token → GuestSharePage（非会員URL閲覧／FR-SHARE、Phase 0）
+│   └── /auth/oauth/:provider/callback → OAuthCallbackPage（v1.1 プロトタイプ反映）
 ├── 認証必須ルート（<RequireAuth>）
-│   ├── / → Navigate to /projects
+│   ├── / → Navigate to /dashboard
+│   ├── /dashboard → SidebarLayout + DashboardPage（v1.1 Phase 0 必須）
 │   ├── /projects → ProjectListPage
 │   ├── /projects/new → ProjectNewPage
 │   ├── /projects/:projectId
@@ -194,32 +199,36 @@ RootLayout（グローバルヘッダー）
 │   │   ├── index → ProjectShellPage（最初の item へ Navigate）
 │   │   ├── /items/:itemId → ItemSchedulePage（SC-06）
 │   │   ├── /edit → ProjectEditPage（SC-10）
-│   │   ├── /members → ProjectMembersPage（SC-11）
-│   │   └── /share-links → ShareLinkAdminPage（SC-16、ディレクターのみ）
+│   │   ├── /members → MemberKanbanPage（SC-17 既定）or ProjectMembersManagePage（?tab=manage、SC-11）
+│   │   └── /share-links → ShareLinkAdminPage（SC-16、ディレクターのみ、v1.1 非会員URL前倒し）
 │   └── /account → AccountPage
 └── * → NotFoundPage
 ```
 
-### 4.3.3. 画面遷移図（Phase 0、PRD §13.1 の Phase 0 抜粋版）
+### 4.3.3. 画面遷移図（Phase 0、v1.1 更新）
 
 ```mermaid
 flowchart LR
-    Login[SC-01 ログイン] --> ProjectList[SC-03 プロジェクト一覧]
-    Signup[SC-01 サインアップ] --> ProjectList
-    Invitation[SC-02 招待受諾] -. 受諾 .-> Login
-    Login -. パスワード再発行 .-> Forgot[SC-01 パスワード再発行]
+    Login[SC-01 ログイン<br/>7状態統合] --> Dashboard[SC-09 ダッシュボード<br/>v1.1 Phase 0]
+    Login -. OAuth .-> OAuthCb[/auth/oauth/:p/callback] --> Dashboard
+    Invitation[SC-02 招待受諾] -. 受諾 .-> Dashboard
+    Dashboard --> ItemSchedule[SC-06 制作物画面]
+    Dashboard --> ProjectList[SC-03 プロジェクト一覧]
     ProjectList --> ProjectNew[SC-04 プロジェクト新規作成]
-    ProjectList --> ItemSchedule[SC-06 制作物画面]
+    ProjectList --> ItemSchedule
     ProjectNew --> ItemSchedule
-    ItemSchedule --> PlanCreate[SC-07 予定作成モーダル]
+    ItemSchedule --> PlanCreate[SC-07 予定作成モーダル<br/>カテゴリ+次の予定]
     ItemSchedule --> BallDetail[SC-08 ボール詳細モーダル]
     ItemSchedule --> ProjectEdit[SC-10 プロジェクト編集]
-    ProjectEdit --> Members[SC-11 参加者管理]
-    ProjectEdit --> ShareAdmin[SC-16 非会員URL 発行・管理]
+    ItemSchedule --> MemberKanban[SC-17 メンバーかんばん<br/>v1.1 新規]
+    ProjectEdit --> Members[SC-11 参加者管理<br/>?tab=manage]
+    MemberKanban -. タブ切替 .-> Members
+    ProjectEdit --> ShareAdmin[SC-16 非会員URL 発行・管理<br/>v1.1 Phase 0 前倒し]
     ShareAdmin -.発行.-> GuestEntry[非会員URL]
     GuestEntry --> GuestShare[GuestSharePage<br/>非会員URL閲覧]
     GuestShare -. TOSS／完了／差し戻し .-> GuestShare
-    BallDetail -. TOSS／完了 .-> ItemSchedule
+    BallDetail -. TOSS/完了 .-> ItemSchedule
+    MemberKanban -. DnD=TOSS/完了 .-> MemberKanban
 ```
 
 ---
@@ -228,31 +237,74 @@ flowchart LR
 
 > 各画面は次の節構成：**目的／URL／表示項目／状態（ローディング・エラー・空・成功）／API 呼び出し／インタラクション／エッジケース**。
 
-### 4.4.1. SC-01 ログイン（`/login`）
+### 4.4.1. SC-01 ログイン（`/login`、v1.1 改訂：Magic-link + OAuth、7 状態統合）
 
-**目的**：既存ユーザーのログイン（FR-AUTH-01）。
+**目的**：既存ユーザーのログイン／新規サインアップ／パスワード再発行／OAuth サインイン（FR-AUTH-01, 10, 11, 12）。
 
-**表示項目**（PRD §7 SC-01）：
+**画面状態（7 ステップ統合、`useSearchParams` で screen を切替）**：
+`login` / `signup` / `email-sent` / `create-account` / `password-reset-request` / `password-reset-email-sent` / `password-reset` / `password-reset-complete`
+
+#### `login` 画面の表示項目
+
 - メールアドレス（Email、必須）
 - パスワード（Password、必須）
-- 「ログイン」ボタン
-- 「アカウントを作成」リンク → `/signup`
-- 「パスワードを忘れた」リンク → `/forgot-password`
+- 「ログイン状態を保存する」チェックボックス
+- 「ログイン →」ボタン
+- 「パスワードをお忘れですか？」リンク → `screen=password-reset-request`
+- **「または」区切り線下に：「Google で続ける」「Microsoft で続ける」ボタン**（v1.1、FR-AUTH-10）
+- 「アカウントをお持ちでない方は新規登録」リンク → `screen=signup`
 
-**処理**：
+#### `signup` 画面（Magic-link 開始）
+
+- メールアドレスのみ入力 → 「はじめる →」
+- **OAuth ボタン（Google / Microsoft）**
+- 利用規約・プライバシー同意文言（明示の同意チェックボックスなし、ボタン押下で同意とみなす）
+
+#### `email-sent` 画面
+
+- メール送信完了表示
+- 再送ボタン（60 秒カウントダウン）
+- （開発用：直接 `screen=create-account` に進めるデバッグボタン）
+
+#### `create-account` 画面（メール認証リンク押下後）
+
+- メールアドレス（読取専用）
+- **お名前（full_name）**（必須、1〜100文字、v1.1、FR-AUTH-11）
+- **ユーザー名／表示名（display_name）**（必須、1〜50文字、v1.1、FR-AUTH-11）
+- パスワード（必須、8文字以上）
+- パスワード（確認、必須）
+- 「プロジェクト作成 →」ボタン
+
+#### `password-reset-*` 画面群
+
+- パスワード再発行フロー（4 状態：request / email-sent / new-password / complete）
+
+#### 処理フロー
+
+**login（メール+パスワード）**：
 1. submit → Supabase Auth `signInWithPassword`
-2. 成功時：
-   - `POST /api/v1/auth/me/sync`（章3 §3.6.2）
-   - `next` クエリパラメータがあればそこへ、なければ `/projects` にリダイレクト
-3. 失敗時：エラーカード表示（メール／パスワード違いは同一文言「メールアドレスまたはパスワードが正しくありません」でユーザー存在を漏らさない）
+2. 成功 → `POST /api/v1/auth/me/sync` → `next` クエリ or `/dashboard` へ
+3. 失敗 → 同一文言エラー（メール／パスワード違い区別なし）
 
-**エッジケース**：
+**signup（Magic-link）**：
+1. メール入力 → Supabase Auth `signInWithOtp({ email, options: { shouldCreateUser: true, emailRedirectTo: APP_URL/login } })`
+2. `screen=email-sent` へ
+3. ユーザーがメールリンク押下 → `/login?token=...&type=signup` で戻る
+4. `verifyOtp(token)` → セッション確立 → `screen=create-account` へ
+5. 詳細入力 → `POST /api/v1/auth/me/complete-signup { fullName, displayName, password }` → `/dashboard` へ
+
+**OAuth**：
+1. 「Google で続ける」押下 → `POST /api/v1/auth/oauth/google/start` → returned `authorizeUrl` へ遷移
+2. プロバイダ同意 → `/auth/oauth/google/callback?code=...&state=...` に戻る
+3. FE が `POST /api/v1/auth/oauth/google/callback` → セッション確立
+4. `POST /api/v1/auth/me/sync` → users 行作成（同一メール別 provider なら 409 SAME_EMAIL_DIFFERENT_PROVIDER 表示）
+5. **requiresProfileCompletion = true なら** `screen=create-account` で display_name 設定（OAuth から full_name は取得済み）→ `/dashboard` へ
+
+#### エッジケース
+
 - メール未認証：「メール認証が完了していません。」+ 再送ボタン
 - ロックアウト（PRD SR-AUTH-04）：詳細は章5
-
-**サインアップ画面（`/signup`）**：
-- 表示項目：メール／パスワード／パスワード再入力／表示名／利用規約同意
-- 処理：Supabase Auth `signUp` → 仮登録完了画面（メール認証案内）
+- **同一メール別認証手段**（v1.1）：「このメールアドレスは Google 認証で登録済みです。Google で続けてください。」と本来の認証手段を案内
 
 ---
 
@@ -424,17 +476,19 @@ useQuery(['projects', projectId, 'items', itemId, 'plans'], fetchPlans)
 
 **起動**：SC-06 の日付セルクリックで開く。`openModal('create-plan', { date: 'YYYY-MM-DD' })` → URL が `?modal=create-plan&date=2026-05-15` に更新される。
 
-**表示項目（Phase 0、TOSS のみ）**：
+**表示項目（Phase 0、TOSS のみ、v1.1 でカテゴリ・後続追加）**：
 
 | 項目 | 型 | 必須 | 補足 |
 |---|---|:---:|---|
 | 予定種別 | Radio | × | Phase 0 は「TOSS予定」固定表示・選択不要（Phase 1 で3種選択） |
 | 予定名 | Text | ✅ | 1〜255 文字 |
+| **カテゴリ** | **Select** | **✅** | **6種固定（wireframe / design / coding / review / meeting / other、v1.1、FR-SCH-18）** |
 | FROM | Select | ✅ | プロジェクト参加メンバーから |
 | TO | Select | ✅ | FROM と異なる必須 |
-| 予定日 | Date | ✅ | 起動時の日付がプリセット |
-| 期日 | Date | × | 任意 |
-| メモ | Textarea | × | 任意 |
+| 開始日（旧 予定日） | Date | ✅ | 起動時の日付がプリセット（プロトタイプに合わせ「開始日」表記） |
+| 終了日 | Date | ✅ | 開始日以降。プロトタイプでは必須扱い |
+| **次の予定** | **Select** | **×** | **任意。同制作物の他予定から選択、`successor_plan_id` に設定（v1.1、FR-SCH-17）**。空欄なら紐付けなし。説明文「TOSS 完了時に自動的に次の予定が開始されます」 |
+| メモ | Textarea | × | 任意（プロトタイプには未実装、Phase 0 で追加検討） |
 
 **フォーム実装**：
 - React Hook Form + Zod（`packages/shared/schemas/plans.ts` を流用）
@@ -530,12 +584,15 @@ useQuery(['projects', projectId, 'items', itemId, 'plans'], fetchPlans)
 
 ---
 
-### 4.4.9. SC-11 参加者管理（`/projects/:projectId/members`）
+### 4.4.9. SC-11 参加者管理（`/projects/:projectId/members?tab=manage`、v1.1：SC-17 と URL を共有しタブ分離）
 
 **目的**：参加者の追加／編集／削除（FR-AUTH-07〜09）。
 
+**URL**：`/projects/:projectId/members?tab=manage`（SC-17 メンバーかんばんと同 URL、タブで切替）
+
 **表示項目（PRD SC-11）**：
-- テーブル：名前／所属名／メール／種別／sortOrder／受諾状態（accepted/pending/expired）／操作
+- 上部タブ：「**メンバー**」（既定、SC-17 メンバーかんばん）／「**管理**」（SC-11 本画面）
+- テーブル：名前／所属名／メール／種別（client/production）／sortOrder／受諾状態（accepted/pending/expired）／操作
 - ソートハンドルで `sortOrder` 変更（ドラッグ＆ドロップ、Phase 0）
 - 「+ 参加者を追加」ボタン → モーダル
 
@@ -547,7 +604,144 @@ useQuery(['projects', projectId, 'items', itemId, 'plans'], fetchPlans)
 
 ---
 
-### 4.4.10. SC-16 非会員URL 発行・管理（`/projects/:projectId/share-links`）
+### 4.4.10. SC-09 ダッシュボード（`/dashboard`、v1.1 改訂：階層ビュー、Phase 0 必須）
+
+**目的**：ログイン直後の起点画面として、自分が見られる全プロジェクトの「今日のタスク」を俯瞰（FR-DASH-01〜09、UC-13）。
+
+**URL**：`/dashboard`
+
+**画面構成**：
+
+```
+┌────────────────────────────────────────────────┐
+│ ダッシュボード（今日 yyyy/m/d）                  │
+├────────────┬────────────────────────────────┤
+│ 今日のタスク │ 期限超過                       │
+│   42        │   3                             │
+├────────────┴────────────────────────────────┤
+│ 🔵 ECサイトリニューアル (12件)                  │
+│   👤 田中 太郎 (3件)                           │
+│     [予定カード wireframe] [予定カード design]  │
+│   👤 佐藤 花子 (5件)                           │
+│     [予定カード design]    [予定カード review] │
+│ 🟢 コーポレートサイト制作 (5件)                 │
+│   ...                                          │
+└────────────────────────────────────────────────┘
+```
+
+**主要コンポーネント**：
+
+| コンポーネント | 責務 |
+|---|---|
+| `DashboardSummaryCards` | 上部 2 サマリーカード（今日のタスク数 / 期限超過数） |
+| `DashboardProjectGroup` | プロジェクトドット + 名前 + ヘッダー、配下メンバーセクション |
+| `DashboardMemberSection` | メンバーアバター + 名前 + 配下予定カードグリッド |
+| `DashboardTaskCard` | 予定カード（カテゴリ色、期限超過時赤系）。クリックで SC-06 へ遷移 |
+
+**表示項目**：
+
+| セクション | 内容 |
+|---|---|
+| ヘッダー | 「ダッシュボード」+ 「今日（yyyy/m/d）のプロジェクトとメンバーの状況」 |
+| サマリー | 「今日のタスク」総数 + 「期限超過」数（赤系） |
+| プロジェクトグループ | プロジェクトカラードット + 名前 + (件数) |
+| メンバーセクション | アバター（イニシャル）+ 名前 + (件数) |
+| 予定カード | 予定名 + 制作物名 + 期間（yyyy/m/d 〜 yyyy/m/d）、カテゴリ色背景、期限超過時赤背景 |
+| 空状態 | 「今日のタスクはありません」 |
+
+**API**：`GET /api/v1/users/me/dashboard`
+
+**インタラクション**：
+- 予定カードクリック → `navigate('/projects/:projectId/items/:itemId', { state: { scrollToBallId: planId } })`
+- 該当制作物画面（SC-06）でハイライト + 該当位置へスクロール
+
+**カテゴリ色マップ**（章 4.9 デザイントークンに統合）：
+
+| カテゴリ | 背景 | 枠線 |
+|---|---|---|
+| wireframe | purple-50 | purple-300 |
+| design | blue-50 | blue-300 |
+| coding | green-50 | green-300 |
+| review | orange-50 | orange-300 |
+| meeting | yellow-50 | yellow-300 |
+| other | gray-50 | gray-300 |
+| **期限超過** | **red-50** | **red-400** |
+
+**Phase 1 拡張**：
+- 「進行判定フィルター」タブ（平常／要確認／遅延の3カラム、FR-DASH-08）
+- メンバー指定の絞り込み・検索（FR-DASH-09, 10）
+
+---
+
+### 4.4.11. SC-17 メンバーかんばん（`/projects/:projectId/members`、v1.1 新規、Phase 0 必須）
+
+**目的**：プロジェクト参加メンバーごとに、担当している予定を準備中／TOSS済／完了の状態で並べたかんばんビュー。DnD で TOSS・完了を実行（UC-26、FR-BALL-02, 03, 08, 11）。
+
+**URL**：`/projects/:projectId/members`（既定タブ、SC-11 参加者管理は `?tab=manage` で切替）
+
+**画面構成**：
+
+```
+┌────────────────────────────────────────────────┐
+│ プロジェクト名 | [メンバー][管理]タブ            │
+├──────────┬──────────┬──────────┬──────────┤
+│ 状態＼担当  │ 田中 太郎 │ 佐藤 花子 │ 鈴木 次郎 │
+├──────────┼──────────┼──────────┼──────────┤
+│ 準備中     │ [card][card]│         │ [card]    │
+├──────────┼──────────┼──────────┼──────────┤
+│ TOSS済    │ [card]     │ [card]   │           │
+├──────────┼──────────┼──────────┼──────────┤
+│ 完了      │ [card]     │ [card]   │ [card]    │
+└──────────┴──────────┴──────────┴──────────┘
+```
+
+**主要コンポーネント**：
+
+| コンポーネント | 責務 |
+|---|---|
+| `MemberKanbanGrid` | グリッドレイアウト（CSS Grid：縦軸=状態、横軸=メンバー） |
+| `KanbanColumn` | 状態×メンバーのセル（DnD ドロップターゲット） |
+| `KanbanCard` | 予定カード（DnD ドラッグソース）、カテゴリ色 |
+| `MemberColumnHeader` | メンバーヘッダー（クライアント／制作グルーピング） |
+
+**DnD ライブラリ**：react-dnd（プロトタイプと同じ）
+
+**DnD 操作のドメインマッピング**（章 §4.7.4 と整合）：
+
+| DnD 操作 | API 呼び出し | event_type |
+|---|---|---|
+| メンバー A 列 → メンバー B 列（同状態） | `POST .../plans/:planId/toss { toMemberId: B }` | tossed (source='human') |
+| 準備中 → TOSS済（同メンバー、自分 = currentMember） | `POST .../plans/:planId/toss { toMemberId: currentMemberId }` | 同上 |
+| TOSS済 → 完了（同メンバー） | `POST .../plans/:planId/complete` | completed (source='human') |
+| 完了 → TOSS済（Phase 1 取消） | `POST .../plans/:planId/cancel-toss` | canceled |
+| メンバー＋状態を同時に動かす | 2 つの API を順次（FE 側で sequential mutation） | 各イベント |
+
+**認可・エラー処理**：
+- すべての DnD 操作は既存 API のミドルウェアで認可される（Ball Holder でない／状態遷移不可なら 403/422）
+- 失敗時：トースト「操作できませんでした：{エラーメッセージ}」+ カード位置を元に戻す（楽観更新ロールバック）
+
+**楽観更新**：
+- DnD でドロップした瞬間にカードを新位置に移動（`setQueryData`）
+- API 成功で確定、失敗で元に戻す（§4.7 と整合）
+
+**API**：
+- 一覧：`GET /api/v1/projects/:projectId/items/{各itemId}/plans` を全制作物分まとめて取得（or 専用 EP `/projects/:projectId/plans` を Phase 1 で検討）
+- 各 DnD：上記マッピング表参照
+
+**空状態**：「このプロジェクトには予定がまだありません」 + 「最初の予定を作成」リンク → SC-06 への導線
+
+**A11Y**：
+- DnD は **キーボード操作（矢印キー）** にも対応（react-dnd の HTML5Backend + KeyboardBackend）
+- カード移動時に `aria-live="polite"` で読み上げ「{予定名} を {新メンバー} に TOSS しました」
+
+**議論ポイント（§4.10）**：
+- カンバンでメンバー多数時の UX（横スクロール vs グルーピング）
+- 自己 TOSS（同一メンバー列内の状態移動）の API 表現
+- 状態カラム名の表示文言（「準備中」「TOSS済」「完了」が PRD ボール状態名と一致するか確認）
+
+---
+
+### 4.4.12. SC-16 非会員URL 発行・管理（`/projects/:projectId/share-links`、v1.1 非会員URL前倒し）
 
 **目的**：クライアント向けの非会員URLの発行・有効期限管理・個別失効・アクセスログ確認（FR-SHARE-01〜04、UC-23）。
 
@@ -575,7 +769,7 @@ useQuery(['projects', projectId, 'items', itemId, 'plans'], fetchPlans)
 
 ---
 
-### 4.4.11. 非会員URL 閲覧画面（`/share/:token`）
+### 4.4.13. 非会員URL 閲覧画面（`/share/:token`、v1.1 非会員URL前倒し）
 
 **目的**：非会員URL閲覧者（クライアント）が、共有スコープに応じてプロジェクト・制作物・ボールを閲覧し、自分が Ball Holder のボールに対して TOSS／完了／差し戻しを実行する（FR-SHARE-05、UC-23、SR-AUTHZ-02）。
 
@@ -702,7 +896,7 @@ const tossMutation = useMutation({
     const previous = queryClient.getQueryData(planKey);
     queryClient.setQueryData(planKey, (old) => {
       // 章3 §3.8 の deriveBallHolder を共通関数として呼び出す
-      const optimisticEvent = { eventType: 'tossed', actorMemberId: currentMember.id };
+      const optimisticEvent = { eventType: 'tossed', actorMemberId: currentMember.id, source: 'human' };  // v1.1 source 追加
       const newHolder = deriveBallHolder(old.plan, optimisticEvent);
       return { ...old, plan: { ...old.plan, ballHolder: newHolder, ballState: 'tossed' } };
     });
@@ -727,7 +921,75 @@ const tossMutation = useMutation({
 
 これにより、**FE と BE で同じロジックが Ball Holder を導出**するため、楽観更新の表示と API 確定後の表示が一致する。
 
-### 4.7.3. 競合した場合（API が 409 等を返した場合）
+### 4.7.3a. 自動 TOSS 連鎖（auto_chain）の楽観更新（v1.1 新規）
+
+`complete` API は v1.1 で **successor_plan_id が設定されていれば同一トランザクションで後続自動 TOSS を実行**（章3 §3.6.8、UC-25、FR-BALL-13）。レスポンスに `autoTossed: { plan, event }` が含まれる。
+
+FE の `useCompleteMutation` は以下のように扱う：
+
+```typescript
+const completeMutation = useMutation({
+  mutationFn: () => api.complete({ projectId, itemId, planId }),
+  onMutate: async () => {
+    // 自分の plan を completed に楽観更新
+    queryClient.setQueryData(planKey, (old) => /* ... ballState: 'completed' */);
+    // 後続 plan のキャッシュも先読みで更新（plan.successorPlanId があれば）
+    if (currentPlan.successorPlanId) {
+      const successorKey = ['projects', projectId, 'items', itemId, 'plans', currentPlan.successorPlanId];
+      queryClient.setQueryData(successorKey, (old) => {
+        if (!old || old.plan.status !== 'active') return old;
+        const optimisticEvent = { eventType: 'tossed', actorMemberId: null, source: 'auto_chain' };
+        const newHolder = deriveBallHolder(old.plan, optimisticEvent);
+        return { ...old, plan: { ...old.plan, ballHolder: newHolder, ballState: 'tossed' } };
+      });
+    }
+  },
+  onSuccess: (data) => {
+    // サーバが auto_chain を行ったらトースト表示
+    if (data.autoTossed) {
+      toast.success(`次の予定「${data.autoTossed.plan.title}」に自動 TOSS しました`);
+    }
+  },
+  onSettled: () => {
+    // 両 plan を invalidate
+    queryClient.invalidateQueries({ queryKey: planKey });
+    if (currentPlan.successorPlanId) {
+      queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'items', itemId, 'plans', currentPlan.successorPlanId] });
+    }
+    queryClient.invalidateQueries({ queryKey: plansKey });  // 一覧
+  },
+});
+```
+
+**UI 表現**：
+- 自動 TOSS の結果のイベントは `source: 'auto_chain'` で識別。SC-08 ボール詳細モーダルの履歴に「🔗 自動連鎖」アイコンを表示
+- ダッシュボード（SC-09）でも、auto_chain で TOSS された予定の Ball Holder 表示は通常 TOSS と区別なし（責任は移動済み）
+
+### 4.7.4. カンバン DnD の楽観更新（v1.1 新規、SC-17）
+
+SC-17 メンバーかんばんでの DnD 操作は、内部的に `useTossMutation` / `useCompleteMutation` を呼ぶ。
+
+**DnD ハンドラの実装イメージ**：
+
+```typescript
+function handleCardDrop(planId: string, fromMemberId: string, toMemberId: string, fromState: string, toState: string) {
+  if (fromMemberId !== toMemberId) {
+    // メンバー間移動 → toss with toMemberId
+    tossMutation.mutate({ planId, toMemberId });
+  }
+  if (fromState !== toState && toState === 'completed') {
+    completeMutation.mutate({ planId });
+  }
+  // 両方同時の場合は順次（toss → complete）
+}
+```
+
+**楽観更新**：
+- ドロップ即座にカード位置を変更（kanban state を更新）
+- mutation の `onError` でロールバック
+- 章 §4.4.11 SC-17 と整合
+
+### 4.7.5. 競合した場合（API が 409 等を返した場合）
 
 - 楽観更新をロールバック（`onError`）
 - トースト「他の操作と競合しました。最新の状態を取得します」
@@ -870,6 +1132,11 @@ Phase 0 では実装しない（CSS 変数化の素地は §4.9.1 で確保）�
 | 8 | 楽観更新 | **Phase 0 から実装**（TOSS / 完了、`packages/shared/domain/ball-holder.ts` を共有） | PRD SC-08「TOSS中…→相手にTOSSしました→自動クローズ」体験の確保 |
 | 9 | ブランドカラー（accent） | **仮確定 #1F6FEB（青系）** | 実装を止めない。デザイン確定後にトークン1点更新で全体反映 |
 | 10 | 国際化（i18n） | **`packages/shared/i18n/messages.ja.ts` に集約、ライブラリは未導入** | Phase 0 は日本語固定、文字列定数化のみで将来 EN 化への下地 |
+| 11 | カンバン DnD の意味論（v1.1、SC-17） | **既存 TOSS / 完了 API に集約、専用 EP なし** | UC-26 と整合。メンバー列移動 = `POST .../toss { toMemberId }`、状態列移動 = `POST .../complete` 等。認可・監査ログが既存ガードに乗る |
+| 12 | 「次の予定」選択肢の範囲（v1.1） | **同制作物内に限定**（Phase 0、プロトタイプ仕様と一致） | 異なる制作物・プロジェクトを跨ぐ後続は Phase 1+ で検討（議論ポイントとして残置） |
+| 13 | カンバンのメンバー多数時の UX（v1.1） | **横スクロール許容 + Sticky 状態カラム見出し**（Phase 0） | 5〜10 名は横スクロールなしで収まる前提。Phase 1 でグルーピング・フィルタを追加検討 |
+| 14 | カテゴリの導入範囲（v1.1） | **Phase 0 から必須項目、6 値固定**（FR-SCH-18） | 中立色の `other` を用意することで全予定に必ず1つ割当可能 |
+| 15 | OAuth ボタン配置（v1.1、SC-01） | **「または」区切り下、メール+パスワードの後**（プロトタイプ仕様） | スクリーン構成の慣例、メイン認証手段（password）を上に置く |
 
 ---
 
@@ -888,16 +1155,18 @@ Phase 0 では実装しない（CSS 変数化の素地は §4.9.1 で確保）�
 | FR-BALL-12 | §4.4.7 SC-08 削除は物理削除＋FE 確認モーダル |
 | §13.1 画面遷移図 | §4.3.3 に Phase 0 抜粋版で記載 |
 
-### Phase 1+ 持ち越し
+### Phase 1+ 持ち越し（v1.1 で SC-09 / SC-17 が Phase 0 へ繰り上げ）
 
 - SC-05 プロジェクトTOP（代表ボール表示）
-- SC-09 ダッシュボード（3カラム）
+- SC-09 「進行判定フィルター」タブ（平常／要確認／遅延の3カラム、FR-DASH-08）
 - SC-12 アーカイブ一覧
 - SC-13 コメント／ファイル共有パネル
 - SC-14 通知設定
 - SC-07 の予定種別3種対応（共同予定／単独予定）
 - SC-08 の TOSS 取消／差し戻し／再 TOSS
+- SC-17 メンバーかんばんのフィルタ・グルーピング（メンバー多数時 UX）
 - ダッシュボードのモバイル最適化（NFR-MOBILE-01 本格対応）
+- 異プロジェクト間の successor 紐付け
 
 ### PRD 整合メモ（PRD 改訂提案）
 
@@ -911,4 +1180,5 @@ Phase 0 では実装しない（CSS 変数化の素地は §4.9.1 で確保）�
 |---|---|---|
 | 2026-05-09 | Draft（たたき台） | §4.10 議論ポイント10項目を未確定で起稿 |
 | 2026-05-09 | **v1.0 確定** | §4.10 全10論点を AskUserQuestion で確定。モーダル管理は推奨案「Zustand ベース」から **「URL 同期方式」に変更**、他9項目は推奨案どおり。§4.2.4 / §4.4.6 SC-07 / §4.4.7 SC-08 / §4.8.1 を URL 同期方式に書き換え。 |
-| 2026-05-09 | **v1.1 確定** | PRD v1.3 改訂（非会員URL共有 Phase 0 化）に追従。§4.3.1 URL 構造に `/share/:token` と `/projects/:projectId/share-links` を追加、§4.3.2 ルートツリーを更新、§4.3.3 画面遷移図に SC-16 と GuestEntry / GuestSharePage を追加、§4.4.10 SC-16 非会員URL 発行・管理／§4.4.11 非会員URL 閲覧画面を新設、§4.11 Phase 1+ 持ち越しから SC-16 を除外。 |
+| 2026-05-09 | **v1.1 確定**（非会員URL前倒し） | PRD v1.3 改訂（非会員URL共有 Phase 0 化）に追従。§4.3.1 URL 構造に `/share/:token` と `/projects/:projectId/share-links` を追加、§4.3.2 ルートツリーを更新、§4.3.3 画面遷移図に SC-16 と GuestEntry / GuestSharePage を追加、§4.4.12 SC-16 非会員URL 発行・管理／§4.4.13 非会員URL 閲覧画面を新設、§4.11 Phase 1+ 持ち越しから SC-16 を除外。 |
+| 2026-05-24 | **v1.1 確定**（プロトタイプ反映） | SC-01 改訂（Magic-link + OAuth、7状態統合）／SC-07 改訂（カテゴリ + 次の予定）／SC-09 改訂（階層ビュー、Phase 0 必須化）／SC-11 改訂（タブ分離）／SC-17 新規（メンバーかんばん DnD = TOSS）／§4.3 ルーティング更新（/dashboard 必須化、/login 7状態統合、members タブ切替）／§4.7.3a 自動 TOSS 楽観更新／§4.7.4 カンバン DnD 楽観更新／§4.10 論点 11〜15 追加。 |

--- a/docs/design/05-security.md
+++ b/docs/design/05-security.md
@@ -3,10 +3,10 @@
 | 項目 | 内容 |
 |---|---|
 | 章番号 | 05 |
-| ステータス | **v1.0 確定** |
-| 確定日 | 2026-05-09 |
-| 上位ドキュメント | [TRAKON PRD v1.2](../prd/trakon-prd.md) ／ [01-architecture.md](01-architecture.md) ／ [02-database.md](02-database.md) ／ [03-api.md](03-api.md) ／ [04-frontend.md](04-frontend.md) |
-| 主参照 PRD 節 | §9 全節（§9.1〜§9.11）／§4.3 SR要約／§10.2 Phase 0 セキュリティ成功基準 |
+| ステータス | **v1.1 確定**（v1.0: 2026-05-09 / v1.1: 2026-05-24 プロトタイプ反映） |
+| 確定日 | 2026-05-24 |
+| 上位ドキュメント | [TRAKON PRD v1.3](../prd/trakon-prd.md) ／ [01-architecture.md](01-architecture.md) ／ [02-database.md](02-database.md) ／ [03-api.md](03-api.md) ／ [04-frontend.md](04-frontend.md) |
+| 主参照 PRD 節 | §9 全節（§9.1〜§9.11）／§4.3 SR要約（v1.3 で SR-AUTH-10 追加）／§4.1.1 FR-AUTH-10〜12／§10.2 Phase 0 セキュリティ成功基準 |
 
 ---
 
@@ -212,6 +212,23 @@ COMMIT;
 | 期限超過後の利用 | クエリ条件で除外、応答も 404 に集約 |
 | プロジェクト ID 漏洩 | URL に projectId を含めない（章3 §3.6.3 の経緯） |
 
+#### 招待トークン × OAuth の組み合わせ（v1.1 追記、FR-AUTH-10 / 12）
+
+招待リンクから OAuth でログイン／サインアップする場合：
+
+```
+1. ユーザーが招待リンク（/invitations/:token）にアクセス
+2. SC-02 招待受諾画面で「Google で続けて受諾」ボタン押下
+3. FE は token を sessionStorage に保管 → OAuth フロー（§5.3.9）開始
+4. OAuth callback → /auth/me/sync で users 行作成（同一メール検証）
+5. FE は sessionStorage の token を取り出して POST /invitations/:token/accept
+6. 受諾完了、プロジェクトへ遷移
+```
+
+**整合性**：
+- **招待メールと OAuth プロバイダのメールが一致しない場合**：受諾を拒否（422 `INVITATION_EMAIL_MISMATCH`）。理由：他人のメールで作られた招待を別人の OAuth アカウントで横取りできないようにするため
+- **同一メール 1 認証手段制約**（FR-AUTH-12）：招待メールアドレスで既存 users が `password` 認証で存在する場合、OAuth 受諾は 409。ユーザーは password ログインで受諾する必要がある
+
 ### 5.3.6. FE 側トークン保持戦略
 
 **結論**：Supabase Auth クライアント SDK の標準（**localStorage 保持**）を採用する。
@@ -308,6 +325,142 @@ export const auth = createMiddleware(async (c, next) => {
 
 ---
 
+### 5.3.9. OAuth 認証（Google / Microsoft）（v1.1 新規、✅ Phase 0、FR-AUTH-10, 12 / SR-AUTH-10）
+
+PRD §9.3 SR-AUTH-10 を実装する OAuth セクション。Supabase Auth Provider 設定 + PKCE フロー + state 検証 + 同一メール 1 認証手段制約を本節で確定。
+
+#### 5.3.9.1 採用方針
+
+| 観点 | 方針 |
+|---|---|
+| プロバイダ | **Google** + **Microsoft（Entra ID / Personal account 両対応）** を Phase 0 から提供 |
+| フロー | **PKCE Authorization Code Flow**（OAuth 2.0 + PKCE、Implicit Flow は不採用） |
+| **state 検証** | BE が `state` を uuidv7 で生成して短期 KV/メモリに保管（5分 TTL）、callback で必ず検証（CSRF 対策） |
+| 同一メール 1 認証制約 | FR-AUTH-12：1 メール = 1 `primary_auth_method`。別 provider での再ログイン試行は 409 で拒否し、本来の認証手段を案内 |
+| ID トークン保持 | localStorage（章5 §5.3.6 と同じ、CSP 厳格化で軽減） |
+| **Supabase Auth Provider 設定** | Google Cloud Console / Microsoft Entra ID で OAuth App 作成 → Supabase ダッシュボードで Client ID / Secret 登録（章6 §6.6.1） |
+
+#### 5.3.9.2 OAuth フロー（シーケンス）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as ユーザー
+    participant FE as Vite SPA
+    participant BE as Hono API
+    participant SAuth as Supabase Auth
+    participant Provider as Google/Microsoft
+
+    U->>FE: 「Google で続ける」押下
+    FE->>BE: POST /auth/oauth/google/start { redirectTo: '/dashboard' }
+    BE->>BE: PKCE code_verifier 生成、state 生成、KV に保管（5分 TTL）
+    BE-->>FE: { authorizeUrl, state }
+    FE->>SAuth: signInWithOAuth({ provider: 'google', options: { redirectTo, queryParams: { state } } })
+    SAuth->>Provider: PKCE Authorize URL へリダイレクト
+    U->>Provider: 同意
+    Provider->>SAuth: code + state（コールバック）
+    SAuth-->>FE: /auth/oauth/google/callback?code=...&state=...
+    FE->>BE: POST /auth/oauth/google/callback { code, state }
+    BE->>BE: state を KV と照合（CSRF 検証）
+    BE->>SAuth: exchangeCodeForSession(code, code_verifier)
+    SAuth-->>BE: access_token + refresh_token
+    BE-->>FE: tokens
+    FE->>BE: POST /auth/me/sync (Bearer JWT)
+    alt 同一メールが別 provider で既登録
+        BE-->>FE: 409 SAME_EMAIL_DIFFERENT_PROVIDER
+        FE-->>U: 「このメールは password 認証で登録済み」案内
+    else 新規 or 同 provider
+        BE->>BE: users INSERT (primary_auth_method=provider)、oauth_identities INSERT
+        BE-->>FE: { user, requiresProfileCompletion }
+        alt requiresProfileCompletion
+            FE-->>U: screen=create-account へ（display_name 入力）
+        else
+            FE-->>U: /dashboard へ遷移
+        end
+    end
+```
+
+#### 5.3.9.3 同一メール 1 認証手段制約の実装（FR-AUTH-12）
+
+`POST /auth/me/sync` で users 検索時に以下のロジックを実行：
+
+```typescript
+// apps/web/server/services/auth.ts
+async function syncUser(jwt: SupabaseJWT): Promise<UserSyncResult> {
+  const authUserId = jwt.sub;
+  const email = jwt.email;
+  const provider = jwt.app_metadata?.provider ?? 'email';  // Supabase Auth が提供
+  const newAuthMethod = providerToAuthMethod(provider);    // 'password' | 'google' | 'microsoft'
+
+  // 1) auth_user_id 一致の users を検索
+  let user = await prisma.users.findUnique({ where: { auth_user_id: authUserId } });
+  if (user) return { user, requiresProfileCompletion: !user.full_name || !user.display_name };
+
+  // 2) 同一メールの既存 users を検索（auth_user_id 不一致の場合）
+  const existingByEmail = await prisma.users.findUnique({ where: { email } });
+  if (existingByEmail && existingByEmail.primary_auth_method !== newAuthMethod) {
+    throw new HttpError(409, 'SAME_EMAIL_DIFFERENT_PROVIDER', {
+      message: `このメールアドレスは ${labelForAuthMethod(existingByEmail.primary_auth_method)} で登録済みです。`,
+      registeredMethod: existingByEmail.primary_auth_method,
+    });
+  }
+
+  // 3) 新規ユーザー作成
+  user = await prisma.users.create({
+    data: {
+      auth_user_id: authUserId,
+      email,
+      full_name: jwt.user_metadata?.full_name ?? jwt.user_metadata?.name ?? '',
+      display_name: jwt.user_metadata?.display_name ?? jwt.user_metadata?.name ?? '',
+      primary_auth_method: newAuthMethod,
+    },
+  });
+
+  // 4) OAuth の場合は oauth_identities INSERT
+  if (newAuthMethod !== 'password') {
+    await prisma.oauth_identities.create({
+      data: {
+        user_id: user.id,
+        provider: newAuthMethod,
+        provider_user_id: jwt.sub,  // Supabase Auth の sub と同等扱い（厳密には provider_id を別取得）
+        email,
+      },
+    });
+  }
+
+  return { user, requiresProfileCompletion: !user.full_name || !user.display_name };
+}
+```
+
+#### 5.3.9.4 PKCE / state の保管
+
+| 観点 | 方針 |
+|---|---|
+| code_verifier | BE で生成、URL のクエリではなく BE 側 KV に保管（state とペア）。callback 時に取り出して Supabase Auth に渡す |
+| state | BE で uuidv7 生成、5 分 TTL の KV（Phase 0 は Vercel KV / Upstash 未導入のため **メモリ Map（短命）** で代替、商用リリース前に KV 化） |
+| state 検証失敗時 | 400 `INVALID_STATE` を返し、`audit_logs` に `oauth_state_failure`（Phase 1） |
+
+> **議論ポイント §5.11-11**：Phase 0 でメモリ Map（Vercel Functions のサーバレス前提でステートレス）使用 vs Upstash KV を Phase 0 から導入。
+
+#### 5.3.9.5 OAuth プロバイダのメール変更時のハンドリング
+
+| 観点 | 方針 |
+|---|---|
+| 検知 | Supabase Auth の `auth.users.email` 更新を Webhook で受ける（章2 §2.5.3） |
+| 同期 | Webhook ハンドラで `users.email` と `oauth_identities.email` を片方向更新 |
+| ユーザー通知 | Phase 1 で「メールアドレスが変更されました」通知メール（Resend） |
+
+#### 5.3.9.6 セキュリティ上の留意
+
+| 項目 | 方針 |
+|---|---|
+| OAuth Client Secret 漏洩対策 | Vercel Env + Supabase Vault、SR-OPS-03 と同じ。漏洩時の再生成手順を Runbook 化（章6 §6.7） |
+| Authorize URL のドメイン検証 | Supabase Auth が標準で正規プロバイダドメインのみ許可 |
+| open redirect 対策 | `redirectTo` パラメータは同一オリジン以外を 400 で拒否（章3 §3.6.2） |
+| プロバイダから取得する PII | メール・名前のみ。プロフィール画像（picture）は Phase 0 では取得しても表示せず、`users.avatar_url` への保存も Phase 1+ で検討（PRD SR-PRIVACY-01 最小収集） |
+
+---
+
 ## 5.4. 認可実装
 
 ### 5.4.1. 認可ガード階層（章3 §3.3.2 の詳細化）
@@ -351,6 +504,9 @@ Phase 0 は role_type を実装しないため、簡易ロール導出：
 | URL の :itemId 改ざん | `requireItemInProject` で「指定 projectId の配下に存在するか」を必ず確認（**親子関係の検証**） |
 | URL の :planId 改ざん | `requirePlanInItem` で同上 |
 | リクエストボディの id 参照（例：`from_member_id`） | サービス層で「対象 member が currentProject の参加者であること」を検証 |
+| **`successor_plan_id` の指定（v1.1）** | サービス層で「対象後続 plan が **同一 project 内** に存在すること」を検証（Phase 0 制約）。`UNIQUE` 制約 + アプリ層の循環参照検出 |
+| **`oauth_identities` の参照（v1.1）** | アカウント設定画面（Phase 1+）で OAuth 連携を表示する際、`user_id == currentUser.id` を必ず WHERE 句に含める |
+| **カンバン DnD の `toMemberId`（v1.1、SC-17）** | TOSS API のサービス層で「対象 member が currentProject の参加者で、is_active=true であること」を検証 |
 
 > **原則**：URL パラメータと、リクエストボディに含まれる ID は **すべて currentProject に属することを必ず検証**する。これを Repository に「`findXxxInProject(id, projectId)`」のシグネチャで強制（projectId を引数に必須化）。
 
@@ -530,24 +686,27 @@ app.use('/share/:token/*', async (c, next) => {
 
 ## 5.6. 監査ログ実装
 
-### 5.6.1. Phase 0 の記録対象
+### 5.6.1. Phase 0 の記録対象（v1.1 で auto_toss / oauth_login を追加）
 
 PRD SR-AUDIT-01 の全項目のうち、**Phase 0 では以下の最低限を記録**：
 
-| action | トリガ | 記録元 |
-|---|---|---|
-| `login` | サインアップ・ログイン成功 | `POST /auth/me/sync` |
-| `toss` | TOSS 実行成功（認証経路） | `POST .../toss` |
-| `complete` | 予定完了成功（認証経路） | `POST .../complete` |
-| `share_create` | 非会員URL 発行成功 | `POST /projects/:projectId/share-links` |
-| `share_revoke` | 非会員URL 個別失効 | `DELETE /projects/:projectId/share-links/:shareLinkId` |
-| `share_access` | 非会員URL 経由のアクセス（GET/POST すべて） | `requireShareToken` ミドルウェア |
-| `share_toss` | 非会員URL 経由の TOSS 実行 | `POST /share/:token/plans/:planId/toss` |
-| `share_complete` | 非会員URL 経由の完了 | `POST /share/:token/plans/:planId/complete` |
+| action | トリガ | 記録元 | 備考 |
+|---|---|---|---|
+| `login` | サインアップ・ログイン成功（password / OAuth 両方） | `POST /auth/me/sync` | actor_user_id = currentUser.id |
+| `toss` | TOSS 実行成功（human、認証経路） | `POST .../toss` | source='human' |
+| `auto_toss` **(v1.1 プロトタイプ反映)** | **後続自動 TOSS 連鎖**（UC-25、FR-BALL-13） | `POST .../complete` 内部処理 | source='auto_chain'、**actor_user_id = NULL**（system actor）、extra に `triggered_by_plan_id` |
+| `complete` | 予定完了成功（認証経路） | `POST .../complete` | actor_user_id = currentUser.id |
+| `share_create` **(v1.1 非会員URL前倒し)** | 非会員URL 発行成功 | `POST /projects/:projectId/share-links` | actor_user_id = currentUser.id |
+| `share_revoke` **(v1.1)** | 非会員URL 個別失効 | `DELETE /projects/:projectId/share-links/:shareLinkId` | actor_user_id = currentUser.id |
+| `share_access` **(v1.1)** | 非会員URL 経由のアクセス（GET/POST すべて） | `requireShareToken` ミドルウェア | actor_user_id = NULL、share_link_id 設定、IP/UA 記録（FR-SHARE-04） |
+| `share_toss` **(v1.1)** | 非会員URL 経由の TOSS 実行 | `POST /share/:token/plans/:planId/toss` | actor_user_id = NULL、share_link_id 設定 |
+| `share_complete` **(v1.1)** | 非会員URL 経由の完了 | `POST /share/:token/plans/:planId/complete` | 同上 |
 
-> v1.1 改訂：`share_*` 5アクションは v1.0 まで Phase 1 追加リストに含まれていたが、PRD v1.3 で非会員URL共有が Phase 0 化されたため Phase 0 必須記録対象に格上げ（FR-SHARE-04、SR-AUTH-08）。
+> **v1.1 改訂（非会員URL前倒し）**：`share_*` 5アクションは v1.0 まで Phase 1 追加リストに含まれていたが、PRD v1.3 で非会員URL共有が Phase 0 化されたため Phase 0 必須記録対象に格上げ（FR-SHARE-04、SR-AUTH-08）。
 
-> Phase 1 で追加：`logout`、`login_failed`、`cancel_toss`、`return`、`retoss`、`member_added`、`member_removed`、`item_deleted`、`project_closed`、`project_archived`、`project_deleted`、`pdf_export`、`file_download`、`invitation_accepted`。
+> Phase 1 で追加：`logout`、`login_failed`、**`oauth_login` / `oauth_state_failure` / `complete_signup` / `email_changed`（v1.1 想定）**、`cancel_toss`、`return`、`retoss`、`member_added`、`member_removed`、`item_deleted`、`project_closed`、`project_archived`、`project_deleted`、`pdf_export`、`file_download`、`invitation_accepted`、`invitation_email_mismatch`。
+
+> **重要（v1.1 プロトタイプ反映）**：`auto_toss` の `actor_user_id` は NULL とし、`ball_events.actor_user_id` および `ball_events.actor_member_id` も NULL になる（章2 §2.4.6 `ck_be_actor_consistency`）。**system actor 操作を人間 actor と明確に区別**する。同様に `share_*` 系は actor_user_id = NULL、share_link_id を設定して非会員 URL 経路の操作を明示する。
 
 ### 5.6.2. ログ書き込みの実装方式（AuditLogger 抽象）
 
@@ -780,6 +939,10 @@ Content-Security-Policy:
 | 8 | サインイン失敗表示 | **区別しない（同一文言）** | PRD §9.1 機密第一、ユーザー列挙攻撃の素地を作らない |
 | 9 | 利用規約・プライバシー | **同意チェックのみ、文書整備は別途（リーガル監修）** | 法務観点の本文整備は専門領域、設計でブロックしない |
 | 10 | Sentry 送信データ | **スタックトレース・URL・user.id のみ、ボディ・クエリ・PII は scrub** | PRD SR-DATA-06 に準拠、デバッグ便利性は二次 |
+| 11 | OAuth state の保管先（v1.1） | **Phase 0 はメモリ Map で代替、商用リリース前に Upstash KV / Vercel KV へ移行** | Vercel Functions のサーバレス性質でメモリ持続性は弱いが、5分 TTL かつ取り扱いトラフィックが Phase 0 では小規模なため許容。Phase 1 で KV 化 |
+| 12 | OAuth プロバイダのメール変更同期（v1.1） | **Webhook 経由で users.email / oauth_identities.email を片方向同期**（Supabase Auth が真） | Phase 1 でユーザー通知メール追加 |
+| 13 | 招待リンク × OAuth のメール不一致（v1.1） | **422 INVITATION_EMAIL_MISMATCH で拒否**（招待先メール ≠ OAuth プロバイダのメール） | 他人の招待を別アカウントで横取り防止 |
+| 14 | system actor（auto_chain）の監査記録（v1.1） | **`audit_logs.actor_user_id = NULL`、ball_events も同様**、`source='auto_chain'` で識別 | 「人間の操作」と「システム自動連鎖」を改ざんログレベルで分離（DB CHECK で強制） |
 
 ---
 
@@ -823,4 +986,5 @@ Content-Security-Policy:
 |---|---|---|
 | 2026-05-09 | Draft（たたき台） | §5.11 議論ポイント10項目を未確定で起稿 |
 | 2026-05-09 | **v1.0 確定** | §5.11 全10論点を AskUserQuestion で確定（全て推奨案＝たたき台どおり） |
-| 2026-05-09 | **v1.1 確定** | PRD v1.3 改訂（非会員URL共有 Phase 0 化）に追従。§5.1 で非会員URL共有を本章節（Phase 0）扱いに変更、§5.2 公開範囲・デフォルト非公開の Phase 区切りを更新、§5.4.5 非会員URL共有のセキュリティ実装を新設（トークン生成・保管・検証・スコープ判定・クローラ防止・期限失効優先順位）、§5.6.1 監査ログ Phase 0 必須に `share_*` 5アクションを追加、§5.12 Phase 1+ 持ち越しを組織レベル統制（Phase 2）のみに整理。 |
+| 2026-05-09 | **v1.1 確定**（非会員URL前倒し） | PRD v1.3 改訂（非会員URL共有 Phase 0 化）に追従。§5.1 で非会員URL共有を本章節（Phase 0）扱いに変更、§5.2 公開範囲・デフォルト非公開の Phase 区切りを更新、§5.4.5 非会員URL共有のセキュリティ実装を新設（トークン生成・保管・検証・スコープ判定・クローラ防止・期限失効優先順位）、§5.6.1 監査ログ Phase 0 必須に `share_*` 5アクションを追加、§5.12 Phase 1+ 持ち越しを組織レベル統制（Phase 2）のみに整理。 |
+| 2026-05-24 | **v1.1 確定**（プロトタイプ反映） | §5.3.5 招待トークン × OAuth 組合せルール追記／§5.3.9 OAuth 認証セクション新規（フロー・PKCE/state・同一メール1認証制約・メール変更同期）／§5.4.3 IDOR にカンバン DnD toMemberId 検証 / successor_plan_id 検証 / oauth_identities 検証を追加／§5.6.1 監査ログに `auto_toss` を追加（system actor 識別）／§5.11 論点 11〜14 追加。 |

--- a/docs/design/06-infrastructure.md
+++ b/docs/design/06-infrastructure.md
@@ -3,10 +3,10 @@
 | 項目 | 内容 |
 |---|---|
 | 章番号 | 06 |
-| ステータス | **v1.0 確定** |
-| 確定日 | 2026-05-09 |
-| 上位ドキュメント | [TRAKON PRD v1.2](../prd/trakon-prd.md) ／ [01-architecture.md](01-architecture.md) ／ [05-security.md](05-security.md) |
-| 主参照 PRD 節 | §4.2（NFR）／§9.5（データ保護）／§9.6（監査ログ）／§9.10（脆弱性・運用）／§10（フェーズ） |
+| ステータス | **v1.1 確定**（v1.0: 2026-05-09 / v1.1: 2026-05-24 プロトタイプ反映） |
+| 確定日 | 2026-05-24 |
+| 上位ドキュメント | [TRAKON PRD v1.3](../prd/trakon-prd.md) ／ [01-architecture.md](01-architecture.md) ／ [05-security.md](05-security.md) |
+| 主参照 PRD 節 | §4.2（NFR）／§9.5（データ保護）／§9.6（監査ログ）／§9.10（脆弱性・運用）／§9.3 SR-AUTH-10（OAuth）／§10（フェーズ） |
 
 ---
 
@@ -228,8 +228,13 @@ Vercel は1プロジェクトで以下の環境を持つ：
 | `RESEND_API_KEY` | All | Resend ダッシュボード | BE 専用 |
 | `SENTRY_DSN_BE` | All | Sentry BE プロジェクト | BE 専用 |
 | `APP_URL` | Production / Preview | 自身の URL | BE 専用（招待リンクの組み立て用） |
+| **`GOOGLE_OAUTH_CLIENT_ID`** **(v1.1)** | All | Google Cloud Console | BE 専用（Supabase Auth Provider 設定にも入れる） |
+| **`GOOGLE_OAUTH_CLIENT_SECRET`** **(v1.1)** | All | 同上 | BE 専用、絶対漏洩禁止 |
+| **`MICROSOFT_OAUTH_CLIENT_ID`** **(v1.1)** | All | Microsoft Entra ID（Azure portal） | BE 専用 |
+| **`MICROSOFT_OAUTH_CLIENT_SECRET`** **(v1.1)** | All | 同上 | BE 専用、絶対漏洩禁止 |
+| **`OAUTH_STATE_TTL_SECONDS`** **(v1.1)** | All | 設定値（既定 300） | BE 専用、state KV の TTL |
 
-> **環境別値**：Vercel の各環境（Production / Preview / Development）で別の値を設定。Preview は dev Supabase を指す。
+> **環境別値**：Vercel の各環境（Production / Preview / Development）で別の値を設定。Preview は dev Supabase を指す。**OAuth Client は dev / prod で別アプリ作成**（Authorized redirect URI が環境別の URL を指すため）。
 
 ### 6.5.4. デプロイ戦略（GitHub Release ベース）
 
@@ -325,18 +330,52 @@ jobs:
 
 ## 6.6. Supabase 構成
 
-### 6.6.1. プロジェクト設定
+### 6.6.1. プロジェクト設定（v1.1 で OAuth 追加）
 
 | 項目 | 設定 |
 |---|---|
 | リージョン | Northeast Asia (Tokyo) |
 | プラン | Free（Phase 0 dev/prod 両方） → 商用リリース前に prod を Pro へ昇格 |
 | Postgres バージョン | 15.x（Phase 0 開始時の Supabase 既定） |
-| 認証プロバイダ | Email（メール+パスワード）のみ Phase 0 で有効 |
+| 認証プロバイダ | **Email（メール+パスワード Magic-link）+ Google + Microsoft** を Phase 0 で有効化（v1.1、FR-AUTH-10） |
 | 認証メール送信 | **無効化**（章5 §5.3.2、Resend で自前送信） |
 | API スキーマ | `public`（自動生成 PostgREST API は使用しない、Hono BE 経由） |
 | Storage | 無効（Phase 1 で有効化） |
 | Realtime | 無効（Phase 0 不要） |
+
+#### Google OAuth Provider 設定手順（v1.1 新規）
+
+1. **Google Cloud Console**（[console.cloud.google.com](https://console.cloud.google.com)）でプロジェクト作成
+2. 「API とサービス」→「OAuth 同意画面」：
+   - User Type: External
+   - アプリ名: TRAKON、サポートメール: 連絡先
+   - 認可スコープ: `email`, `profile`, `openid`
+   - テストユーザー（開発期間中）登録
+3. 「認証情報」→「+ 認証情報を作成」→ OAuth クライアント ID：
+   - アプリケーションの種類: ウェブアプリケーション
+   - 名前: TRAKON Web (dev) / TRAKON Web (prod)
+   - **承認済みリダイレクト URI**: `https://<supabase-project-ref>.supabase.co/auth/v1/callback`
+4. Client ID / Client Secret を Vercel Env と Supabase ダッシュボードに登録：
+   - Supabase: Authentication → Providers → Google を有効化、Client ID / Secret を貼り付け
+   - Vercel Env: `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET`
+
+#### Microsoft OAuth Provider 設定手順（v1.1 新規）
+
+1. **Microsoft Entra ID**（旧 Azure AD）でアプリ登録：
+   - サポートされるアカウントの種類: **個人アカウント＋職場/学校アカウント**（v2.0 エンドポイント）
+   - **リダイレクト URI**: `https://<supabase-project-ref>.supabase.co/auth/v1/callback`
+2. 「証明書とシークレット」→「クライアントシークレット」を新規作成（有効期限24ヶ月推奨）
+3. 「API のアクセス許可」→ Microsoft Graph の `User.Read`, `openid`, `email`, `profile` を委任で追加
+4. アプリ (クライアント) ID と シークレットを Vercel Env と Supabase ダッシュボードに登録：
+   - Supabase: Authentication → Providers → Azure (Microsoft) を有効化、Client ID / Secret を貼り付け
+   - Vercel Env: `MICROSOFT_OAUTH_CLIENT_ID` / `MICROSOFT_OAUTH_CLIENT_SECRET`
+
+#### 共通の注意点（v1.1）
+
+- **dev / prod で別 OAuth App を作成**（リダイレクト URI が異なるため、同じ Client を流用しない）
+- **Same-email 1 認証手段制約**（FR-AUTH-12）：BE 側で実装（章5 §5.3.9.3）、Supabase Auth 側の設定では制御しない
+- Supabase Auth の **Site URL** を `https://app.trakon.example`（または Vercel 既定 URL）に設定。`Additional Redirect URLs` に開発用 URL を追加
+- 認証メールは Supabase 側を OFF にしているため、OAuth プロバイダのコールバック後は **自前メール（Resend）で welcome メール送信**（Phase 1 で実装、Phase 0 はサインアップ通知のみ）
 
 ### 6.6.2. データベース設定
 
@@ -383,6 +422,8 @@ flowchart LR
 | Supabase service_role key | Vercel Env + Supabase Vault | 漏洩疑い時に即時、Phase 1 で四半期定期 |
 | Resend API キー | Vercel Env | 同上 |
 | Supabase DB パスワード | Vercel Env | 同上 |
+| **Google OAuth Client Secret** **(v1.1)** | Vercel Env + Supabase Auth Provider 設定 | 漏洩疑い時に即時（Google Cloud Console で再生成）、Phase 1 で **年次定期**（OAuth 標準慣行） |
+| **Microsoft OAuth Client Secret** **(v1.1)** | Vercel Env + Supabase Auth Provider 設定 | 同上、ただし**作成時に有効期限を 24ヶ月で設定**しているため、期限前カレンダー登録（運用 Runbook §6.15.6） |
 | GitHub Actions シークレット | GitHub Settings → Secrets | リポジトリ管理者のみ閲覧 |
 
 ### 6.7.2. ローカル開発（`.env.local`）
@@ -397,6 +438,12 @@ SUPABASE_SERVICE_ROLE_KEY=
 SUPABASE_JWT_SECRET=
 RESEND_API_KEY=
 APP_URL=http://localhost:5173
+# v1.1 OAuth
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+MICROSOFT_OAUTH_CLIENT_ID=
+MICROSOFT_OAUTH_CLIENT_SECRET=
+OAUTH_STATE_TTL_SECONDS=300
 ```
 
 `.env.local` は **gitignore 必須**。実値は開発者個別に Supabase CLI から取得 or Vercel CLI で `vercel env pull .env.local` で同期。
@@ -710,6 +757,15 @@ jobs:
 
 ドメインの自動更新を有効化、レジストラに支払い情報登録。年1回の手動確認をカレンダーに登録。
 
+### 6.15.7. OAuth Client Secret 期限管理（v1.1 新規）
+
+| 項目 | 運用 |
+|---|---|
+| Microsoft Client Secret | 作成時に有効期限 24ヶ月を設定、**期限の 30 日前にカレンダー通知**（運用担当者の Google カレンダー登録）→ 新シークレット作成 → Vercel Env と Supabase Auth Provider 設定を更新 → 旧シークレット削除 |
+| Google Client Secret | 期限なしだが、年次（毎年4月）に自主ローテーションを実施（漏洩リスクを下げる） |
+| 失効時の影響 | OAuth サインアップ・ログインが全停止。**期限切れ警告は Better Stack uptime で 401 監視を兼ねる** |
+| 漏洩疑い時 | Google Cloud Console / Microsoft Entra ID で即時シークレット削除 → 新規生成 → Vercel/Supabase 更新
+
 ---
 
 ## 6.16. 議論ポイントの確定結果
@@ -726,6 +782,10 @@ jobs:
 | 8 | Uptime 監視 | **Better Stack Free で 5分間隔 /healthz 監視** | Vercel から独立した外部監視、無料枠で要件充足 |
 | 9 | DB ロール分離 | **Phase 0 から `app_user` / `app_migrator` の2ロール分離** | 章2 §2.7 の append-only 強制（REVOKE）を Phase 0 から有効化、多層防御を初日から確保 |
 | 10 | Production デプロイ承認 | **GitHub Release 公開タイミングで Production デプロイ**（§6.5.4） | main マージは Preview のみ、Release が承認行為。誤マージで本番に流れない安全装置。Phase 1 で GitHub Environments の Protection Rules で2段階化 |
+| 11 | OAuth Client の dev/prod 分離（v1.1） | **dev と prod で別の OAuth App を作成**（Google Cloud Console / Microsoft Entra ID で別アプリ） | リダイレクト URI が環境別で異なるため、シークレット混在事故も防止 |
+| 12 | OAuth state の保管基盤（v1.1） | **Phase 0 はメモリ Map（代替）、商用リリース前に Upstash KV / Vercel KV 導入** | Vercel Functions のステートレス性で持続性弱いが、5分 TTL かつトラフィック小規模で Phase 0 は許容（章5 §5.11-11） |
+| 13 | OAuth Secret ローテーション周期（v1.1） | **Google: 年次自主、Microsoft: 24ヶ月で期限切れ予告 → 期限30日前にローテ** | プロバイダの慣行と運用負荷のバランス |
+| 14 | カテゴリ・後続紐付け運用（v1.1） | **インフラ層は新規対応なし**（DB スキーマと API のみ、章2・章3 で対応済み） | 既存インデックス追加（章2 §2.8）で対応、本章は監視ダッシュボードに後続自動 TOSS 件数の指標を Phase 1 で追加検討 |
 
 ---
 
@@ -765,4 +825,5 @@ jobs:
 |---|---|---|
 | 2026-05-09 | Draft（たたき台） | §6.16 議論ポイント10項目を未確定で起稿 |
 | 2026-05-09 | **v1.0 確定** | §6.16 全10論点を AskUserQuestion で確定。Production デプロイは推奨案「Phase 0 は自動」から **「GitHub Release ベース」に変更**、他9項目は推奨案どおり。§6.5.4 / §6.8 / §6.9 / §6.15 を Release ベースに書き換え。 |
-| 2026-05-09 | **v1.1 確定** | PRD v1.3 改訂（非会員URL共有 Phase 0 化）に追従。§6.4.1 ドメイン構成に `/share/:token` の `noindex`／robots.txt／Cloudflare キャッシュバイパス運用注記を追加、§6.14 Phase 1+ 拡張計画に「非会員URL共有のレート制限・総当り検知」と「組織レベル On/OFF 統制」を追加。 |
+| 2026-05-09 | **v1.1 確定**（非会員URL前倒し） | PRD v1.3 改訂（非会員URL共有 Phase 0 化）に追従。§6.4.1 ドメイン構成に `/share/:token` の `noindex`／robots.txt／Cloudflare キャッシュバイパス運用注記を追加、§6.14 Phase 1+ 拡張計画に「非会員URL共有のレート制限・総当り検知」と「組織レベル On/OFF 統制」を追加。 |
+| 2026-05-24 | **v1.1 確定**（プロトタイプ反映） | §6.5.3 環境変数に OAuth Client ID/Secret + state TTL 追加／§6.6.1 Google・Microsoft OAuth Provider 設定手順を新規セクションとして追加／§6.7.1 シークレット保管・ローテに OAuth Secret 2行追加／§6.7.2 .env.example に OAuth 行追加／§6.15.7 OAuth Client Secret 期限管理 Runbook 追加／§6.16 論点 11〜14 追加。 |

--- a/docs/prd/trakon-prd.md
+++ b/docs/prd/trakon-prd.md
@@ -7,7 +7,7 @@
 | プロダクト名 | TRAKON |
 | 発行元 | 株式会社おさまるカンパニー |
 | ドキュメント版 | v1.3 |
-| 発行日 | 2026-05-09 |
+| 発行日 | 2026-05-24 |
 | ステータス | Draft |
 | 本書の位置づけ | 基本原則 > **本PRD** > 個別仕様書 |
 
@@ -18,7 +18,8 @@
 | v1.0 | 2026-04-19 | 初版（基本原則・正規仕様書・MVP仕様書・ピッチ資料を統合） | — |
 | v1.1 | 2026-04-25 | 非会員URL共有を Phase 1 で正式採用。組織管理者による機能 On/OFF トグルを Phase 2 で提供。§3／§4.1／§4.3／§9.1〜9.4／§10.3〜10.4／§11／§12 を該当箇所書き換え。 | — |
 | v1.2 | 2026-04-25 | データモデルの命名整合：`schedules` テーブル → `plans` に改名（概念「予定」と整合）。関連カラム `schedule_type / schedule_id` → `plan_type / plan_id`。`organization_settings`、`share_links` テーブルを追加。§8.1〜8.5 を全面書き換え。各テーブルに「司る機能・情報」コメントを付与。改名対応表を §8.2 末尾に追加。 | — |
-| v1.3 | 2026-05-09 | 非会員URL共有（FR-SHARE-01〜06、SR-AUTH-08、UC-23、SC-16、`share_links` テーブル）を Phase 1 → Phase 0 へ前倒し。組織レベル統制（FR-ORG-04, 05、FR-SHARE-07、SR-AUTH-09、`organizations` / `organization_settings`）は Phase 2 維持。§3／§4.1／§4.3／§5／§6／§7／§8／§9／§10／§11／§13 を該当箇所書き換え。 | — |
+| v1.3a | 2026-05-09 | **非会員URL共有（FR-SHARE-01〜06、SR-AUTH-08、UC-23、SC-16、`share_links` テーブル）を Phase 1 → Phase 0 へ前倒し**。組織レベル統制（FR-ORG-04, 05、FR-SHARE-07、SR-AUTH-09、`organizations` / `organization_settings`）は Phase 2 維持。§3／§4.1／§4.3／§5／§6／§7／§8／§9／§10／§11／§13 を該当箇所書き換え。 | — |
+| v1.3b | 2026-05-24 | **Figma Make プロトタイプ反映による機能追加**：① **OAuth (Google/Microsoft) を Phase 0 から提供**（FR-AUTH-10、SR-AUTH-10）／② **新規登録項目を拡充**（full_name + display_name 2列、Magic-link 風サインアップ、FR-AUTH-11、UC-01 改訂）／③ **タスク後続紐付けによる自動 TOSS 遷移**（plans.successor_plan_id、FR-SCH-17、FR-BALL-13、UC-25）／④ **ダッシュボードを Phase 0 へ繰り上げ**、仕様を「プロジェクト×メンバー×今日」階層ビューに改訂（FR-DASH-01〜10、SC-09）／⑤ **カテゴリ概念追加**（plans.category 6値必須、FR-SCH-18）／⑥ **メンバーかんばん画面 SC-17 新規**（カンバン DnD = TOSS、UC-26）／⑦ **oauth_identities テーブル新規**。§1.3／§4.1.1／§4.1.4／§4.1.5／§4.1.7／§6／§7／§8／§9.3／§10.2 を該当箇所改訂。v1.3a と統合して **v1.3 として確定**。 | — |
 
 ## 参照元ドキュメント
 
@@ -101,6 +102,12 @@
 | **TOSS取消（Canceled）** | 誤って実行した TOSS を無効化し、直前状態に戻す操作 |
 | **制作物** | プロジェクトに紐づく成果物単位（Webページ／ドキュメント／バナー 等） |
 | **プロジェクト** | 参加者・制作物・ボール・予定を束ねる親単位 |
+| **タスク** | UI 上で「予定」を指す通称。設計書／DB上は「予定（plan）」に統一する（v1.3 追加） |
+| **カテゴリ** | 予定の作業種別。`wireframe / design / coding / review / meeting / other` の6値（v1.3 追加、FR-SCH-18） |
+| **後続紐付け** | 1つの予定（先行）に対し1つの後続予定を紐付ける関係。先行が完了したとき後続を **system actor による自動 TOSS** で受領状態に遷移させる（v1.3 追加、FR-SCH-17／FR-BALL-13） |
+| **メンバーかんばん** | プロジェクト参加メンバーごとに「準備中／TOSS済／完了」状態で予定を並べたかんばんビュー（SC-17）。DnD によるメンバー間移動は TOSS、状態間移動は完了などのドメイン操作にマッピングされる（v1.3 追加） |
+| **Magic-link サインアップ** | メールアドレス入力 → 認証メールリンク押下 → 詳細入力（full_name／display_name／password）→ 自動ログインの2段階フロー（v1.3 追加、UC-01） |
+| **OAuth プロバイダ** | Google / Microsoft 等の外部ID連携。Phase 0 から Google / Microsoft の2プロバイダを提供（v1.3 追加、FR-AUTH-10／SR-AUTH-10） |
 
 ### 1.4. 関連仕様書との対応表
 
@@ -280,6 +287,9 @@ Phase 0 では、まず ③ 各制作物画面 で「ボールの受け渡しが
 | FR-AUTH-07 | プロジェクトの参加者追加時、未登録メールには招待メールを送る（招待＝FR-AUTH-02） | **0** | プロジェクト仕様書 v1.2 §6 |
 | FR-AUTH-08 | 参加者は所属名・表示名・種別（client / production）・役割（role_type）を持つ | **0** | プロジェクト仕様書 v1.2 §6 |
 | FR-AUTH-09 | 参加者は一時非表示（is_active=false）／論理削除（deleted_at）ができる | 1 | プロジェクト仕様書 v1.2 §6 |
+| FR-AUTH-10 | ユーザーは Google / Microsoft の OAuth プロバイダでサインアップ／ログインできる | **0** | 新規定義（SR-AUTH-10 連携） |
+| FR-AUTH-11 | サインアップ時のアカウント詳細項目は `full_name`（本名）／`display_name`（表示名）／`password` を持つ。サインアップは Magic-link 風2段階（メール先行 → リンク押下 → 詳細入力 → 自動ログイン）で実行する | **0** | 新規定義（UC-01 連携） |
+| FR-AUTH-12 | 同一メールアドレスは1つの認証手段（`password` / `google` / `microsoft` のいずれか）にのみ紐付ける。別認証手段でのサインインは拒否し、本来の認証手段を案内する | **0** | 新規定義（SR-AUTH-10、§5.3） |
 
 #### 4.1.2. プロジェクト系（FR-PRJ）
 
@@ -320,6 +330,8 @@ Phase 0 では、まず ③ 各制作物画面 で「ボールの受け渡しが
 | FR-SCH-09 | 予定に Draft 状態は持たない（保存した時点で有効） | **0** | 予定種別仕様書 v1.1 §2 |
 | FR-SCH-10 | 同一日に複数の予定は3件まで表示し、4件目以降は「+N」で集約 | 1 | カレンダー表示仕様 v1.0 §10 |
 | FR-SCH-11 | 月の切り替わりに区切り線を表示する | **0** | カレンダー表示仕様 v1.0 §4 |
+| FR-SCH-17 | 予定は **1つの後続予定（successor_plan_id）** を持てる。先行予定の完了で、後続予定への自動 TOSS が走る（FR-BALL-13）。Phase 0 では同一プロジェクト内に限定 | **0** | 新規定義（SC-07／FR-BALL-13 連携） |
+| FR-SCH-18 | 予定は **カテゴリ**を必須項目として持つ。値は `wireframe / design / coding / review / meeting / other` の6種（DB側は CHECK 制約で可変）。カレンダー・カンバン・ダッシュボードの色分けに用いる | **0** | 新規定義（SC-06／SC-07／SC-09／SC-17 連携） |
 
 #### 4.1.5. ボール状態遷移系（FR-BALL）
 
@@ -337,6 +349,7 @@ Phase 0 では、まず ③ 各制作物画面 で「ボールの受け渡しが
 | FR-BALL-10 | ボール履歴は削除せず保持する | 1 | ボール状態遷移仕様書 v1.1.1 §5 |
 | FR-BALL-11 | Ball Holder は常に1名に定まり、「空」にならない | 1 | 予定種別仕様書 v1.1 §7 |
 | FR-BALL-12 | MVP ではボール削除は即時物理削除・確認モーダルなし（簡易実装） | **0** | MVP仕様書 §6.3 |
+| FR-BALL-13 | **後続自動 TOSS**：先行予定が `completed` になったとき、同一トランザクション内で `successor_plan_id` が指す後続予定に対し **system actor（`ball_events.source='auto_chain'`、`actor_user_id=NULL`）** で TOSS を実行する。後続が `completed` / `canceled` ならスキップ。Phase 0 では1段のみ（A→B→C の C は B 完了時に自動 TOSS） | **0** | 新規定義（FR-SCH-17／UC-25） |
 
 #### 4.1.6. 共同予定／単独予定系（Phase 1 以降）
 
@@ -350,18 +363,20 @@ Phase 0 では、まず ③ 各制作物画面 で「ボールの受け渡しが
 
 #### 4.1.7. ダッシュボード／進行判定系（FR-DASH）
 
+> **v1.3 改訂**：仕様を「プロジェクト×メンバー×今日」**階層ビュー**に書き換え、**Phase 0 へ繰り上げ**。3カラム（平常／要確認／遅延）仕様は将来「進行判定フィルター」として Phase 1+ で併設可能（FR-DASH-08）。
+
 | ID | 概要 | 対応Phase | 参照仕様 |
 |---|---|---|---|
-| FR-DASH-01 | ダッシュボードは全プロジェクト横断、ログインユーザーが Ball Holder である未完了予定を対象 | 1 | ダッシュボード仕様 v1.0 §5 |
-| FR-DASH-02 | 初期表示対象は「未完了」かつ「Ball Holder = 自分」かつ「監視基準日を持つ」予定 | 1 | ダッシュボード仕様 v1.0 §5 |
-| FR-DASH-03 | 画面上部にサマリー文言を動的表示する | 1 | ダッシュボード仕様 v1.0 §7-2 |
-| FR-DASH-04 | 3カラム（平常／要確認／遅延）で予定カードを表示する | 1 | ダッシュボード仕様 v1.0 §7-3 |
-| FR-DASH-05 | 進行判定：要確認＝基準日から前日・当日・翌日、遅延＝2日以上前かつ未完了 | 1 | ダッシュボード仕様 v1.0 §6-5, §6-6 |
-| FR-DASH-06 | 進行判定区分の並び順と、各カラム内の並び順を定義する | 1 | ダッシュボード仕様 v1.0 §9 |
-| FR-DASH-07 | 予定カードは プロジェクト名／予定名／期日／Ball Holder を表示 | 1 | ダッシュボード仕様 v1.0 §8 |
-| FR-DASH-08 | 予定カード押下で各制作物画面へ遷移、該当位置までスクロール＋ハイライト | 1 | ダッシュボード仕様 v1.0 §10 |
-| FR-DASH-09 | ダッシュボードは監視・確認の起点であり、個別ボール操作は行わない | 1 | ダッシュボード仕様 v1.0 §10 |
-| FR-DASH-10 | チーム全体ビュー（他者のターン横断）は将来拡張 | 2 | ダッシュボード仕様 v1.0 §11 |
+| FR-DASH-01 | ダッシュボードはログイン直後の起点画面（`/dashboard`）。**自分が見られる全プロジェクト**を横断対象とする | **0** | 新規定義（v1.3 改訂） |
+| FR-DASH-02 | 画面上部に **2 つのサマリーカード**を表示：① 今日のタスク総数 ② 期限超過タスク数 | **0** | 新規定義（SC-09） |
+| FR-DASH-03 | 本体は **プロジェクト → メンバー → 予定カード** の階層ビュー。「今日が期間内（startDate ≤ today ≤ endDate）かつ未完了」の予定のみを対象 | **0** | 新規定義（SC-09） |
+| FR-DASH-04 | 予定カードは プロジェクト名／予定名／制作物名／期間／Ball Holder を表示。**カテゴリ（FR-SCH-18）に応じた色分け**、期限超過は赤系で強調 | **0** | 新規定義（SC-09） |
+| FR-DASH-05 | 期限超過判定：`status='active'` かつ `endDate < today`（JST 暦日基準） | **0** | 新規定義 |
+| FR-DASH-06 | 予定カード押下で各制作物画面（SC-06）へ遷移、該当位置までスクロール＋ハイライト（ナビゲーション state `scrollToBallId` 経由） | **0** | 新規定義（SC-06／SC-09） |
+| FR-DASH-07 | ダッシュボードは監視・確認の起点であり、個別ボール操作は SC-08（ボール詳細モーダル）へ遷移してから行う | **0** | 新規定義 |
+| FR-DASH-08 | 「進行判定フィルター」（平常／要確認／遅延の3区分、進行判定ロジックは旧 FR-DASH-05 を踏襲）を Phase 1 で追加。階層ビューとフィルタータブ切替で提供する | 1 | ダッシュボード仕様 v1.0 §6, §7（旧仕様を Phase 1 機能として再採用） |
+| FR-DASH-09 | プロジェクト・メンバー多数時の UX（フィルタ／グルーピング／検索）は Phase 1 で詳細化 | 1 | 新規定義 |
+| FR-DASH-10 | チーム全体ビュー（他者のターン横断視点）は階層ビュー（FR-DASH-03）で既に表現済み。Phase 1 で「メンバー指定の絞り込み」「組織横断ビュー」を追加 | 1 | 新規定義（v1.3 でスコープ整理） |
 
 #### 4.1.8. プロジェクト代表ボール系（FR-PRJ-SUM）
 
@@ -453,6 +468,7 @@ Phase 0 では、まず ③ 各制作物画面 で「ボールの受け渡しが
 | SR-AUTH-09 | 組織管理者は組織レベルで非会員URL共有機能を On/OFF できる（FR-ORG-04, 05） |
 | SR-AUTH-02 | 招待リンクは有効期限付き・ワンタイム利用とする |
 | SR-AUTH-03 | パスワードポリシーを強制する（長さ・複雑性・既知流出照合） |
+| SR-AUTH-10 | OAuth プロバイダ（Google / Microsoft）認証を提供する。**PKCE フロー必須・state パラメータ検証必須・同一メールは1認証手段に限定**（FR-AUTH-10, 12 連携） |
 | SR-AUTHZ-01 | プロジェクト単位の参加認可、ロール別の操作権限を最小権限原則で設計 |
 | SR-AUTHZ-02 | クライアントおよび非会員URL閲覧者は、自分が Ball Holder の予定への操作と、発行者が指定した範囲のプロジェクト閲覧のみ可 |
 | SR-DATA-01 | 転送時 TLS1.2 以上必須 |
@@ -584,11 +600,18 @@ flowchart LR
     UC21[UC-21 PDF出力]
     UC22[UC-22 権限管理]
     UC23[UC-23 非会員URLでの確認・差し戻し]
+    UC24[UC-24 OAuth サインアップ／ログイン]
+    UC25[UC-25 後続予定の自動 TOSS 連鎖]
+    UC26[UC-26 メンバーかんばんでの担当者変更／完了]
 
-    D & M & C --> UC01
+    D & M & C --> UC01 & UC24
     D --> UC21 & UC22 & UC23
     C --> UC23
+    D & M --> UC25
+    D & M & C --> UC26
 ```
+
+> **v1.3 追加**：UC-24（OAuth）／UC-25（後続自動 TOSS）／UC-26（メンバーかんばん DnD）。詳細は §6 各 UC を参照。
 
 ---
 
@@ -597,38 +620,41 @@ flowchart LR
 > 各ユースケースは次の統一フォーマットで記述する。
 > **フェーズ列**は要件ID と連動。Phase 0 の UC は見出しに `✅ Phase 0` を付す。
 
-### UC-01: アカウント作成・ログイン（✅ Phase 0）
+### UC-01: アカウント作成・ログイン（✅ Phase 0、v1.3 改訂：Magic-link 風 + OAuth）
 
 | 項目 | 内容 |
 |---|---|
 | アクター | 全ロール |
 | 事前条件 | なし（招待経由または自主登録） |
 | トリガ | サインアップ／ログインURLにアクセス |
-| メインフロー | ①メール・パスワード入力 ②メール認証 ③ログイン成功 |
-| 例外 | ③-a 認証失敗、③-b 未認証メール、③-c パスワード再発行 |
-| 事後条件 | セッション確立、ダッシュボード／プロジェクト一覧へ遷移 |
-| 関連要件 | FR-AUTH-01, 03, 04, 05、SR-AUTH-01, 03 |
+| メインフロー（メール+パスワード） | ① メール入力（Magic-link 開始）② 認証メール内リンク押下 ③ **詳細入力（full_name / display_name / password）** ④ 自動ログイン完了、ダッシュボードへ |
+| メインフロー（OAuth） | ① 「Google で続ける」or「Microsoft で続ける」押下 ② プロバイダ同意画面 ③ アプリへリダイレクト ④ 初回ログイン時のみ詳細入力（display_name のみ。full_name は OAuth から取得） ⑤ ダッシュボードへ |
+| 例外 | ③-a 認証失敗、③-b 認証メールリンク失効、③-c パスワード再発行、③-d OAuth プロバイダで拒否、**③-e 同一メールが別認証手段で既登録（FR-AUTH-12）→ 本来の認証手段を案内** |
+| 事後条件 | セッション確立、ダッシュボードへ遷移、`audit_logs` に `login` 記録 |
+| 関連要件 | FR-AUTH-01, 03, 04, 05, 10, 11, 12、SR-AUTH-01, 03, 10、UC-24 |
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant U as ユーザー
     participant FE as TRAKON フロント
     participant API as TRAKON API
-    participant Mail as メール配信
-    U->>FE: サインアップ画面を開く
-    U->>FE: メール・パスワード入力
-    FE->>API: サインアップ要求
-    API->>API: 入力検証・ハッシュ化・保存
-    API->>Mail: 認証メール送信
-    API-->>FE: 仮登録完了
-    Mail-->>U: 認証URL
-    U->>FE: 認証URL押下
-    FE->>API: 認証トークン検証
-    API-->>FE: 有効化完了
-    U->>FE: ログイン
-    FE->>API: 認証要求
-    API-->>FE: セッション発行
-    FE-->>U: プロジェクト一覧 or ダッシュボード
+    participant SAuth as Supabase Auth
+    participant Mail as Resend
+    U->>FE: サインアップ画面でメール入力
+    FE->>SAuth: signInWithOtp(email)（Magic-link 送信要求）
+    SAuth->>Mail: 認証メール送信（TRAKON ブランド）
+    Mail-->>U: メール内リンク（token 付き）
+    U->>FE: リンク押下 → /login?token=...&type=signup
+    FE->>SAuth: verifyOtp(token)
+    SAuth-->>FE: セッション確立
+    FE->>FE: 詳細入力画面（full_name / display_name / password）
+    U->>FE: 詳細入力 → 「プロジェクト作成 →」
+    FE->>API: POST /auth/me/complete-signup
+    API->>SAuth: updateUser({ password })
+    API->>API: users INSERT (full_name, display_name, primary_auth_method='password')
+    API-->>FE: 完了
+    FE-->>U: ダッシュボードへ遷移
 ```
 
 ### UC-02: プロジェクト作成（✅ Phase 0）
@@ -974,29 +1000,139 @@ sequenceDiagram
     end
 ```
 
+### UC-24: OAuth サインアップ／ログイン（✅ Phase 0、v1.3 新規）
+
+| 項目 | 内容 |
+|---|---|
+| アクター | 全ロール |
+| 事前条件 | OAuth プロバイダ（Google / Microsoft）にユーザーアカウントを持つこと |
+| トリガ | ログイン／サインアップ画面の「Google で続ける」or「Microsoft で続ける」押下 |
+| メインフロー | ① FE が Supabase Auth `signInWithOAuth` を呼ぶ ② プロバイダで同意 ③ アプリにリダイレクト＋セッション確立 ④ BE が `users` 行を作成 or 取得、`oauth_identities` を INSERT ⑤ 初回は `display_name` 設定画面、それ以外はダッシュボードへ |
+| 例外 | プロバイダで拒否、**同一メールが別認証手段で既登録**（FR-AUTH-12、409 SAME_EMAIL_DIFFERENT_PROVIDER）、`state` 検証失敗 |
+| 事後条件 | セッション確立、`oauth_identities` 行作成、`audit_logs` に `oauth_login`（Phase 1 で正式記録、Phase 0 は最低限 `login`）を記録 |
+| 関連要件 | FR-AUTH-10, 12、SR-AUTH-10、UC-01 |
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as ユーザー
+    participant FE as フロント
+    participant SAuth as Supabase Auth
+    participant Provider as Google/Microsoft
+    participant API as TRAKON API
+    U->>FE: 「Google で続ける」押下
+    FE->>SAuth: signInWithOAuth({ provider: 'google' })
+    SAuth->>Provider: PKCE + state でリダイレクト
+    U->>Provider: 同意
+    Provider->>SAuth: code + state
+    SAuth->>SAuth: state 検証・トークン交換
+    SAuth-->>FE: セッション確立
+    FE->>API: POST /auth/me/sync
+    alt 同一メールが別 provider で既登録
+        API-->>FE: 409 SAME_EMAIL_DIFFERENT_PROVIDER
+        FE-->>U: 「このメールは password 認証で登録済み」
+    else 新規 or 同 provider
+        API->>API: users 行 INSERT、oauth_identities INSERT
+        API-->>FE: ユーザー情報
+        FE-->>U: ダッシュボードへ
+    end
+```
+
+### UC-25: 後続予定の自動 TOSS 連鎖（✅ Phase 0、v1.3 新規）
+
+| 項目 | 内容 |
+|---|---|
+| アクター | 先行予定の Ball Holder（人間）／システム（自動 TOSS） |
+| 事前条件 | 先行予定（A）に `successor_plan_id` が設定済み。後続予定（B）が `active` 状態 |
+| トリガ | 先行予定 A を完了する操作（SC-08 ボール詳細モーダルから「完了する」） |
+| メインフロー | ① ユーザーが A を `complete` → ② BE が同一トランザクションで A.status='completed'、ball_events INSERT(event_type='completed', source='human') ③ A の successor_plan_id が指す B を SELECT FOR UPDATE ④ B.status='active' なら ball_events INSERT(event_type='tossed', source='auto_chain', actor_user_id=NULL) ⑤ Ball Holder = B.to_member に切り替わる ⑥ 監査ログに `auto_toss` 記録（Phase 1） |
+| 例外 | B が `completed`/`canceled` → スキップ。循環参照（A→…→A）→ INSERT 時にアプリ層で拒否（409） |
+| 事後条件 | A.status='completed'、B にも tossed イベントが追加され、Ball Holder が B.to_member |
+| 関連要件 | FR-SCH-17、FR-BALL-13、SC-07、SC-08 |
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as ユーザー
+    participant API as TRAKON API
+    participant DB as Postgres
+    U->>API: POST /plans/:planA/complete
+    API->>DB: BEGIN TRANSACTION
+    API->>DB: plans[A].status='completed'
+    API->>DB: ball_events INSERT(plan=A, type='completed', source='human', actor=U)
+    API->>DB: SELECT plans[A].successor_plan_id (=B)
+    alt B.status='active'
+        API->>DB: ball_events INSERT(plan=B, type='tossed', source='auto_chain', actor=NULL)
+        Note over DB: Ball Holder = B.to_member に切り替わる（導出ロジック）
+    else B が completed/canceled
+        Note over API: 何もしない（連鎖スキップ）
+    end
+    API->>DB: audit_logs INSERT (action='complete', actor=U)
+    API->>DB: COMMIT
+    API-->>U: 完了レスポンス（B の Ball Holder も含む）
+```
+
+### UC-26: メンバーかんばんでの担当者変更／完了（✅ Phase 0、v1.3 新規）
+
+| 項目 | 内容 |
+|---|---|
+| アクター | プロジェクト参加者（ディレクター／メンバー／クライアント） |
+| 事前条件 | プロジェクト参加、SC-17 メンバーかんばん画面を開いている |
+| トリガ | カンバン上でカード（予定）をドラッグ＆ドロップ |
+| メインフロー | **メンバー列間移動**：別メンバーへドロップ → `POST /plans/:planId/toss { toMemberId }`（既存 TOSS API を呼ぶ） / **状態列間移動**（準備中→TOSS済 など）：対応するドメイン API を呼ぶ（toss / complete / cancel-toss） / **両方同時**：2 つの API を順次呼ぶ |
+| 例外 | 認可エラー（Ball Holder でない、ロール不足）、状態遷移不可（既に completed） |
+| 事後条件 | 該当予定のステータスと Ball Holder が更新され、楽観更新でカードが新位置に表示される。サーバ確定後に最終状態へ反映 |
+| 関連要件 | FR-BALL-02, 03, 08, 11、SC-17、SR-AUTHZ-01 |
+
+> **重要**：カンバン UI は専用 API を持たず、**全てのドメイン操作を既存の TOSS / 完了 / 取消エンドポイントに集約**する。認可ガード・状態遷移ガード・監査ログは既存の章3 §3.3 / 章5 §5.4 のミドルウェアに乗る（基本設計書 04-frontend §4.10 議論ポイント参照）。
+
 ---
 
 ## 7. 画面ごとの機能要件・画面項目要件
 
 各画面について、アクター／目的／機能要件（FR-ID紐付け）／画面項目／状態・例外／権限制御を定義する。
 
-### SC-01: サインアップ／ログイン（✅ Phase 0）
+### SC-01: サインアップ／ログイン（✅ Phase 0、v1.3 改訂：Magic-link + OAuth）
 
 - **アクター**：全ロール（未認証状態）
-- **目的**：アカウント作成・ログイン・パスワード再発行
-- **主機能**：FR-AUTH-01, 03, 04, 05
-- **画面項目**：
+- **目的**：アカウント作成・ログイン・パスワード再発行・OAuth サインイン
+- **主機能**：FR-AUTH-01, 03, 04, 05, 10, 11, 12
+- **画面状態（7 ステップ）**：`login` / `signup` / `email-sent` / `create-account` / `password-reset-request` / `password-reset-email-sent` / `password-reset` / `password-reset-complete`
+
+**ログイン画面（`login`）の項目**：
 
 | 項目 | 型 | 必須 | バリデーション |
 |---|---|---|---|
-| メールアドレス | Email | ○ | 形式検証、重複登録不可 |
-| パスワード | Password | ○ | 長さ8以上／英数記号／既知流出照合（Phase 1） |
-| パスワード再入力（サインアップ時） | Password | ○ | 上記と一致 |
-| 利用規約・プライバシー同意 | Check | ○ | — |
+| メールアドレス | Email | ○ | 形式検証 |
+| パスワード | Password | ○ | — |
+| ログイン状態を保存する | Check | × | — |
+| 「Google で続ける」ボタン | Button | — | OAuth 開始（FR-AUTH-10） |
+| 「Microsoft で続ける」ボタン | Button | — | OAuth 開始（FR-AUTH-10） |
+| パスワード再発行リンク | Link | — | `password-reset-request` へ遷移 |
+| 新規登録リンク | Link | — | `signup` へ遷移 |
 
-- **状態**：未入力／入力中／送信中／成功／エラー（認証失敗・ロック）
+**サインアップ画面（`signup`、Magic-link 開始）の項目**：
+
+| 項目 | 型 | 必須 | バリデーション |
+|---|---|---|---|
+| メールアドレス | Email | ○ | 形式検証 |
+| 「Google で続ける」「Microsoft で続ける」 | Button | — | OAuth 経由のサインアップ |
+| 利用規約・プライバシー同意（文言で明示） | Text | — | 「続けることで〜に同意したものとみなされます」 |
+
+**詳細入力画面（`create-account`、メール認証リンク押下後）の項目**：
+
+| 項目 | 型 | 必須 | バリデーション |
+|---|---|---|---|
+| メールアドレス | Email（読取専用） | ○ | 認証済みメール |
+| お名前（full_name） | Text | ○ | 1〜100文字、本名／請求書類用（FR-AUTH-11） |
+| ユーザー名（display_name） | Text | ○ | 1〜50文字、表示名（FR-AUTH-11） |
+| パスワード | Password | ○ | 長さ8以上／英数記号／既知流出照合（Phase 1） |
+| パスワード（確認） | Password | ○ | 上記と一致 |
+
+- **状態**：未入力／入力中／送信中／成功／エラー（認証失敗・ロック・**SAME_EMAIL_DIFFERENT_PROVIDER**）
 - **権限**：未認証のみアクセス可能
-- **例外／エラー表示**：認証失敗回数制限、メール未認証時の再送導線
+- **例外／エラー表示**：認証失敗回数制限、メール再送導線（60秒カウントダウン）、同一メール別認証手段の案内
+- **送信成功後**：`/dashboard` へ自動遷移
 
 ### SC-02: 招待受諾（✅ Phase 0）
 
@@ -1083,6 +1219,8 @@ sequenceDiagram
 | TOSS予定 | TO（同上） | ○ |
 | TOSS予定 | 予定日 | ○ |
 | TOSS予定 | 期日 | 任 |
+| TOSS予定 | **カテゴリ**（wireframe/design/coding/review/meeting/other） | ○（FR-SCH-18） |
+| TOSS予定 | **次の予定（successor_plan_id）** | 任（FR-SCH-17、選択肢は同制作物の他予定） |
 | TOSS予定 | メモ | 任 |
 | 共同予定 | 予定名 | ○ |
 | 共同予定 | 主担当者（1名） | ○ |
@@ -1119,31 +1257,43 @@ sequenceDiagram
 - **履歴表示**：TOSS／取消／差し戻し／再TOSS／完了の時系列ログ
 - **コメント／添付**（Phase 1）：同モーダル内タブで表示
 
-### SC-09: ダッシュボード（3カラム）（Phase 1）
+### SC-09: ダッシュボード（✅ Phase 0、v1.3 改訂：階層ビュー）
 
-- **アクター**：全ロール
-- **主機能**：FR-DASH-01〜09
+- **アクター**：全ロール（ログイン直後の起点画面）
+- **目的**：今日のタスク状況をプロジェクト・メンバー単位で俯瞰する
+- **主機能**：FR-DASH-01〜09（v1.3 改訂版）
+- **URL**：`/dashboard`
 - **画面構成**：
 
 ```
-┌──────────────────────────────────────────┐
-│ ▼ サマリー文言（例：「いくつかの予定が遅延しています」）  │
-├────────────┬────────────┬────────────┤
-│ 平常        │ 要確認      │ 遅延        │
-│ ─────────  │ ─────────  │ ─────────  │
-│ [カード]    │ [カード]    │ [カード]    │
-│  PRJ名     │  PRJ名     │  PRJ名     │
-│  予定名     │  予定名     │  予定名     │
-│  期日      │  期日      │  期日      │
-│  Ball Holder│  Ball Holder│  Ball Holder│
-│ ...        │ ...        │ ...        │
-└────────────┴────────────┴────────────┘
+┌────────────────────────────────────────────────┐
+│ ダッシュボード（今日 yyyy/m/d）                  │
+├────────────┬────────────────────────────────┤
+│ 今日のタスク │ 期限超過                       │
+│   42        │   3                             │
+├────────────┴────────────────────────────────┤
+│ 🔵 ECサイトリニューアル (12件)                  │
+│   👤 田中 太郎 (3件)                           │
+│     [予定カード wireframe] [予定カード design]  │
+│   👤 佐藤 花子 (5件)                           │
+│     [予定カード design]    [予定カード review] │
+│ 🟢 コーポレートサイト制作 (5件)                 │
+│   ...                                          │
+└────────────────────────────────────────────────┘
 ```
 
-- **カード項目**：プロジェクト名／予定名／期日／Ball Holder（所属名＋表示名）
-- **並び順**：カラム内は監視基準日が古い順→last_action_at が古い順→id 昇順
-- **遷移**：カード押下→各制作物画面（該当位置スクロール・ハイライト）
-- **空状態**：「すべての予定は平常で進行しています。」
+- **サマリーカード**（2枚）：今日のタスク総数／期限超過数（赤系強調）
+- **本体**：プロジェクト → メンバー → 予定カード の3階層
+  - 対象：`status='active' AND startDate <= today <= endDate`（JST 暦日基準）
+  - プロジェクトはブランドカラードット付きで識別
+  - メンバーはイニシャルアバター付き
+  - 予定カードの色分けはカテゴリ（FR-SCH-18）に応じる
+- **カード項目**：予定名／制作物名／期間（startDate〜endDate）
+- **期限超過カード**：背景赤系、文字赤、期間が `endDate < today` のもの
+- **遷移**：カード押下 → 各制作物画面（SC-06）へ、ナビゲーション state `scrollToBallId` でハイライト
+- **空状態**：「今日のタスクはありません」
+- **権限**：認証済みの全ロール
+- **進行判定フィルター**（Phase 1）：3カラム（平常／要確認／遅延）への切替タブを追加可能（FR-DASH-08）
 
 ### SC-10: プロジェクト編集（✅ Phase 0：基本、Phase 1：終了・アーカイブ）
 
@@ -1156,11 +1306,36 @@ sequenceDiagram
   - 「削除」（Archived時、Phase 1、確認必須）
 - **警告**：終了日変更で範囲外ボール、終了操作時の未完了ボール件数
 
-### SC-11: 参加者管理（✅ Phase 0：基本、Phase 1：詳細）
+### SC-11: 参加者管理（✅ Phase 0：基本、Phase 1：詳細、v1.3：SC-17 と URL 階層を共有しタブ分離）
 
 - **アクター**：ディレクター
+- **目的**：プロジェクト参加者の追加・編集・削除
 - **主機能**：FR-AUTH-07, 08, 09
-- **画面項目**：名前／所属名／メール／種別／役割（Phase 1）／sort_order（カレンダー列順）／is_active／削除（論理）
+- **URL**：`/projects/:projectId/members?tab=manage`（または `/manage` サブパス）。**SC-17 メンバーかんばんと同じ親 URL を共有**し、タブで切替
+- **画面項目**：名前／所属名／メール／種別（client/production）／役割（Phase 1）／sort_order（カレンダー列順）／is_active（Phase 1）／削除（Phase 1：論理削除、Phase 0：物理削除＋アクティブボール存在時 409）
+
+### SC-17: メンバーかんばん（✅ Phase 0、v1.3 新規）
+
+- **アクター**：プロジェクト参加者（ディレクター／メンバー／クライアント、自分が見える範囲のみ）
+- **目的**：プロジェクト参加メンバーごとに、担当している予定の進行状況をかんばん形式で俯瞰／DnD 操作で TOSS・完了を実行
+- **主機能**：FR-BALL-02, 03, 08, 11、UC-26
+- **URL**：`/projects/:projectId/members`（既定タブ）
+- **画面構成**：
+  - 横軸：プロジェクト参加メンバー列（client / production グルーピング、所属名見出し）
+  - 縦軸：状態カラム（準備中（=Ready）／TOSS済（=Tossed）／完了（=Completed））
+  - カード：予定タイトル、制作物名、カテゴリ色分け、期限表示
+- **DnD 操作のドメインマッピング**：
+
+| DnD 操作 | 呼び出される API | ball_events |
+|---|---|---|
+| 別メンバー列へドラッグ（同状態） | `POST .../plans/:planId/toss { toMemberId }` | event_type='tossed', source='human' |
+| 別状態列へドラッグ（同メンバー） | `POST .../plans/:planId/complete` 等 | 状態に応じたイベント |
+| 両方同時 | 2 API を順次 | — |
+
+- **権限**：プロジェクト参加者のみ。各 DnD 操作は背後で既存 TOSS / 完了 API のガード（章3 §3.3 / 章5 §5.4）を通る
+- **整合性**：カンバン UI は専用 API を持たず、すべて既存ドメイン API に集約（UC-26）
+- **空状態**：「このプロジェクトには予定がまだありません」 → SC-06 への導線
+- **参加者管理画面（SC-11）への切替**：上部タブ「メンバー」「管理」
 
 ### SC-12: アーカイブ一覧（Phase 1）
 
@@ -1215,6 +1390,7 @@ sequenceDiagram
 ```mermaid
 erDiagram
     users ||--o{ project_members : "has"
+    users ||--o{ oauth_identities : "links"
     organizations ||--o{ users : "belongs"
     organizations ||--o{ projects : "owns"
     organizations ||--|| organization_settings : "configures"
@@ -1225,6 +1401,7 @@ erDiagram
     plans ||--o{ ball_events : "logs"
     plans ||--o{ comments : "has"
     plans ||--o{ attachments : "has"
+    plans }o--|| plans : "successor_plan_id (v1.3)"
     users ||--o{ notifications : "receives"
     users ||--o{ audit_logs : "performs"
     plans }o--|| project_members : "from_member / to_member / owner_member"
@@ -1241,20 +1418,39 @@ erDiagram
 
 #### users（認証ユーザー）
 
-> **コメント**：システムに永続参加するアカウントの認証情報を管理する。プロジェクトの永続参加・編集を行う全ロール（ディレクター／メンバー／クライアント）が必ず1行を持つ。非会員URL閲覧者（FR-SHARE）は本テーブルに行を持たない。
-> **司る機能**：UC-01 アカウント作成・ログイン／FR-AUTH-01〜06／SR-AUTH-01〜07
-> **関連**：`project_members.user_id`, `audit_logs.actor_user_id`, `notifications.user_id`
+> **コメント**：システムに永続参加するアカウントの認証情報を管理する。プロジェクトの永続参加・編集を行う全ロール（ディレクター／メンバー／クライアント）が必ず1行を持つ。非会員URL閲覧者（FR-SHARE）は本テーブルに行を持たない。**v1.3 で `full_name`（本名）と `display_name`（表示名）を2列に分離、`primary_auth_method` を追加**。
+> **司る機能**：UC-01 アカウント作成・ログイン／UC-24 OAuth ログイン／FR-AUTH-01〜06, 10〜12／SR-AUTH-01〜07, 10
+> **関連**：`project_members.user_id`, `oauth_identities.user_id`, `audit_logs.actor_user_id`, `notifications.user_id`
 
 | カラム | 説明 |
 |---|---|
 | id | PK |
 | email | ログインID／一意 |
-| password_hash | パスワード（ハッシュ化） |
-| display_name | 表示名 |
+| password_hash | パスワード（ハッシュ化）。OAuth ユーザーは NULL |
+| **full_name** | 本名（招待・請求書類用、v1.3 追加、FR-AUTH-11） |
+| **display_name** | 表示名・ハンドル（画面表示用、v1.3 で本名と分離） |
+| **primary_auth_method** | 'password' / 'google' / 'microsoft'（CHECK、同一メール1認証制約／v1.3 追加、FR-AUTH-12） |
 | email_verified_at | メール認証完了日時 |
 | mfa_enabled / mfa_secret | 多要素認証（Phase 2、SR-AUTH-06） |
 | organization_id | FK（Phase 2、組織所属） |
 | created_at / updated_at / deleted_at | 監査・論理削除 |
+
+#### oauth_identities（OAuth 連携／✅ Phase 0、v1.3 新規）
+
+> **コメント**：Supabase Auth が管理する `auth.identities` の補完情報を、アプリ DB 側にミラーする。1 ユーザー = 1 identity が Phase 0 制約（FR-AUTH-12）。Phase 1+ で複数プロバイダ同時連携 UI を提供する場合はこのテーブルを多対多に拡張する。
+> **司る機能**：FR-AUTH-10, 12／UC-24 OAuth ログイン／SR-AUTH-10
+> **関連**：`users.id`
+
+| カラム | 説明 |
+|---|---|
+| id | PK |
+| user_id | FK → users.id |
+| provider | 'google' / 'microsoft'（CHECK） |
+| provider_user_id | OAuth プロバイダの subject（一意） |
+| email | OAuth から取得したメール（users.email と一致） |
+| created_at / updated_at | 監査 |
+
+- UNIQUE：(provider, provider_user_id)、(user_id, provider)
 
 #### organizations（組織・テナント／Phase 2）
 
@@ -1355,21 +1551,25 @@ erDiagram
 | participants | 参加者リスト（共同・将来用、JSON または別テーブル） |
 | location_or_url | 場所／URL（共同予定用） |
 | status | active / completed / canceled |
+| **category** | wireframe / design / coding / review / meeting / other（CHECK、NOT NULL、v1.3 追加、FR-SCH-18） |
+| **successor_plan_id** | 後続予定の FK（self、NULL 可、UNIQUE、v1.3 追加、FR-SCH-17）。Phase 0 では同一プロジェクト内に限定 |
 | memo / started_at / completed_at | 補助 |
 | deleted_at | 論理削除（Phase 1 以降。Phase 0 MVP は物理削除：FR-BALL-12） |
 
 #### ball_events（ボール責任移動履歴）
 
-> **コメント**：「ボール」（責任の所在）の移動・操作を時系列で **追記専用** に記録する履歴テーブル。物理削除しない。差し戻し（Returned）／TOSS取消（Canceled）／再TOSS／完了などの遷移を全て記録し、現在の Ball Holder は `plans` ＋本テーブルから導出する。
-> **司る機能**：FR-BALL-04〜10／UC-08 TOSS実行／UC-09 TOSS取消／UC-10 差し戻し／UC-11 再TOSS／UC-12 予定完了
-> **関連**：`plans.id`, `project_members.id`
+> **コメント**：「ボール」（責任の所在）の移動・操作を時系列で **追記専用** に記録する履歴テーブル。物理削除しない。差し戻し（Returned）／TOSS取消（Canceled）／再TOSS／完了などの遷移を全て記録し、現在の Ball Holder は `plans` ＋本テーブルから導出する。**v1.3 で `source` 列を追加（human / auto_chain）、`actor_user_id` を NULL 許容化**（system actor 対応、FR-BALL-13）。
+> **司る機能**：FR-BALL-04〜10, 13／UC-08 TOSS実行／UC-09 TOSS取消／UC-10 差し戻し／UC-11 再TOSS／UC-12 予定完了／UC-25 後続自動TOSS連鎖
+> **関連**：`plans.id`, `project_members.id`, `users.id`（actor、NULL 可）
 
 | カラム | 説明 |
 |---|---|
 | id | PK |
 | plan_id | FK（旧 `schedule_id`） |
 | event_type | tossed / canceled / returned / retossed / completed |
-| actor_member_id | 実行者（FK：project_members） |
+| actor_member_id | 実行者（FK：project_members、自動連鎖時は NULL） |
+| **actor_user_id** | NULL 可（system actor のため、v1.3 追加） |
+| **source** | 'human' / 'auto_chain'（CHECK、NOT NULL、v1.3 追加、FR-BALL-13）|
 | occurred_at | 実行日時 |
 | note | メモ（差し戻し理由など） |
 
@@ -1709,47 +1909,56 @@ gantt
 
 > 目安スケジュール。実際の着手日・期間は TBD。
 
-### 10.2. Phase 0：MVP ✅ **本PRDの着手スコープ**
+### 10.2. Phase 0：MVP ✅ **本PRDの着手スコープ**（v1.3 拡充）
 
-- **目的**：「縦型スケジュール上でボールの受け渡しを可視化できる」ことの最速検証
-- **予算・期間**：50万円（税込）／2〜3週間（MVP仕様書 v1.0 §10）
+- **目的**：「縦型スケジュール上でボールの受け渡しを可視化できる」ことの最速検証 + プロトタイプ反映機能の検証
+- **予算・期間**：50万円（税込）／2〜3週間（MVP仕様書 v1.0 §10） + プロトタイプ反映分（v1.3 追加分）の上振れは別途見積
 - **対象ユーザー**：制作ディレクター（メインテスター）、付随してクライアント・制作メンバー
 - **提供機能（要件ID）**：
-  - 認証：FR-AUTH-01, 02, 03, 04, 05, 07, 08（基本型のみ）
+  - 認証：FR-AUTH-01, 02, 03, 04, 05, 07, 08、**10（OAuth）**、**11（詳細登録項目）**、**12（同一メール1認証）**
   - プロジェクト：FR-PRJ-01, 02, 03, 09
   - 制作物：FR-ITEM-01, 03, 05
-  - スケジュール：FR-SCH-01, 02, 03, 04, 05, 06, 08, 09, 11
-  - ボール：FR-BALL-01, 02, 03, 08, 12
-  - 共有・アクセス制御：FR-SHARE-01, 02, 03, 04, 05, 06（v1.3 で Phase 1 → Phase 0 へ前倒し。組織レベル On/OFF＝FR-SHARE-07 は Phase 2 維持）
-  - セキュリティ：SR-AUTH-01, 02, 03, 04, **08**、SR-AUTHZ-01, 02、SR-DATA-01, 02、SR-AUDIT-01（最低限）、SR-PRIVACY-01〜03
-- **対象画面**：SC-01, 02, 03, 04, 06, 07（TOSS相当のみ）, 08（TOSS実行・完了のみ）, 10（基本編集）, 11（基本）, **16（非会員URL 発行・管理）**
-- **対象ユースケース**：UC-01, 02, 03, 04（登録・編集）, 05（TOSS相当）, 08（TOSS実行）, 12（予定完了）, 15（制作物画面での俯瞰）, 16（クライアント確認の基本動線）, **23（非会員URLでの確認・差し戻し）**
+  - スケジュール：FR-SCH-01, 02, 03, 04, 05, 06, 08, 09, 11、**17（後続紐付け）**、**18（カテゴリ必須）**
+  - ボール：FR-BALL-01, 02, 03, 08, 12、**13（後続自動 TOSS）**
+  - **ダッシュボード：FR-DASH-01〜07, 09（v1.3 で Phase 0 へ繰り上げ、階層ビュー）**
+  - 共有・アクセス制御：**FR-SHARE-01, 02, 03, 04, 05, 06**（v1.3 で Phase 1 → Phase 0 へ前倒し。組織レベル On/OFF＝FR-SHARE-07 は Phase 2 維持）
+  - セキュリティ：SR-AUTH-01, 02, 03, 04, **08**（非会員URL）、**10（OAuth PKCE）**、SR-AUTHZ-01, 02、SR-DATA-01, 02、SR-AUDIT-01（最低限）、SR-PRIVACY-01〜03
+- **対象画面**：SC-01（**Magic-link + OAuth 拡充**）, 02, 03, 04, 06, 07（TOSS相当のみ + **カテゴリ + successor**）, 08（TOSS実行・完了のみ）, **09（階層ビュー、新規）**, 10（基本編集）, 11（タブ化）, **16（非会員URL 発行・管理）**, **17（メンバーかんばん、新規）**
+- **対象ユースケース**：UC-01（改訂）, 02, 03, 04（登録・編集）, 05（TOSS相当）, 08（TOSS実行）, 12（予定完了）, 15（制作物画面での俯瞰）, 16（クライアント確認の基本動線）, **23（非会員URLでの確認・差し戻し）**、**UC-24（OAuth）**、**UC-25（後続自動TOSS）**、**UC-26（カンバン操作）**
 - **除外事項（Phase 1 以降）**：
   - 予定種別（共同予定・単独予定）
   - 差し戻し／TOSS取消／再TOSS
-  - ダッシュボード3カラム
+  - ダッシュボード「進行判定フィルター」（3カラム平常／要確認／遅延、FR-DASH-08）
   - プロジェクトTOP・代表ボール表示
   - 通知（メール）
   - コメント／ファイル添付
   - PDF出力
   - プロジェクト終了・アーカイブ・削除
   - MFA・組織・権限・プラン
-- **成功基準**（MVP仕様書 §8 受け入れ条件に本PRDのセキュリティ条件を追加）：
+  - 複数チェーン（A→B→C）の連鎖（v1.3：Phase 0 は1段のみ）
+  - 異プロジェクト間 successor
+- **成功基準**（v1.3 拡充）：
   1. ディレクターがプロジェクトを1件作成できる
   2. 期間に応じた縦の日付一覧が表示される
   3. 参加者が所属名とともに横に並んで表示される
-  4. 任意の日付にボールを追加できる／FROM・TO を設定できる
+  4. 任意の日付にボールを追加できる／FROM・TO・**カテゴリ・後続予定**を設定できる
   5. ボールが該当担当者列に表示される
   6. 最新のボールから Ball Holder がヘッダー表示される
   7. **Phase 0 では永続参加の全ユーザー（ディレクター／メンバー／クライアント）に認証を必須とし、未認証アクセスは §9.2 統制下の非会員URL共有経路に限定する**（SR-AUTH-01、FR-SHARE-01〜06、SR-AUTH-08）
   8. **通信は TLS、保管は暗号化、主要操作は監査ログに記録される**（SR-DATA-01, 02、SR-AUDIT-01）
   9. **クライアントは、招待ログイン経路と非会員URL経路のいずれでも確認・差し戻しを完結できる**（FR-SHARE-01〜06、UC-23）
   10. **全ての非会員URLアクセスが監査ログから時系列で再現できる**（FR-SHARE-04、SR-AUDIT-01）
+  11. **Google / Microsoft でサインアップ・ログインできる**（FR-AUTH-10、UC-24）
+  12. **先行予定の完了で、紐付けた後続予定が自動 TOSS される**（FR-BALL-13、UC-25）
+  13. **ダッシュボードに「プロジェクト×メンバー×今日」階層ビューが表示される**（FR-DASH-03、SC-09）
+  14. **メンバーかんばん（SC-17）でカードを別メンバーへドラッグすると TOSS が走る**（UC-26）
 - **重要な設計判断**：
   - MVP版のボール削除は即時物理削除（§6.3）
   - Ball Holder 判定は「最新ボールの to_member」で簡易実装（MVP §6 後フェーズで正規化）
   - 共同予定・単独予定・予定種別選択は未実装。Phase 0 の UI は「TOSS相当」のみに簡素化
   - **非会員URL共有は組織レベル統制を持たず**（Phase 0 では `organizations` / `organization_settings` 未導入）、URL 単位の安全装置（短時間有効期限・個別失効・監査ログ）のみで運用する。組織レベル On/OFF（FR-ORG-04, 05、FR-SHARE-07、SR-AUTH-09）は Phase 2 で追加導入する
+  - **後続自動 TOSS は同一トランザクション内で実行、失敗時は全巻き戻し**（FR-BALL-13）
+  - **OAuth と password 認証は同一メールで併用不可**（FR-AUTH-12、ユーザー体験のシンプル化）
   - **セキュリティは短期実装でも妥協しない**（上記 7., 8., 9., 10.）
 
 ### 10.3. Phase 1：ディレクターツール（正規仕様 v1.x 本格適用）


### PR DESCRIPTION
## Summary

Figma Make プロトタイプ（`prototype/` 配下）の調査結果を踏まえ、**4 つの追加機能 + 派生 3 要素**を PRD（v1.2 → v1.3）と基本設計書全 6 章（v1.0 → v1.1）へ反映する大規模改訂です。

### 反映した追加機能

1. **OAuth (Google / Microsoft)** — Phase 0 から提供（FR-AUTH-10, SR-AUTH-10, UC-24）
2. **新規登録項目の拡充** — `users.full_name` / `users.display_name` 2 列分離、Magic-link 風サインアップ（FR-AUTH-11, UC-01 改訂）
3. **後続紐付けによる自動 TOSS 連鎖** — `plans.successor_plan_id` (1対1)、先行完了で system actor 自動 TOSS（FR-SCH-17, FR-BALL-13, UC-25）
4. **ダッシュボード** — プロトタイプ階層ビュー（プロジェクト × メンバー × 今日）を採用、**Phase 0 へ繰り上げ**（FR-DASH-01〜10 改訂、SC-09 改訂）
5. **カテゴリ必須化** — `plans.category`（wireframe/design/coding/review/meeting/other、CHECK 6 値、FR-SCH-18）
6. **メンバーかんばん** — SC-17 新規（DnD = TOSS、UC-26）
7. **oauth_identities** — 新規テーブル（1 user 1 identity 制約、FR-AUTH-12）

### 主要な技術判断

- 同一メール 1 認証手段限定（password / google / microsoft のいずれか、FR-AUTH-12）
- 自動 TOSS は同一トランザクション内連鎖（`ball_events.source='auto_chain'`、`actor_user_id NULL`）。Phase 0 は単段、長い循環はアプリ層で検出
- カンバン DnD は専用 API を作らず、既存 TOSS / 完了 API に集約（UC-26）
- OAuth は PKCE + state 必須、state は Phase 0 メモリ Map → 商用前に KV 化

### 変更ファイル（7）

| ファイル | バージョン |
|---|---|
| `docs/prd/trakon-prd.md` | v1.2 → **v1.3** |
| `docs/design/00-index.md` | 用語整理表追加 |
| `docs/design/02-database.md` | v1.0 → **v1.1** |
| `docs/design/03-api.md` | v1.0.1 → **v1.1** |
| `docs/design/04-frontend.md` | v1.0 → **v1.1** |
| `docs/design/05-security.md` | v1.0 → **v1.1** |
| `docs/design/06-infrastructure.md` | v1.0 → **v1.1** |

### 留意事項：main との競合可能性

このブランチは `28e8ecb`（v1.0 初版コミット）から分岐しています。一方 `main` には別 PR で「非会員URL共有を Phase 1 → Phase 0 へ前倒し」（`1aee604`）が merge 済みです。両者とも `docs/prd/trakon-prd.md` の §4.1, §10.2 など同節を編集している可能性があり、**マージ時にコンフリクト調整が必要**です。

両方の意図を残す方針：
- 非会員URL 前倒し（main 側） + プロトタイプ反映（本 PR 側）を併存させ、改訂履歴を時系列で v1.3 にまとめる
- 必要であれば本 PR を main で rebase してコンフリクト解決の上で再 push

## Test plan

- [ ] `docs/prd/trakon-prd.md` 改訂履歴 v1.3 の文言レビュー
- [ ] PRD §4.1.1 FR-AUTH-10〜12 の妥当性確認（OAuth フロー、同一メール制約）
- [ ] PRD §4.1.4 FR-SCH-17, 18（後続紐付け、カテゴリ）の文言レビュー
- [ ] PRD §4.1.7 FR-DASH 改訂版（階層ビュー、Phase 0 繰り上げ）の妥当性確認
- [ ] PRD §6 UC-24, 25, 26 の新規シーケンス図確認
- [ ] PRD §7 SC-01（Magic-link + OAuth）、SC-09（階層ビュー）、SC-17（メンバーかんばん）の画面項目妥当性
- [ ] PRD §8.2 `users` / `oauth_identities` / `plans` / `ball_events` の列定義確認
- [ ] PRD §9.3 SR-AUTH-10 の追加内容確認
- [ ] PRD §10.2 Phase 0 成功基準（9.〜12. 追加分）の妥当性
- [ ] `docs/design/02-database.md` `users.full_name` / `display_name` の用途分離が妥当か
- [ ] `docs/design/02-database.md` `ck_be_actor_consistency`（human ⇒ actor 必須、auto_chain ⇒ actor NULL）の妥当性
- [ ] `docs/design/03-api.md` `GET /users/me/dashboard` のレスポンス構造の妥当性
- [ ] `docs/design/03-api.md` `POST .../complete` の自動 TOSS 連鎖レスポンス（`autoTossed`）の妥当性
- [ ] `docs/design/04-frontend.md` SC-17 メンバーかんばんの DnD ドメインマッピングの妥当性
- [ ] `docs/design/05-security.md` §5.3.9 OAuth フロー（同一メール 1 認証制約の 409 ハンドリング）の妥当性
- [ ] `docs/design/06-infrastructure.md` Google / Microsoft Provider 設定手順の正確性
- [ ] main との conflict 調整方針の合意（rebase vs 後追い merge）

## 関連

- プロトタイプ：`prototype/` 配下（Vite + React 18、本 PR では未コミット）
- 検討経緯：`/Users/masakazukawazu/.claude/plans/playful-sniffing-summit.md` のプランファイル

🤖 Generated with [Claude Code](https://claude.com/claude-code)