### PR TITLE
Sub-Phase 0.2 PR B: 参加者管理 / 招待受諾 / Resend ダミー

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@hono/node-server": "^1.13.7",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",
+    "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-separator": "^1.1.0",

--- a/apps/web/server/app.ts
+++ b/apps/web/server/app.ts
@@ -5,6 +5,7 @@ import { secureHeaders } from 'hono/secure-headers';
 import { errorMiddleware, notFoundHandler } from './middleware/error.js';
 import { authRoute } from './routes/v1/auth.js';
 import { healthRoute } from './routes/v1/healthz.js';
+import { invitationsRoute } from './routes/v1/invitations.js';
 import { projectsRoute } from './routes/v1/projects.js';
 
 export function createApp() {
@@ -16,6 +17,7 @@ export function createApp() {
   app.route('/api/v1', healthRoute);
   app.route('/api/v1/auth', authRoute);
   app.route('/api/v1/projects', projectsRoute);
+  app.route('/api/v1/invitations', invitationsRoute);
 
   app.notFound(notFoundHandler);
   app.onError(errorMiddleware);

--- a/apps/web/server/lib/env.ts
+++ b/apps/web/server/lib/env.ts
@@ -8,6 +8,8 @@ const envSchema = z.object({
   DATABASE_URL: z.string().url().optional(),
   DIRECT_URL: z.string().url().optional(),
   SERVER_PORT: z.coerce.number().default(3001),
+  /** 招待 URL の組み立てに使用 (FE オリジン) */
+  PUBLIC_APP_URL: z.string().url().default('http://localhost:5173'),
 });
 
 export type ServerEnv = z.infer<typeof envSchema>;

--- a/apps/web/server/lib/mailer.ts
+++ b/apps/web/server/lib/mailer.ts
@@ -1,0 +1,50 @@
+/**
+ * Mailer インターフェース。Sub-Phase 0.6 で Resend 本実装に差し替える。
+ * 詳細: docs/design/06-infrastructure.md §6.5
+ */
+
+export type InvitationEmail = {
+  to: string;
+  projectName: string;
+  inviterName: string;
+  acceptUrl: string;
+  expiresAt: Date;
+};
+
+export type Mailer = {
+  sendInvitation(input: InvitationEmail): Promise<void>;
+};
+
+/**
+ * Sub-Phase 0.2: 開発用ダミー実装。
+ * - dev / test: console.log で送信内容を出力するのみ
+ * - prod: 例外を投げて事故を防ぐ
+ * Sub-Phase 0.6 で Resend を本実装する際に `createResendMailer()` を追加し、
+ * APP_ENV に応じてファクトリで切り替える。
+ */
+export function createDummyMailer(): Mailer {
+  return {
+    async sendInvitation(input) {
+      if (process.env.NODE_ENV === 'production') {
+        throw new Error(
+          '[trakon] Dummy mailer is not allowed in production. Wire up Resend in Sub-Phase 0.6.',
+        );
+      }
+      // eslint-disable-next-line no-console
+      console.log(
+        `[trakon][mailer/dummy] invitation -> ${input.to} | project="${input.projectName}" inviter="${input.inviterName}" url=${input.acceptUrl} expires=${input.expiresAt.toISOString()}`,
+      );
+    },
+  };
+}
+
+let cached: Mailer | undefined;
+export function getMailer(): Mailer {
+  if (!cached) cached = createDummyMailer();
+  return cached;
+}
+
+/** テスト用: モック差し込みポイント */
+export function __setMailerForTest(m: Mailer): void {
+  cached = m;
+}

--- a/apps/web/server/lib/tokens.test.ts
+++ b/apps/web/server/lib/tokens.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultInvitationExpiresAt,
+  generateInvitationToken,
+  hashToken,
+} from './tokens.js';
+
+describe('generateInvitationToken', () => {
+  it('returns a base64url string and a SHA-256 hex hash', () => {
+    const { raw, hash } = generateInvitationToken();
+    expect(raw).toMatch(/^[A-Za-z0-9_-]+$/);
+    // 32 bytes base64url ≈ 43 chars
+    expect(raw.length).toBeGreaterThanOrEqual(42);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('produces different tokens on each call', () => {
+    const a = generateInvitationToken();
+    const b = generateInvitationToken();
+    expect(a.raw).not.toBe(b.raw);
+    expect(a.hash).not.toBe(b.hash);
+  });
+
+  it('hashToken is deterministic for the same input', () => {
+    const t = 'fixed-token-1234';
+    expect(hashToken(t)).toBe(hashToken(t));
+  });
+});
+
+describe('defaultInvitationExpiresAt', () => {
+  it('returns ~72 hours after the given base time', () => {
+    const base = new Date('2026-05-25T00:00:00Z');
+    const exp = defaultInvitationExpiresAt(base);
+    expect(exp.getTime() - base.getTime()).toBe(72 * 60 * 60 * 1000);
+  });
+});

--- a/apps/web/server/lib/tokens.ts
+++ b/apps/web/server/lib/tokens.ts
@@ -1,0 +1,22 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+/**
+ * 256 bit のランダムトークン (生 / ハッシュ) を生成する。
+ * - 生トークンはメール本文の URL に埋め込み、DB には保存しない
+ * - ハッシュは SHA-256 (16 進文字列) で `invitations.token_hash` などに保存
+ * 設計書: docs/design/05-security.md §5.5
+ */
+export function generateInvitationToken(): { raw: string; hash: string } {
+  const raw = randomBytes(32).toString('base64url');
+  const hash = hashToken(raw);
+  return { raw, hash };
+}
+
+export function hashToken(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+/** 既定: 72 時間 (PRD SR-AUTH-02) */
+export function defaultInvitationExpiresAt(now: Date = new Date()): Date {
+  return new Date(now.getTime() + 72 * 60 * 60 * 1000);
+}

--- a/apps/web/server/routes/v1/invitations.test.ts
+++ b/apps/web/server/routes/v1/invitations.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+
+describe('invitations routes', () => {
+  beforeAll(() => {
+    process.env.SUPABASE_URL = 'http://127.0.0.1:54321';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key-1234567890';
+  });
+
+  it('requires authentication for POST /invitations/:token/accept', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/invitations/abc/accept', { method: 'POST' });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('AUTH_MISSING');
+  });
+
+  it('requires authentication for member routes', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/projects/xyz/members');
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/web/server/routes/v1/invitations.ts
+++ b/apps/web/server/routes/v1/invitations.ts
@@ -1,0 +1,27 @@
+import { Hono } from 'hono';
+
+import { requireAuth } from '../../middleware/auth.js';
+import { attachCurrentUserId } from '../../middleware/projectAuth.js';
+import { ApiException } from '../../lib/errors.js';
+import { acceptInvitation, verifyInvitation } from '../../services/invitations.js';
+
+/**
+ * `/api/v1/invitations/:token`
+ *  - GET: 未認証可。トークンを検証してプロジェクト概要を返す
+ *  - POST `/accept`: JWT 必須。受諾して project_members.user_id を埋める
+ */
+export const invitationsRoute = new Hono()
+  .get('/:token', async (c) => {
+    const token = c.req.param('token');
+    if (!token) throw new ApiException('BAD_REQUEST', 400, 'token required.');
+    const dto = await verifyInvitation(token);
+    return c.json({ data: dto });
+  })
+
+  .post('/:token/accept', requireAuth(), attachCurrentUserId(), async (c) => {
+    const token = c.req.param('token');
+    if (!token) throw new ApiException('BAD_REQUEST', 400, 'token required.');
+    const userId = c.get('currentUserId');
+    const dto = await acceptInvitation({ rawToken: token, currentUserId: userId });
+    return c.json({ data: dto }, 201);
+  });

--- a/apps/web/server/routes/v1/members.ts
+++ b/apps/web/server/routes/v1/members.ts
@@ -1,0 +1,82 @@
+import { Hono } from 'hono';
+
+import {
+  requireProjectDirector,
+  requireProjectMember,
+} from '../../middleware/projectAuth.js';
+import { ApiException } from '../../lib/errors.js';
+import { prisma } from '@trakon/db';
+import {
+  addMembersBodySchema,
+  updateMemberBodySchema,
+} from '../../schemas/members.js';
+import {
+  addMembers,
+  deleteMember,
+  listMembers,
+  updateMember,
+} from '../../services/members.js';
+
+/**
+ * `/projects/:projectId/members` の各エンドポイント。
+ * `requireAuth()` + `attachCurrentUserId()` は親 projectsRoute で適用済み。
+ * 認可は requireProjectMember / requireProjectDirector を個別に付与する。
+ */
+export const membersRoute = new Hono()
+  .get('/', requireProjectMember(), async (c) => {
+    const project = c.get('project');
+    const members = await listMembers(project.projectId);
+    return c.json({ data: members });
+  })
+
+  .post('/', requireProjectMember(), requireProjectDirector(), async (c) => {
+    const project = c.get('project');
+    const userId = c.get('currentUserId');
+    const body = addMembersBodySchema.parse(await c.req.json());
+
+    const [projectRow, inviter] = await Promise.all([
+      prisma.project.findUnique({ where: { id: project.projectId }, select: { name: true } }),
+      prisma.user.findUnique({ where: { id: userId }, select: { displayName: true } }),
+    ]);
+    if (!projectRow || !inviter) throw new ApiException('NOT_FOUND', 404, 'Project not found.');
+
+    const created = await addMembers({
+      projectId: project.projectId,
+      projectName: projectRow.name,
+      inviterDisplayName: inviter.displayName,
+      body,
+    });
+    return c.json({ data: created }, 201);
+  })
+
+  .patch(
+    '/:memberId',
+    requireProjectMember(),
+    requireProjectDirector(),
+    async (c) => {
+      const project = c.get('project');
+      const memberId = c.req.param('memberId');
+      if (!memberId) throw new ApiException('BAD_REQUEST', 400, 'memberId required.');
+      const body = updateMemberBodySchema.parse(await c.req.json());
+      const member = await updateMember({ memberId, projectId: project.projectId, body });
+      return c.json({ data: member });
+    },
+  )
+
+  .delete(
+    '/:memberId',
+    requireProjectMember(),
+    requireProjectDirector(),
+    async (c) => {
+      const project = c.get('project');
+      const userId = c.get('currentUserId');
+      const memberId = c.req.param('memberId');
+      if (!memberId) throw new ApiException('BAD_REQUEST', 400, 'memberId required.');
+      await deleteMember({
+        memberId,
+        projectId: project.projectId,
+        currentUserId: userId,
+      });
+      return c.body(null, 204);
+    },
+  );

--- a/apps/web/server/routes/v1/projects.ts
+++ b/apps/web/server/routes/v1/projects.ts
@@ -27,6 +27,7 @@ import {
   updateItem,
 } from '../../services/items.js';
 import { ApiException } from '../../lib/errors.js';
+import { membersRoute } from './members.js';
 
 export const projectsRoute = new Hono()
   .use('*', requireAuth())
@@ -123,4 +124,7 @@ export const projectsRoute = new Hono()
       await deleteItem({ itemId, projectId: project.projectId });
       return c.body(null, 204);
     },
-  );
+  )
+
+  // ----------------------------- /projects/:projectId/members -----------------------------
+  .route('/:projectId/members', membersRoute);

--- a/apps/web/server/schemas/members.ts
+++ b/apps/web/server/schemas/members.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const memberInputSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  email: z.string().trim().toLowerCase().email().max(320),
+  organizationName: z.string().trim().max(255).default(''),
+  memberType: z.enum(['client', 'production']),
+});
+export type MemberInput = z.infer<typeof memberInputSchema>;
+
+export const addMembersBodySchema = z.object({
+  members: z.array(memberInputSchema).min(1).max(20),
+});
+export type AddMembersBody = z.infer<typeof addMembersBodySchema>;
+
+export const updateMemberBodySchema = z.object({
+  name: z.string().trim().min(1).max(100).optional(),
+  organizationName: z.string().trim().max(255).optional(),
+  memberType: z.enum(['client', 'production']).optional(),
+  sortOrder: z.number().int().min(0).max(10_000).optional(),
+});
+export type UpdateMemberBody = z.infer<typeof updateMemberBodySchema>;

--- a/apps/web/server/services/invitations.ts
+++ b/apps/web/server/services/invitations.ts
@@ -1,0 +1,145 @@
+import { prisma } from '@trakon/db';
+
+import { ApiException } from '../lib/errors.js';
+import { hashToken } from '../lib/tokens.js';
+
+export type InvitationVerifyDTO = {
+  project: { id: string; name: string };
+  invitedMember: {
+    id: string;
+    name: string;
+    email: string;
+    organizationName: string;
+    memberType: 'client' | 'production';
+  };
+  expiresAt: string;
+};
+
+export type InvitationAcceptDTO = {
+  project: { id: string; name: string };
+  member: { id: string; memberType: 'client' | 'production' };
+};
+
+/**
+ * 招待を検証して状態を返す。期限切れ・受諾済・失効・未存在は全て 404 集約。
+ */
+export async function verifyInvitation(rawToken: string): Promise<InvitationVerifyDTO> {
+  const inv = await findActiveInvitation(rawToken);
+  return {
+    project: { id: inv.project.id, name: inv.project.name },
+    invitedMember: {
+      id: inv.invitedMember.id,
+      name: inv.invitedMember.name,
+      email: inv.invitedMember.email,
+      organizationName: inv.invitedMember.organizationName,
+      memberType: inv.invitedMember.memberType as 'client' | 'production',
+    },
+    expiresAt: inv.expiresAt.toISOString(),
+  };
+}
+
+/**
+ * 招待を受諾。同一トランザクションで:
+ *  1. project_members.user_id をログインユーザーの users.id に設定
+ *  2. invitations.accepted_at = now()
+ *  3. audit_logs に invitation 受諾の login 相当を記録
+ *
+ * 招待されたメールアドレスと、受諾しようとしているユーザーのメールが一致しない場合は 403。
+ */
+export async function acceptInvitation(input: {
+  rawToken: string;
+  currentUserId: string;
+}): Promise<InvitationAcceptDTO> {
+  const inv = await findActiveInvitation(input.rawToken);
+
+  const user = await prisma.user.findUnique({
+    where: { id: input.currentUserId },
+    select: { id: true, email: true },
+  });
+  if (!user) throw new ApiException('PROFILE_NOT_COMPLETED', 404, 'Profile is required.');
+
+  if (user.email.toLowerCase() !== inv.invitedMember.email.toLowerCase()) {
+    throw new ApiException(
+      'INVITATION_EMAIL_MISMATCH',
+      403,
+      'This invitation was sent to a different email address.',
+    );
+  }
+
+  // 既にこのプロジェクトに別の member 行で参加していないか
+  const dup = await prisma.projectMember.findFirst({
+    where: {
+      projectId: inv.project.id,
+      userId: user.id,
+      id: { not: inv.invitedMember.id },
+      deletedAt: null,
+    },
+    select: { id: true },
+  });
+  if (dup) {
+    throw new ApiException(
+      'ALREADY_MEMBER',
+      409,
+      'You are already a member of this project.',
+    );
+  }
+
+  const result = await prisma.$transaction(async (tx) => {
+    const updatedMember = await tx.projectMember.update({
+      where: { id: inv.invitedMember.id },
+      data: { userId: user.id },
+    });
+    await tx.invitation.update({
+      where: { id: inv.id },
+      data: { acceptedAt: new Date() },
+    });
+    await tx.auditLog.create({
+      data: {
+        actorUserId: user.id,
+        action: 'login',
+        resourceType: 'invitation',
+        resourceId: inv.id,
+        result: 'success',
+        extra: { projectId: inv.project.id, memberId: updatedMember.id },
+      },
+    });
+    return updatedMember;
+  });
+
+  return {
+    project: { id: inv.project.id, name: inv.project.name },
+    member: { id: result.id, memberType: result.memberType as 'client' | 'production' },
+  };
+}
+
+async function findActiveInvitation(rawToken: string) {
+  const tokenHash = hashToken(rawToken);
+  const inv = await prisma.invitation.findFirst({
+    where: {
+      tokenHash,
+      acceptedAt: null,
+      revokedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+    include: {
+      project: { select: { id: true, name: true } },
+      invitedMember: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          organizationName: true,
+          memberType: true,
+        },
+      },
+    },
+  });
+  if (!inv) {
+    throw new ApiException(
+      'INVITATION_NOT_FOUND_OR_EXPIRED',
+      404,
+      'Invitation not found, expired, accepted, or revoked.',
+    );
+  }
+  return inv;
+}

--- a/apps/web/server/services/members.ts
+++ b/apps/web/server/services/members.ts
@@ -1,0 +1,224 @@
+import { prisma } from '@trakon/db';
+
+import { ApiException } from '../lib/errors.js';
+import { getServerEnv } from '../lib/env.js';
+import { getMailer } from '../lib/mailer.js';
+import {
+  defaultInvitationExpiresAt,
+  generateInvitationToken,
+} from '../lib/tokens.js';
+import type { AddMembersBody, UpdateMemberBody } from '../schemas/members.js';
+
+export type MemberDTO = {
+  id: string;
+  userId: string | null;
+  name: string;
+  email: string;
+  organizationName: string;
+  memberType: 'client' | 'production';
+  sortOrder: number;
+  inviteStatus: 'accepted' | 'pending' | 'expired';
+  createdAt: string;
+  updatedAt: string;
+};
+
+function inviteStatusOf(
+  m: {
+    userId: string | null;
+    invitations: Array<{ acceptedAt: Date | null; revokedAt: Date | null; expiresAt: Date }>;
+  },
+  now: Date,
+): MemberDTO['inviteStatus'] {
+  if (m.userId) return 'accepted';
+  // 未受諾 → 有効な招待があるか確認
+  const active = m.invitations.find(
+    (i) => !i.acceptedAt && !i.revokedAt && i.expiresAt > now,
+  );
+  return active ? 'pending' : 'expired';
+}
+
+function toDTO(
+  m: {
+    id: string;
+    userId: string | null;
+    name: string;
+    email: string;
+    organizationName: string;
+    memberType: string;
+    sortOrder: number;
+    createdAt: Date;
+    updatedAt: Date;
+    invitations: Array<{ acceptedAt: Date | null; revokedAt: Date | null; expiresAt: Date }>;
+  },
+  now: Date,
+): MemberDTO {
+  return {
+    id: m.id,
+    userId: m.userId,
+    name: m.name,
+    email: m.email,
+    organizationName: m.organizationName,
+    memberType: m.memberType as MemberDTO['memberType'],
+    sortOrder: m.sortOrder,
+    inviteStatus: inviteStatusOf(m, now),
+    createdAt: m.createdAt.toISOString(),
+    updatedAt: m.updatedAt.toISOString(),
+  };
+}
+
+export async function listMembers(projectId: string): Promise<MemberDTO[]> {
+  const rows = await prisma.projectMember.findMany({
+    where: { projectId, deletedAt: null },
+    orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+    include: {
+      invitations: {
+        select: { acceptedAt: true, revokedAt: true, expiresAt: true },
+      },
+    },
+  });
+  const now = new Date();
+  return rows.map((m) => toDTO(m, now));
+}
+
+/**
+ * 参加者を追加。仮メンバー + 招待トークン INSERT + メール送信を 1 トランザクションで。
+ * メール送信失敗時はトランザクション全体をロールバック (Phase 1 で Inngest 非同期化検討)。
+ */
+export async function addMembers(input: {
+  projectId: string;
+  projectName: string;
+  inviterDisplayName: string;
+  body: AddMembersBody;
+}): Promise<MemberDTO[]> {
+  const env = getServerEnv();
+  const mailer = getMailer();
+
+  // 既存メンバーのメールと重複しないかチェック
+  const existing = await prisma.projectMember.findMany({
+    where: { projectId: input.projectId, deletedAt: null },
+    select: { email: true },
+  });
+  const taken = new Set(existing.map((m) => m.email.toLowerCase()));
+  for (const m of input.body.members) {
+    if (taken.has(m.email)) {
+      throw new ApiException(
+        'MEMBER_EMAIL_TAKEN',
+        409,
+        `Email already exists in this project: ${m.email}`,
+        { email: m.email },
+      );
+    }
+  }
+
+  // 招待トークンとメール内容を生成
+  const expiresAt = defaultInvitationExpiresAt();
+  const prepared = input.body.members.map((m, idx) => {
+    const { raw, hash } = generateInvitationToken();
+    return { member: m, raw, hash, idx };
+  });
+
+  // 末尾の sortOrder を取得して採番
+  const last = await prisma.projectMember.findFirst({
+    where: { projectId: input.projectId, deletedAt: null },
+    orderBy: { sortOrder: 'desc' },
+    select: { sortOrder: true },
+  });
+  const baseOrder = (last?.sortOrder ?? -1) + 1;
+
+  const created = await prisma.$transaction(async (tx) => {
+    const result: MemberDTO[] = [];
+    for (const p of prepared) {
+      const member = await tx.projectMember.create({
+        data: {
+          projectId: input.projectId,
+          userId: null,
+          name: p.member.name,
+          email: p.member.email,
+          organizationName: p.member.organizationName,
+          memberType: p.member.memberType,
+          sortOrder: baseOrder + p.idx,
+        },
+      });
+      await tx.invitation.create({
+        data: {
+          projectId: input.projectId,
+          invitedMemberId: member.id,
+          email: p.member.email,
+          tokenHash: p.hash,
+          expiresAt,
+        },
+      });
+      const acceptUrl = `${env.PUBLIC_APP_URL}/invitations/${p.raw}`;
+      // メール送信は同期、失敗時 tx は throw でロールバックされる
+      await mailer.sendInvitation({
+        to: p.member.email,
+        projectName: input.projectName,
+        inviterName: input.inviterDisplayName,
+        acceptUrl,
+        expiresAt,
+      });
+      result.push({
+        id: member.id,
+        userId: null,
+        name: member.name,
+        email: member.email,
+        organizationName: member.organizationName,
+        memberType: member.memberType as MemberDTO['memberType'],
+        sortOrder: member.sortOrder,
+        inviteStatus: 'pending',
+        createdAt: member.createdAt.toISOString(),
+        updatedAt: member.updatedAt.toISOString(),
+      });
+    }
+    return result;
+  });
+  return created;
+}
+
+export async function updateMember(input: {
+  memberId: string;
+  projectId: string;
+  body: UpdateMemberBody;
+}): Promise<MemberDTO> {
+  const existing = await prisma.projectMember.findFirst({
+    where: { id: input.memberId, projectId: input.projectId, deletedAt: null },
+  });
+  if (!existing) throw new ApiException('NOT_FOUND', 404, 'Member not found.');
+
+  const updated = await prisma.projectMember.update({
+    where: { id: input.memberId },
+    data: {
+      name: input.body.name ?? undefined,
+      organizationName: input.body.organizationName ?? undefined,
+      memberType: input.body.memberType ?? undefined,
+      sortOrder: input.body.sortOrder ?? undefined,
+    },
+    include: {
+      invitations: { select: { acceptedAt: true, revokedAt: true, expiresAt: true } },
+    },
+  });
+  return toDTO(updated, new Date());
+}
+
+export async function deleteMember(input: {
+  memberId: string;
+  projectId: string;
+  currentUserId: string;
+}): Promise<void> {
+  const existing = await prisma.projectMember.findFirst({
+    where: { id: input.memberId, projectId: input.projectId, deletedAt: null },
+  });
+  if (!existing) throw new ApiException('NOT_FOUND', 404, 'Member not found.');
+
+  // ディレクター本人の自己削除は不可
+  if (existing.userId === input.currentUserId) {
+    throw new ApiException(
+      'CANNOT_REMOVE_SELF',
+      409,
+      'Director cannot remove themselves from the project.',
+    );
+  }
+
+  // plans 連動 (MEMBER_HAS_ACTIVE_PLANS) は Sub-Phase 0.3 で plans 追加後に実装
+  await prisma.projectMember.delete({ where: { id: input.memberId } });
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,10 +1,12 @@
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes, Navigate as Nav, useParams } from 'react-router-dom';
 
 import { AuthCallbackPage } from './app/AuthCallbackPage';
 import { DashboardPage } from './app/DashboardPage';
 import { SidebarLayout } from './app/SidebarLayout';
 import { RequireAuth } from './features/auth/RequireAuth';
 import { SC01LoginPage } from './features/auth/SC01LoginPage';
+import { InvitationAcceptPage } from './features/invitations/InvitationAcceptPage';
+import { MembersPage } from './features/projects/MembersPage';
 import { ProjectCreatePage } from './features/projects/ProjectCreatePage';
 import { ProjectEditPage } from './features/projects/ProjectEditPage';
 import { ProjectListPage } from './features/projects/ProjectListPage';
@@ -14,6 +16,7 @@ export function App() {
     <Routes>
       <Route path="/login" element={<SC01LoginPage />} />
       <Route path="/auth/callback" element={<AuthCallbackPage />} />
+      <Route path="/invitations/:token" element={<InvitationAcceptPage />} />
 
       <Route
         element={
@@ -26,6 +29,7 @@ export function App() {
         <Route path="/projects" element={<ProjectListPage />} />
         <Route path="/projects/new" element={<ProjectCreatePage />} />
         <Route path="/projects/:projectId/edit" element={<ProjectEditPage />} />
+        <Route path="/projects/:projectId/members" element={<MembersPage />} />
         {/* 詳細画面 (SC-06 縦型カレンダー) は Sub-Phase 0.3 で実装。当面は edit に飛ばす */}
         <Route path="/projects/:projectId" element={<ProjectRedirectToEdit />} />
       </Route>
@@ -36,7 +40,6 @@ export function App() {
   );
 }
 
-import { Navigate as Nav, useParams } from 'react-router-dom';
 function ProjectRedirectToEdit() {
   const { projectId } = useParams<{ projectId: string }>();
   return <Nav to={`/projects/${projectId}/edit`} replace />;

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+
+import { cn } from "./utils";
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+          <XIcon />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "./utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/apps/web/src/features/invitations/InvitationAcceptPage.tsx
+++ b/apps/web/src/features/invitations/InvitationAcceptPage.tsx
@@ -1,0 +1,164 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertCircle, CheckCircle2, Loader2, LogIn } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+import { useCurrentUser } from '@/features/auth/useCurrentUser';
+import { ApiClientError } from '@/lib/api';
+import { invitationsApi } from './api';
+
+const dateTimeFmt = new Intl.DateTimeFormat('ja-JP', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+/**
+ * SC-02 招待受諾画面 (/invitations/:token)
+ *  - 未認証でも開ける (招待内容を表示)
+ *  - ログイン済みなら受諾ボタン → /projects/:id/edit に遷移
+ */
+export function InvitationAcceptPage() {
+  const { token } = useParams<{ token: string }>();
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const verifyQuery = useQuery({
+    queryKey: ['invitations', token],
+    queryFn: () => invitationsApi.verify(token!),
+    enabled: !!token,
+    retry: 0,
+  });
+
+  const { isAuthenticated, isLoading: sessionLoading } = useAuthSession();
+  const { data: userData, isLoading: userLoading } = useCurrentUser();
+  const profileReady = userData && !userData.requiresProfileCompletion;
+
+  const acceptMut = useMutation({
+    mutationFn: () => invitationsApi.accept(token!),
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: ['projects'] });
+      toast.success('プロジェクトに参加しました');
+      navigate(`/projects/${res.project.id}/edit`, { replace: true });
+    },
+    onError: (err) => {
+      if (err instanceof ApiClientError && err.code === 'INVITATION_EMAIL_MISMATCH') {
+        toast.error('招待されたメールアドレスでログインしてください');
+        return;
+      }
+      if (err instanceof ApiClientError && err.code === 'ALREADY_MEMBER') {
+        toast.message('既にこのプロジェクトに参加しています');
+        navigate(`/projects`, { replace: true });
+        return;
+      }
+      toast.error(err instanceof ApiClientError ? err.message : '受諾に失敗しました');
+    },
+  });
+
+  if (!token) return <Centered>無効な招待リンクです</Centered>;
+
+  return (
+    <div className="flex min-h-screen items-start justify-center bg-background px-4 pt-24">
+      <div className="w-full max-w-sm space-y-6">
+        <h1 className="text-center text-2xl font-semibold tracking-tight">TRAKON</h1>
+
+        {verifyQuery.isLoading && (
+          <Card>
+            <CardContent className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              招待を確認しています…
+            </CardContent>
+          </Card>
+        )}
+
+        {verifyQuery.error && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <AlertCircle className="size-4 text-destructive" />
+                招待を確認できません
+              </CardTitle>
+              <CardDescription>
+                招待の期限が切れているか、既に受諾済みかもしれません。招待者にご確認ください。
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        )}
+
+        {verifyQuery.data && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">プロジェクトへの招待</CardTitle>
+              <CardDescription>
+                <span className="font-medium text-foreground">
+                  {verifyQuery.data.project.name}
+                </span>{' '}
+                への招待を受け取りました。
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm">
+                <dt className="text-muted-foreground">招待先</dt>
+                <dd>{verifyQuery.data.invitedMember.email}</dd>
+                <dt className="text-muted-foreground">氏名</dt>
+                <dd>{verifyQuery.data.invitedMember.name}</dd>
+                <dt className="text-muted-foreground">種別</dt>
+                <dd>
+                  {verifyQuery.data.invitedMember.memberType === 'client'
+                    ? 'クライアント'
+                    : '制作側'}
+                </dd>
+                <dt className="text-muted-foreground">有効期限</dt>
+                <dd>
+                  {dateTimeFmt.format(new Date(verifyQuery.data.expiresAt))}
+                </dd>
+              </dl>
+
+              {sessionLoading || userLoading ? (
+                <Button disabled className="w-full">
+                  <Loader2 className="size-4 animate-spin" />
+                  読み込み中…
+                </Button>
+              ) : isAuthenticated && profileReady ? (
+                <Button
+                  className="w-full"
+                  onClick={() => acceptMut.mutate()}
+                  disabled={acceptMut.isPending}
+                >
+                  {acceptMut.isPending ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <CheckCircle2 className="size-4" />
+                  )}
+                  招待を承諾する
+                </Button>
+              ) : (
+                <Button
+                  className="w-full"
+                  onClick={() =>
+                    navigate(
+                      `/login?next=${encodeURIComponent(`/invitations/${token}`)}`,
+                    )
+                  }
+                >
+                  <LogIn className="size-4" />
+                  ログインして承諾する
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4 text-sm text-muted-foreground">
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/features/invitations/api.ts
+++ b/apps/web/src/features/invitations/api.ts
@@ -1,0 +1,28 @@
+import { apiRequest } from '@/lib/api';
+
+export type InvitationVerify = {
+  project: { id: string; name: string };
+  invitedMember: {
+    id: string;
+    name: string;
+    email: string;
+    organizationName: string;
+    memberType: 'client' | 'production';
+  };
+  expiresAt: string;
+};
+
+export type InvitationAccept = {
+  project: { id: string; name: string };
+  member: { id: string; memberType: 'client' | 'production' };
+};
+
+export const invitationsApi = {
+  verify: (token: string) =>
+    apiRequest<InvitationVerify>(`/invitations/${encodeURIComponent(token)}`),
+  accept: (token: string) =>
+    apiRequest<InvitationAccept>(
+      `/invitations/${encodeURIComponent(token)}/accept`,
+      { method: 'POST' },
+    ),
+};

--- a/apps/web/src/features/projects/MembersPage.tsx
+++ b/apps/web/src/features/projects/MembersPage.tsx
@@ -1,0 +1,361 @@
+import { useState } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Loader2, Mail, Plus, Trash2, UsersRound, ArrowLeft } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { ApiClientError } from '@/lib/api';
+import { membersApi, membersQueryKey, type ProjectMember } from './membersApi';
+
+const STATUS_LABEL: Record<ProjectMember['inviteStatus'], { text: string; tone: 'default' | 'secondary' | 'destructive' }> = {
+  accepted: { text: '参加中', tone: 'default' },
+  pending: { text: '招待中', tone: 'secondary' },
+  expired: { text: '期限切れ', tone: 'destructive' },
+};
+
+export function MembersPage() {
+  const { projectId } = useParams<{ projectId: string }>();
+  const [params, setParams] = useSearchParams();
+  const tab = params.get('tab') === 'manage' ? 'manage' : 'kanban';
+
+  if (!projectId) return <NotFound projectId={undefined} />;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-5 px-8 py-10">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">参加者</h1>
+          <p className="text-sm text-muted-foreground">
+            プロジェクトのメンバーを管理します
+          </p>
+        </div>
+        <Button variant="ghost" size="sm" asChild>
+          <Link to={`/projects/${projectId}/edit`}>
+            <ArrowLeft className="size-4" />
+            プロジェクト設定に戻る
+          </Link>
+        </Button>
+      </header>
+
+      <Tabs
+        value={tab}
+        onValueChange={(v) => {
+          const sp = new URLSearchParams(params);
+          if (v === 'manage') sp.set('tab', 'manage');
+          else sp.delete('tab');
+          setParams(sp, { replace: true });
+        }}
+      >
+        <TabsList>
+          <TabsTrigger value="kanban">
+            <UsersRound className="size-4" />
+            メンバー
+          </TabsTrigger>
+          <TabsTrigger value="manage">管理</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {tab === 'kanban' ? (
+        <Card>
+          <CardContent className="py-12 text-center text-sm text-muted-foreground">
+            メンバーかんばん（SC-17）は Sub-Phase 0.4 で実装予定です。
+            <br />
+            参加者の追加・編集は「管理」タブから行えます。
+          </CardContent>
+        </Card>
+      ) : (
+        <ManageTab projectId={projectId} />
+      )}
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// 管理タブ
+// -----------------------------------------------------------------------------
+function ManageTab({ projectId }: { projectId: string }) {
+  const qc = useQueryClient();
+  const [addOpen, setAddOpen] = useState(false);
+  const [removing, setRemoving] = useState<ProjectMember | null>(null);
+
+  const query = useQuery({
+    queryKey: membersQueryKey.list(projectId),
+    queryFn: () => membersApi.list(projectId),
+  });
+
+  const removeMut = useMutation({
+    mutationFn: (memberId: string) => membersApi.remove(projectId, memberId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: membersQueryKey.list(projectId) });
+      toast.success('参加者を削除しました');
+      setRemoving(null);
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '削除に失敗しました'),
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">参加者一覧</CardTitle>
+          <Button size="sm" onClick={() => setAddOpen(true)}>
+            <Plus className="size-4" />
+            参加者を追加
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {query.isLoading && <Skeleton className="h-32 w-full rounded-md" />}
+        {query.error && (
+          <p className="text-sm text-destructive">参加者の取得に失敗しました</p>
+        )}
+        {query.data && (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>氏名</TableHead>
+                <TableHead>所属</TableHead>
+                <TableHead>メール</TableHead>
+                <TableHead>種別</TableHead>
+                <TableHead>状態</TableHead>
+                <TableHead className="w-12" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {query.data.map((m) => {
+                const status = STATUS_LABEL[m.inviteStatus];
+                return (
+                  <TableRow key={m.id}>
+                    <TableCell className="font-medium">{m.name}</TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {m.organizationName || '—'}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{m.email}</TableCell>
+                    <TableCell className="text-xs">
+                      {m.memberType === 'client' ? 'クライアント' : '制作側'}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={status.tone}>{status.text}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setRemoving(m)}
+                        aria-label="削除"
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+
+      <AddMembersDialog
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        projectId={projectId}
+      />
+
+      <AlertDialog open={!!removing} onOpenChange={(o) => !o && setRemoving(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>「{removing?.name}」をプロジェクトから外しますか？</AlertDialogTitle>
+            <AlertDialogDescription>
+              担当ボールがある場合は再アサインを検討してください。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                if (removing) removeMut.mutate(removing.id);
+              }}
+              disabled={removeMut.isPending}
+            >
+              削除する
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// 参加者追加ダイアログ
+// -----------------------------------------------------------------------------
+const addSchema = z.object({
+  name: z.string().trim().min(1, '氏名は必須').max(100),
+  email: z.string().trim().email('メール形式が不正').max(320),
+  organizationName: z.string().trim().max(255),
+  memberType: z.enum(['client', 'production']),
+});
+type AddValues = z.infer<typeof addSchema>;
+
+function AddMembersDialog({
+  open,
+  onClose,
+  projectId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  projectId: string;
+}) {
+  const qc = useQueryClient();
+  const form = useForm<AddValues>({
+    resolver: zodResolver(addSchema),
+    defaultValues: { name: '', email: '', organizationName: '', memberType: 'production' },
+  });
+
+  const addMut = useMutation({
+    mutationFn: (v: AddValues) => membersApi.add(projectId, { members: [v] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: membersQueryKey.list(projectId) });
+      toast.success('招待メールを送信しました', {
+        description: '（開発環境ではコンソールに出力されます）',
+      });
+      form.reset();
+      onClose();
+    },
+    onError: (e) => {
+      if (e instanceof ApiClientError && e.code === 'MEMBER_EMAIL_TAKEN') {
+        toast.error('このメールアドレスは既に追加されています');
+      } else {
+        toast.error(e instanceof ApiClientError ? e.message : '追加に失敗しました');
+      }
+    },
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>参加者を追加</DialogTitle>
+          <DialogDescription>
+            入力されたメールアドレスに招待を送ります（72 時間有効）。
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={form.handleSubmit((v) => addMut.mutate(v))}
+          className="space-y-3"
+          id="add-member-form"
+        >
+          <Field label="氏名" error={form.formState.errors.name?.message}>
+            <Input {...form.register('name')} autoFocus />
+          </Field>
+          <Field label="所属" error={form.formState.errors.organizationName?.message}>
+            <Input {...form.register('organizationName')} />
+          </Field>
+          <Field label="メール" error={form.formState.errors.email?.message}>
+            <Input type="email" {...form.register('email')} />
+          </Field>
+          <Field label="種別" error={form.formState.errors.memberType?.message}>
+            <Select
+              defaultValue="production"
+              onValueChange={(v) =>
+                form.setValue('memberType', v as 'client' | 'production')
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="production">制作側</SelectItem>
+                <SelectItem value="client">クライアント</SelectItem>
+              </SelectContent>
+            </Select>
+          </Field>
+        </form>
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button form="add-member-form" type="submit" disabled={addMut.isPending}>
+            {addMut.isPending ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Mail className="size-4" />
+            )}
+            招待を送信
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Field({
+  label,
+  error,
+  children,
+}: {
+  label: string;
+  error?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label>{label}</Label>
+      {children}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+function NotFound({ projectId: _ }: { projectId: string | undefined }) {
+  return (
+    <div className="mx-auto max-w-3xl px-8 py-20 text-center text-sm text-muted-foreground">
+      プロジェクトが見つかりませんでした。
+    </div>
+  );
+}

--- a/apps/web/src/features/projects/ProjectEditPage.tsx
+++ b/apps/web/src/features/projects/ProjectEditPage.tsx
@@ -137,12 +137,12 @@ function ProjectEditInner({ projectId, onBack }: { projectId: string; onBack: ()
         </CardHeader>
         <CardContent className="flex items-center justify-between gap-3">
           <p className="text-sm text-muted-foreground">
-            参加者の追加・編集・招待メール送信は次回リリースで有効化されます。
+            参加者の追加・招待・削除を行います。
           </p>
-          <Button variant="outline" size="sm" disabled asChild>
+          <Button variant="outline" size="sm" asChild>
             <Link to={`/projects/${projectId}/members?tab=manage`}>
               <Users className="size-4" />
-              参加者管理（準備中）
+              参加者管理を開く
             </Link>
           </Button>
         </CardContent>

--- a/apps/web/src/features/projects/membersApi.ts
+++ b/apps/web/src/features/projects/membersApi.ts
@@ -1,0 +1,53 @@
+import { apiRequest } from '@/lib/api';
+
+export type ProjectMember = {
+  id: string;
+  userId: string | null;
+  name: string;
+  email: string;
+  organizationName: string;
+  memberType: 'client' | 'production';
+  sortOrder: number;
+  inviteStatus: 'accepted' | 'pending' | 'expired';
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AddMembersInput = {
+  members: Array<{
+    name: string;
+    email: string;
+    organizationName: string;
+    memberType: 'client' | 'production';
+  }>;
+};
+
+export type UpdateMemberInput = Partial<{
+  name: string;
+  organizationName: string;
+  memberType: 'client' | 'production';
+  sortOrder: number;
+}>;
+
+export const membersApi = {
+  list: (projectId: string) =>
+    apiRequest<ProjectMember[]>(`/projects/${projectId}/members`),
+  add: (projectId: string, body: AddMembersInput) =>
+    apiRequest<ProjectMember[]>(`/projects/${projectId}/members`, {
+      method: 'POST',
+      body,
+    }),
+  update: (projectId: string, memberId: string, body: UpdateMemberInput) =>
+    apiRequest<ProjectMember>(`/projects/${projectId}/members/${memberId}`, {
+      method: 'PATCH',
+      body,
+    }),
+  remove: (projectId: string, memberId: string) =>
+    apiRequest<void>(`/projects/${projectId}/members/${memberId}`, {
+      method: 'DELETE',
+    }),
+};
+
+export const membersQueryKey = {
+  list: (projectId: string) => ['projects', projectId, 'members'] as const,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.2
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.2
+        version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-label':
         specifier: ^2.1.0
         version: 2.1.8(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Summary

Sub-Phase 0.2 の **後半 PR**。前半（PR #7）で projects / items を実装したので、本 PR で参加者管理・招待受諾・招待メール送信（ダミー実装）を追加し、Sub-Phase 0.2 を完成させます。

### BE（apps/web/server）

- **lib/tokens**：256bit base64url 乱数 + SHA-256 ハッシュ + 72h 既定期限（PRD SR-AUTH-02）
- **lib/mailer**：`Mailer` インターフェース + dummy 実装
  - dev / test では `console.log` で送信内容を出力
  - prod では例外を投げて事故を防止
  - Sub-Phase 0.6 で `createResendMailer()` に差し替え可能なファクトリ構造
- **MemberService**：
  - `addMembers` — 既存メール重複チェック → 仮メンバー + `invitations` INSERT + メール送信 を **1 トランザクション** で実行、メール送信失敗で全ロールバック
  - `deleteMember` — ディレクター自己削除を `CANNOT_REMOVE_SELF` (409) で拒否
- **InvitationService**：
  - `verify` — SHA-256 で引き、期限切れ・受諾済・失効・未存在を **404 集約**
  - `accept` — `project_members.user_id` セット + `invitations.accepted_at` 更新 + `audit_logs` 記録を同一 tx で実行
  - 招待先メールと受諾ユーザーのメール不一致を `INVITATION_EMAIL_MISMATCH` (403) で拒否
- **ルート 6 本**：
  - `/projects/:projectId/members` GET / POST / PATCH / DELETE
  - `/invitations/:token` GET / `POST /accept`
- env に `PUBLIC_APP_URL` を追加（招待 URL 組み立て用、既定 `http://localhost:5173`）

### FE（apps/web/src）

- **SC-11 参加者管理** `/projects/:projectId/members?tab=manage`：
  - Tabs（**メンバー**かんばん placeholder / **管理**）
  - Table + Badge で一覧 + 招待状態（accepted / pending / expired）
  - 追加ダイアログ（RHF + Zod）— 送信成功で「招待メールを送信しました」トースト
  - 削除確認 AlertDialog
- **SC-02 招待受諾** `/invitations/:token`：
  - 未認証可、招待内容を読み取り専用表示
  - 未ログイン → `/login?next=/invitations/:token` に誘導
  - ログイン済み → 「招待を承諾する」で `/projects/:id/edit` へ遷移
  - メール不一致 / 既参加 / 期限切れに応じたエラー UX
- **ProjectEditPage** の「参加者管理（準備中）」リンクを実装に置換
- shadcn primitives 追加：`dialog` / `table`

### Tests

- `tokens.test.ts` 4 ケース（生成・冪等性・期限算出）
- `invitations.test.ts` 2 ケース（認証なし 401）
- 既存ルートと合わせて全体 **26 tests passing**

## 設計書差分メモ

- Resend は **ダミー実装** で進めています（事前合意通り）。Sub-Phase 0.6 で本実装に差し替え時、`createResendMailer()` をファクトリに追加し APP_ENV で切替予定
- `MEMBER_HAS_ACTIVE_PLANS` (409) は `plans` テーブルが Sub-Phase 0.3 で追加される時点で実装。現在は plan 連動なしで物理削除

## 検証

- [x] `pnpm type-check` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test` 通過（26 tests passing）
- [x] `pnpm build` 通過
- [ ] **ローカル E2E**：Supabase CLI セットアップ後、`supabase start` のログから招待 URL を拾って受諾フローを確認可能

## これで Sub-Phase 0.2 完了

マージ後、**Sub-Phase 0.3（予定 / 縦型カレンダー / TOSS・完了の中核機能）** に進みます。Phase 0 で最も重いサブフェーズです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)