### PR TITLE
Sub-Phase 0.3 PR A: plans / ball_events / TOSS・完了・自動連鎖 (DB + BE)

### DIFF
--- a/apps/web/server/middleware/itemAuth.ts
+++ b/apps/web/server/middleware/itemAuth.ts
@@ -1,0 +1,34 @@
+import type { MiddlewareHandler } from 'hono';
+
+import { prisma } from '@trakon/db';
+
+import { ApiException } from '../lib/errors.js';
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    itemId: string;
+  }
+}
+
+/**
+ * `:itemId` パスパラメータが `:projectId` に属するか検証する。
+ * `requireProjectMember()` の後段で使う。
+ * 未存在 / 別プロジェクトのものを 404 集約。
+ */
+export function requireItemInProject(): MiddlewareHandler {
+  return async (c, next) => {
+    const itemId = c.req.param('itemId');
+    if (!itemId) throw new ApiException('BAD_REQUEST', 400, 'itemId param missing.');
+
+    const project = c.get('project');
+    const item = await prisma.projectItem.findFirst({
+      where: { id: itemId, projectId: project.projectId, deletedAt: null },
+      select: { id: true },
+    });
+    if (!item) {
+      throw new ApiException('NOT_FOUND', 404, `Item not found: ${itemId}`);
+    }
+    c.set('itemId', item.id);
+    await next();
+  };
+}

--- a/apps/web/server/routes/v1/plans.test.ts
+++ b/apps/web/server/routes/v1/plans.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+
+describe('plans routes', () => {
+  beforeAll(() => {
+    process.env.SUPABASE_URL = 'http://127.0.0.1:54321';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key-1234567890';
+  });
+
+  it('requires authentication for GET plans list', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/projects/abc/items/def/plans');
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('AUTH_MISSING');
+  });
+
+  it('requires authentication for POST /toss', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/projects/abc/items/def/plans/xyz/toss', {
+      method: 'POST',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('requires authentication for POST /complete', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/projects/abc/items/def/plans/xyz/complete', {
+      method: 'POST',
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/web/server/routes/v1/plans.ts
+++ b/apps/web/server/routes/v1/plans.ts
@@ -1,0 +1,133 @@
+import { Hono } from 'hono';
+
+import {
+  requireProjectDirector,
+  requireProjectMember,
+} from '../../middleware/projectAuth.js';
+import { requireItemInProject } from '../../middleware/itemAuth.js';
+import { ApiException } from '../../lib/errors.js';
+import {
+  createPlanBodySchema,
+  listPlansQuerySchema,
+  setSuccessorBodySchema,
+  tossBodySchema,
+  updatePlanBodySchema,
+} from '../../schemas/plans.js';
+import {
+  createPlan,
+  deletePlan,
+  getPlan,
+  listPlans,
+  setPlanSuccessor,
+  updatePlan,
+} from '../../services/plans.js';
+import { completePlan, tossPlan } from '../../services/ballActions.js';
+
+/**
+ * `/projects/:projectId/items/:itemId/plans` 配下のエンドポイント。
+ * 親 projectsRoute で requireAuth + attachCurrentUserId が適用済み。
+ *
+ * 全 8 本:
+ *  - GET    /                       一覧
+ *  - POST   /                       作成
+ *  - GET    /:planId                詳細 (events 含む)
+ *  - PATCH  /:planId                更新
+ *  - DELETE /:planId                削除 (ball_events なしのみ)
+ *  - PATCH  /:planId/successor      後続紐付け
+ *  - POST   /:planId/toss           TOSS 実行
+ *  - POST   /:planId/complete       完了
+ */
+export const plansRoute = new Hono()
+  .use('*', requireProjectMember())
+  .use('*', requireItemInProject())
+
+  .get('/', async (c) => {
+    const itemId = c.get('itemId');
+    const query = listPlansQuerySchema.parse({
+      from: c.req.query('from'),
+      to: c.req.query('to'),
+      limit: c.req.query('limit'),
+      offset: c.req.query('offset'),
+    });
+    const { items, total } = await listPlans({ itemId, query });
+    return c.json({
+      data: items,
+      meta: { total, limit: query.limit, offset: query.offset },
+    });
+  })
+
+  .post('/', async (c) => {
+    const itemId = c.get('itemId');
+    const project = c.get('project');
+    const body = createPlanBodySchema.parse(await c.req.json());
+    const plan = await createPlan({ itemId, projectId: project.projectId, body });
+    return c.json({ data: plan }, 201);
+  })
+
+  .get('/:planId', async (c) => {
+    const itemId = c.get('itemId');
+    const planId = c.req.param('planId');
+    if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
+    const detail = await getPlan({ itemId, planId });
+    return c.json({ data: detail });
+  })
+
+  .patch('/:planId', async (c) => {
+    const itemId = c.get('itemId');
+    const planId = c.req.param('planId');
+    if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
+    const body = updatePlanBodySchema.parse(await c.req.json());
+    const plan = await updatePlan({ itemId, planId, body });
+    return c.json({ data: plan });
+  })
+
+  .delete('/:planId', requireProjectDirector(), async (c) => {
+    const itemId = c.get('itemId');
+    const planId = c.req.param('planId');
+    if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
+    await deletePlan({ itemId, planId });
+    return c.body(null, 204);
+  })
+
+  .patch('/:planId/successor', async (c) => {
+    const itemId = c.get('itemId');
+    const planId = c.req.param('planId');
+    if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
+    const body = setSuccessorBodySchema.parse(await c.req.json());
+    const plan = await setPlanSuccessor({ itemId, planId, body });
+    return c.json({ data: plan });
+  })
+
+  .post('/:planId/toss', async (c) => {
+    const itemId = c.get('itemId');
+    const project = c.get('project');
+    const planId = c.req.param('planId');
+    if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
+    const body = tossBodySchema.parse(await c.req.json().catch(() => ({})));
+    const result = await tossPlan({
+      itemId,
+      projectId: project.projectId,
+      planId,
+      body,
+      currentUserId: c.get('currentUserId'),
+      currentMemberId: project.memberId,
+      isDirector: project.isDirector,
+    });
+    return c.json({ data: result });
+  })
+
+  .post('/:planId/complete', async (c) => {
+    const itemId = c.get('itemId');
+    const project = c.get('project');
+    const planId = c.req.param('planId');
+    if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
+    const result = await completePlan({
+      itemId,
+      projectId: project.projectId,
+      planId,
+      currentUserId: c.get('currentUserId'),
+      currentMemberId: project.memberId,
+      isDirector: project.isDirector,
+    });
+    return c.json({ data: result });
+  });

--- a/apps/web/server/routes/v1/projects.ts
+++ b/apps/web/server/routes/v1/projects.ts
@@ -28,6 +28,7 @@ import {
 } from '../../services/items.js';
 import { ApiException } from '../../lib/errors.js';
 import { membersRoute } from './members.js';
+import { plansRoute } from './plans.js';
 
 export const projectsRoute = new Hono()
   .use('*', requireAuth())
@@ -127,4 +128,7 @@ export const projectsRoute = new Hono()
   )
 
   // ----------------------------- /projects/:projectId/members -----------------------------
-  .route('/:projectId/members', membersRoute);
+  .route('/:projectId/members', membersRoute)
+
+  // ----------------------------- /projects/:projectId/items/:itemId/plans -----------------------------
+  .route('/:projectId/items/:itemId/plans', plansRoute);

--- a/apps/web/server/schemas/plans.test.ts
+++ b/apps/web/server/schemas/plans.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createPlanBodySchema,
+  setSuccessorBodySchema,
+  tossBodySchema,
+  updatePlanBodySchema,
+} from './plans.js';
+
+describe('createPlanBodySchema', () => {
+  const base = {
+    title: 'デザイン依頼',
+    category: 'design',
+    scheduledDate: '2026-06-01',
+    fromMemberId: '11111111-1111-1111-1111-111111111111',
+    toMemberId: '22222222-2222-2222-2222-222222222222',
+  };
+
+  it('accepts a valid body', () => {
+    expect(createPlanBodySchema.safeParse(base).success).toBe(true);
+  });
+
+  it('rejects identical from / to', () => {
+    const r = createPlanBodySchema.safeParse({
+      ...base,
+      toMemberId: base.fromMemberId,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects invalid category', () => {
+    const r = createPlanBodySchema.safeParse({ ...base, category: 'invalid' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects dueDate before scheduledDate', () => {
+    const r = createPlanBodySchema.safeParse({
+      ...base,
+      scheduledDate: '2026-06-10',
+      dueDate: '2026-06-01',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts each of the 6 allowed categories', () => {
+    for (const c of ['wireframe', 'design', 'coding', 'review', 'meeting', 'other']) {
+      expect(createPlanBodySchema.safeParse({ ...base, category: c }).success).toBe(true);
+    }
+  });
+});
+
+describe('updatePlanBodySchema', () => {
+  it('accepts an empty body', () => {
+    expect(updatePlanBodySchema.safeParse({}).success).toBe(true);
+  });
+
+  it('accepts memo = null (clears memo)', () => {
+    expect(updatePlanBodySchema.safeParse({ memo: null }).success).toBe(true);
+  });
+});
+
+describe('setSuccessorBodySchema', () => {
+  it('accepts null successorPlanId', () => {
+    expect(setSuccessorBodySchema.safeParse({ successorPlanId: null }).success).toBe(true);
+  });
+
+  it('rejects malformed uuid', () => {
+    expect(setSuccessorBodySchema.safeParse({ successorPlanId: 'not-a-uuid' }).success).toBe(false);
+  });
+});
+
+describe('tossBodySchema', () => {
+  it('accepts empty body (defaults to no member override)', () => {
+    expect(tossBodySchema.safeParse({}).success).toBe(true);
+  });
+});

--- a/apps/web/server/schemas/plans.ts
+++ b/apps/web/server/schemas/plans.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+
+const isoDate = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format.');
+
+const uuid = z.string().uuid();
+
+export const planCategoryValues = [
+  'wireframe',
+  'design',
+  'coding',
+  'review',
+  'meeting',
+  'other',
+] as const;
+export const planCategorySchema = z.enum(planCategoryValues);
+export type PlanCategory = z.infer<typeof planCategorySchema>;
+
+export const createPlanBodySchema = z
+  .object({
+    title: z.string().trim().min(1).max(255),
+    category: planCategorySchema,
+    scheduledDate: isoDate,
+    dueDate: isoDate.optional(),
+    fromMemberId: uuid,
+    toMemberId: uuid,
+    successorPlanId: uuid.optional(),
+    memo: z.string().max(2000).optional(),
+  })
+  .refine((v) => v.fromMemberId !== v.toMemberId, {
+    path: ['toMemberId'],
+    message: 'fromMemberId and toMemberId must differ.',
+  })
+  .refine((v) => !v.dueDate || v.dueDate >= v.scheduledDate, {
+    path: ['dueDate'],
+    message: 'dueDate must be on or after scheduledDate.',
+  });
+export type CreatePlanBody = z.infer<typeof createPlanBodySchema>;
+
+export const updatePlanBodySchema = z
+  .object({
+    title: z.string().trim().min(1).max(255).optional(),
+    category: planCategorySchema.optional(),
+    scheduledDate: isoDate.optional(),
+    dueDate: isoDate.nullable().optional(),
+    memo: z.string().max(2000).nullable().optional(),
+  })
+  .refine(
+    (v) => {
+      if (v.scheduledDate && v.dueDate) return v.dueDate >= v.scheduledDate;
+      return true;
+    },
+    { path: ['dueDate'], message: 'dueDate must be on or after scheduledDate.' },
+  );
+export type UpdatePlanBody = z.infer<typeof updatePlanBodySchema>;
+
+export const setSuccessorBodySchema = z.object({
+  successorPlanId: uuid.nullable(),
+});
+export type SetSuccessorBody = z.infer<typeof setSuccessorBodySchema>;
+
+export const listPlansQuerySchema = z.object({
+  from: isoDate.optional(),
+  to: isoDate.optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+export type ListPlansQuery = z.infer<typeof listPlansQuerySchema>;
+
+export const tossBodySchema = z.object({
+  toMemberId: uuid.optional(),
+});
+export type TossBody = z.infer<typeof tossBodySchema>;

--- a/apps/web/server/services/ballActions.ts
+++ b/apps/web/server/services/ballActions.ts
@@ -1,0 +1,234 @@
+import { prisma, type Prisma } from '@trakon/db';
+
+import { ApiException } from '../lib/errors.js';
+import type { TossBody } from '../schemas/plans.js';
+import { toPlanDTO, type PlanDTO } from './plans.js';
+
+export type TossResult = {
+  plan: PlanDTO;
+  autoTossed: PlanDTO | null;
+};
+
+export type CompleteResult = {
+  plan: PlanDTO;
+  autoTossed: PlanDTO | null;
+};
+
+const PLAN_INCLUDE = {
+  fromMember: true,
+  toMember: true,
+  ballEvents: {
+    include: { actorMember: true },
+    orderBy: { occurredAt: 'desc' as const },
+  },
+} as const;
+
+type PlanWithIncludes = Prisma.PlanGetPayload<{ include: typeof PLAN_INCLUDE }>;
+
+async function loadPlanWithIncludes(
+  tx: Prisma.TransactionClient,
+  planId: string,
+  itemId: string,
+): Promise<PlanWithIncludes> {
+  const row = await tx.plan.findFirst({
+    where: { id: planId, itemId, deletedAt: null },
+    include: PLAN_INCLUDE,
+  });
+  if (!row) throw new ApiException('NOT_FOUND', 404, 'Plan not found.');
+  return row;
+}
+
+function ballAlreadyTossed(plan: PlanWithIncludes): boolean {
+  return plan.ballEvents.some((e) => e.eventType === 'tossed');
+}
+
+function ballHolderMemberId(plan: PlanWithIncludes): string | null {
+  if (plan.ballEvents.length === 0) return plan.fromMemberId;
+  // ball_events は occurredAt DESC で取得しているので [0] が最新
+  const latest = plan.ballEvents[0];
+  if (latest?.eventType === 'tossed') return plan.toMemberId;
+  return plan.toMemberId; // completed も to
+}
+
+async function recordAudit(input: {
+  tx: Prisma.TransactionClient;
+  actorUserId: string;
+  action: 'toss' | 'complete' | 'auto_toss';
+  planId: string;
+}): Promise<void> {
+  await input.tx.auditLog.create({
+    data: {
+      actorUserId: input.actorUserId,
+      action: input.action,
+      resourceType: 'plan',
+      resourceId: input.planId,
+      result: 'success',
+    },
+  });
+}
+
+// -----------------------------------------------------------------------------
+// TOSS
+// -----------------------------------------------------------------------------
+export async function tossPlan(input: {
+  itemId: string;
+  projectId: string;
+  planId: string;
+  body: TossBody;
+  currentUserId: string;
+  currentMemberId: string;
+  isDirector: boolean;
+}): Promise<TossResult> {
+  const result = await prisma.$transaction(async (tx) => {
+    const plan = await loadPlanWithIncludes(tx, input.planId, input.itemId);
+
+    if (plan.status !== 'active') {
+      throw new ApiException('PLAN_NOT_ACTIVE', 422, 'Plan is not active.');
+    }
+    if (ballAlreadyTossed(plan)) {
+      throw new ApiException('ALREADY_TOSSED', 409, 'Ball has already been tossed.');
+    }
+
+    // 認可: 現在の Ball Holder (= fromMember) または ディレクター
+    const holder = ballHolderMemberId(plan);
+    if (!input.isDirector && holder !== input.currentMemberId) {
+      throw new ApiException('FORBIDDEN', 403, 'Only the ball holder or director can toss.');
+    }
+
+    // 任意で TOSS 先を変更
+    if (input.body.toMemberId && input.body.toMemberId !== plan.toMemberId) {
+      const validMember = await tx.projectMember.findFirst({
+        where: {
+          id: input.body.toMemberId,
+          projectId: input.projectId,
+          deletedAt: null,
+        },
+        select: { id: true },
+      });
+      if (!validMember) {
+        throw new ApiException(
+          'INVALID_TO_MEMBER',
+          422,
+          'toMemberId does not belong to this project.',
+        );
+      }
+      if (validMember.id === plan.fromMemberId) {
+        throw new ApiException(
+          'INVALID_TO_MEMBER',
+          422,
+          'TOSS target must differ from the current ball holder.',
+        );
+      }
+      await tx.plan.update({
+        where: { id: plan.id },
+        data: { toMemberId: validMember.id },
+      });
+    }
+
+    await tx.ballEvent.create({
+      data: {
+        planId: plan.id,
+        eventType: 'tossed',
+        source: 'human',
+        actorMemberId: input.currentMemberId,
+        actorUserId: input.currentUserId,
+      },
+    });
+
+    await recordAudit({
+      tx,
+      actorUserId: input.currentUserId,
+      action: 'toss',
+      planId: plan.id,
+    });
+
+    const refreshed = await loadPlanWithIncludes(tx, plan.id, input.itemId);
+    return refreshed;
+  });
+
+  return { plan: toPlanDTO(result, []), autoTossed: null };
+}
+
+// -----------------------------------------------------------------------------
+// Complete (with auto-chain TOSS)
+// -----------------------------------------------------------------------------
+export async function completePlan(input: {
+  itemId: string;
+  projectId: string;
+  planId: string;
+  currentUserId: string;
+  currentMemberId: string;
+  isDirector: boolean;
+}): Promise<CompleteResult> {
+  const result = await prisma.$transaction(async (tx) => {
+    const plan = await loadPlanWithIncludes(tx, input.planId, input.itemId);
+
+    if (plan.status !== 'active') {
+      throw new ApiException('PLAN_NOT_ACTIVE', 422, 'Plan is not active.');
+    }
+    // 認可: 現在の Ball Holder か ディレクター
+    const holder = ballHolderMemberId(plan);
+    if (!input.isDirector && holder !== input.currentMemberId) {
+      throw new ApiException(
+        'FORBIDDEN',
+        403,
+        'Only the ball holder or director can complete.',
+      );
+    }
+
+    await tx.ballEvent.create({
+      data: {
+        planId: plan.id,
+        eventType: 'completed',
+        source: 'human',
+        actorMemberId: input.currentMemberId,
+        actorUserId: input.currentUserId,
+      },
+    });
+    await tx.plan.update({
+      where: { id: plan.id },
+      data: { status: 'completed', completedAt: new Date() },
+    });
+    await recordAudit({
+      tx,
+      actorUserId: input.currentUserId,
+      action: 'complete',
+      planId: plan.id,
+    });
+
+    // 自動連鎖 (Phase 0 は同一 item 内、1 段のみ)
+    let autoTossed: PlanWithIncludes | null = null;
+    if (plan.successorPlanId) {
+      const successor = await tx.plan.findFirst({
+        where: { id: plan.successorPlanId, itemId: input.itemId, deletedAt: null },
+        include: PLAN_INCLUDE,
+      });
+      if (successor && successor.status === 'active' && !ballAlreadyTossed(successor)) {
+        await tx.ballEvent.create({
+          data: {
+            planId: successor.id,
+            eventType: 'tossed',
+            source: 'auto_chain',
+            actorMemberId: null,
+            actorUserId: null,
+          },
+        });
+        await recordAudit({
+          tx,
+          actorUserId: input.currentUserId,
+          action: 'auto_toss',
+          planId: successor.id,
+        });
+        autoTossed = await loadPlanWithIncludes(tx, successor.id, input.itemId);
+      }
+    }
+
+    const completed = await loadPlanWithIncludes(tx, plan.id, input.itemId);
+    return { completed, autoTossed };
+  });
+
+  return {
+    plan: toPlanDTO(result.completed, []),
+    autoTossed: result.autoTossed ? toPlanDTO(result.autoTossed, []) : null,
+  };
+}

--- a/apps/web/server/services/plans.ts
+++ b/apps/web/server/services/plans.ts
@@ -1,0 +1,369 @@
+import { prisma, type Prisma } from '@trakon/db';
+import { deriveBallHolder, pickLatestBallEvent } from '@trakon/shared';
+
+import { ApiException } from '../lib/errors.js';
+import type {
+  CreatePlanBody,
+  ListPlansQuery,
+  PlanCategory,
+  SetSuccessorBody,
+  UpdatePlanBody,
+} from '../schemas/plans.js';
+
+export type MemberRef = {
+  id: string;
+  name: string;
+  organizationName: string;
+  memberType: 'client' | 'production';
+};
+
+export type BallEventDTO = {
+  id: string;
+  eventType: 'tossed' | 'completed';
+  source: 'human' | 'auto_chain';
+  actor: MemberRef | null;
+  occurredAt: string;
+  note: string | null;
+};
+
+export type PlanDTO = {
+  id: string;
+  itemId: string;
+  planType: 'toss';
+  title: string;
+  category: PlanCategory;
+  scheduledDate: string;
+  dueDate: string | null;
+  fromMember: MemberRef | null;
+  toMember: MemberRef | null;
+  successorPlanId: string | null;
+  status: 'active' | 'completed' | 'canceled';
+  memo: string | null;
+  ballHolder: MemberRef | null;
+  ballState: 'ready' | 'tossed' | 'completed';
+  latestEvent: BallEventDTO | null;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PlanWithEventsDTO = {
+  plan: PlanDTO;
+  events: BallEventDTO[];
+};
+
+function toDateString(d: Date | null | undefined): string | null {
+  return d ? d.toISOString().slice(0, 10) : null;
+}
+
+function toMemberRef(m: {
+  id: string;
+  name: string;
+  organizationName: string;
+  memberType: string;
+} | null | undefined): MemberRef | null {
+  if (!m) return null;
+  return {
+    id: m.id,
+    name: m.name,
+    organizationName: m.organizationName,
+    memberType: m.memberType as 'client' | 'production',
+  };
+}
+
+type PlanRow = Prisma.PlanGetPayload<{
+  include: {
+    fromMember: true;
+    toMember: true;
+    ballEvents: {
+      include: { actorMember: true };
+      orderBy: { occurredAt: 'desc' };
+    };
+  };
+}>;
+
+function toEventDTO(ev: PlanRow['ballEvents'][number]): BallEventDTO {
+  return {
+    id: ev.id,
+    eventType: ev.eventType as 'tossed' | 'completed',
+    source: ev.source as 'human' | 'auto_chain',
+    actor: toMemberRef(ev.actorMember),
+    occurredAt: ev.occurredAt.toISOString(),
+    note: ev.note,
+  };
+}
+
+export function toPlanDTO(row: PlanRow, members: PlanRow['fromMember'][]): PlanDTO {
+  const fromMember = toMemberRef(row.fromMember);
+  const toMember = toMemberRef(row.toMember);
+  const eventsDesc = row.ballEvents; // already DESC
+  const latest = pickLatestBallEvent(
+    eventsDesc.map((e) => ({
+      eventType: e.eventType as 'tossed' | 'completed',
+      source: e.source as 'human' | 'auto_chain',
+      occurredAt: e.occurredAt,
+    })),
+  );
+  const holder = deriveBallHolder(
+    { fromMemberId: row.fromMemberId, toMemberId: row.toMemberId, status: row.status as 'active' | 'completed' | 'canceled' },
+    latest,
+  );
+
+  let ballHolder: MemberRef | null = null;
+  if (holder.memberId === row.fromMemberId) ballHolder = fromMember;
+  else if (holder.memberId === row.toMemberId) ballHolder = toMember;
+  else if (holder.memberId) {
+    const found = members.find((m) => m?.id === holder.memberId);
+    ballHolder = toMemberRef(found ?? null);
+  }
+
+  const latestEventDTO = eventsDesc[0] ? toEventDTO(eventsDesc[0]) : null;
+
+  return {
+    id: row.id,
+    itemId: row.itemId,
+    planType: row.planType as 'toss',
+    title: row.title,
+    category: row.category as PlanCategory,
+    scheduledDate: toDateString(row.scheduledDate)!,
+    dueDate: toDateString(row.dueDate),
+    fromMember,
+    toMember,
+    successorPlanId: row.successorPlanId,
+    status: row.status as 'active' | 'completed' | 'canceled',
+    memo: row.memo,
+    ballHolder,
+    ballState: holder.state,
+    latestEvent: latestEventDTO,
+    completedAt: row.completedAt?.toISOString() ?? null,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+const PLAN_INCLUDE = {
+  fromMember: true,
+  toMember: true,
+  ballEvents: {
+    include: { actorMember: true },
+    orderBy: { occurredAt: 'desc' as const },
+  },
+} as const;
+
+// -----------------------------------------------------------------------------
+// list / get
+// -----------------------------------------------------------------------------
+
+export async function listPlans(input: {
+  itemId: string;
+  query: ListPlansQuery;
+}): Promise<{ items: PlanDTO[]; total: number }> {
+  const where: Prisma.PlanWhereInput = {
+    itemId: input.itemId,
+    deletedAt: null,
+    ...(input.query.from && { scheduledDate: { gte: new Date(`${input.query.from}T00:00:00Z`) } }),
+    ...(input.query.to && {
+      scheduledDate: {
+        ...(input.query.from && { gte: new Date(`${input.query.from}T00:00:00Z`) }),
+        lte: new Date(`${input.query.to}T00:00:00Z`),
+      },
+    }),
+  };
+  const [rows, total] = await Promise.all([
+    prisma.plan.findMany({
+      where,
+      orderBy: [{ scheduledDate: 'asc' }, { createdAt: 'asc' }],
+      include: PLAN_INCLUDE,
+      take: input.query.limit,
+      skip: input.query.offset,
+    }),
+    prisma.plan.count({ where }),
+  ]);
+  return { items: rows.map((r) => toPlanDTO(r, [])), total };
+}
+
+export async function getPlan(input: { itemId: string; planId: string }): Promise<PlanWithEventsDTO> {
+  const row = await prisma.plan.findFirst({
+    where: { id: input.planId, itemId: input.itemId, deletedAt: null },
+    include: PLAN_INCLUDE,
+  });
+  if (!row) throw new ApiException('NOT_FOUND', 404, 'Plan not found.');
+  return {
+    plan: toPlanDTO(row, []),
+    events: row.ballEvents.map(toEventDTO),
+  };
+}
+
+// -----------------------------------------------------------------------------
+// create / update / delete
+// -----------------------------------------------------------------------------
+
+async function assertMembersBelongToProject(input: {
+  projectId: string;
+  memberIds: string[];
+}): Promise<void> {
+  const found = await prisma.projectMember.findMany({
+    where: { projectId: input.projectId, id: { in: input.memberIds }, deletedAt: null },
+    select: { id: true },
+  });
+  if (found.length !== input.memberIds.length) {
+    throw new ApiException(
+      'INVALID_MEMBER',
+      422,
+      'Some member ids do not belong to this project.',
+    );
+  }
+}
+
+async function assertSuccessorAvailable(input: {
+  successorPlanId: string;
+  itemId: string;
+  excludePlanId?: string;
+}): Promise<void> {
+  const target = await prisma.plan.findFirst({
+    where: { id: input.successorPlanId, itemId: input.itemId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!target) {
+    throw new ApiException(
+      'SUCCESSOR_OUT_OF_SCOPE',
+      422,
+      'successorPlanId must reference a plan within the same item.',
+    );
+  }
+  // 既に別 plan の successor として使われていないか
+  const occupier = await prisma.plan.findFirst({
+    where: {
+      successorPlanId: input.successorPlanId,
+      ...(input.excludePlanId && { id: { not: input.excludePlanId } }),
+    },
+    select: { id: true },
+  });
+  if (occupier) {
+    throw new ApiException(
+      'SUCCESSOR_ALREADY_USED',
+      422,
+      'successorPlanId is already used by another plan.',
+    );
+  }
+}
+
+export async function createPlan(input: {
+  itemId: string;
+  projectId: string;
+  body: CreatePlanBody;
+}): Promise<PlanDTO> {
+  await assertMembersBelongToProject({
+    projectId: input.projectId,
+    memberIds: [input.body.fromMemberId, input.body.toMemberId],
+  });
+  if (input.body.successorPlanId) {
+    await assertSuccessorAvailable({
+      successorPlanId: input.body.successorPlanId,
+      itemId: input.itemId,
+    });
+  }
+
+  const row = await prisma.plan.create({
+    data: {
+      itemId: input.itemId,
+      title: input.body.title,
+      category: input.body.category,
+      scheduledDate: new Date(`${input.body.scheduledDate}T00:00:00Z`),
+      dueDate: input.body.dueDate ? new Date(`${input.body.dueDate}T00:00:00Z`) : null,
+      fromMemberId: input.body.fromMemberId,
+      toMemberId: input.body.toMemberId,
+      successorPlanId: input.body.successorPlanId ?? null,
+      memo: input.body.memo ?? null,
+    },
+    include: PLAN_INCLUDE,
+  });
+  return toPlanDTO(row, []);
+}
+
+export async function updatePlan(input: {
+  itemId: string;
+  planId: string;
+  body: UpdatePlanBody;
+}): Promise<PlanDTO> {
+  const existing = await prisma.plan.findFirst({
+    where: { id: input.planId, itemId: input.itemId, deletedAt: null },
+  });
+  if (!existing) throw new ApiException('NOT_FOUND', 404, 'Plan not found.');
+  if (existing.status !== 'active') {
+    throw new ApiException('PLAN_NOT_ACTIVE', 422, 'Plan is not editable.');
+  }
+
+  const data: Prisma.PlanUpdateInput = {};
+  if (input.body.title !== undefined) data.title = input.body.title;
+  if (input.body.category !== undefined) data.category = input.body.category;
+  if (input.body.scheduledDate !== undefined)
+    data.scheduledDate = new Date(`${input.body.scheduledDate}T00:00:00Z`);
+  if (input.body.dueDate !== undefined)
+    data.dueDate = input.body.dueDate ? new Date(`${input.body.dueDate}T00:00:00Z`) : null;
+  if (input.body.memo !== undefined) data.memo = input.body.memo;
+
+  const row = await prisma.plan.update({
+    where: { id: input.planId },
+    data,
+    include: PLAN_INCLUDE,
+  });
+  return toPlanDTO(row, []);
+}
+
+export async function setPlanSuccessor(input: {
+  itemId: string;
+  planId: string;
+  body: SetSuccessorBody;
+}): Promise<PlanDTO> {
+  const existing = await prisma.plan.findFirst({
+    where: { id: input.planId, itemId: input.itemId, deletedAt: null },
+  });
+  if (!existing) throw new ApiException('NOT_FOUND', 404, 'Plan not found.');
+
+  if (input.body.successorPlanId === null) {
+    const row = await prisma.plan.update({
+      where: { id: input.planId },
+      data: { successorPlanId: null },
+      include: PLAN_INCLUDE,
+    });
+    return toPlanDTO(row, []);
+  }
+
+  if (input.body.successorPlanId === input.planId) {
+    throw new ApiException('SELF_SUCCESSOR', 422, 'A plan cannot be its own successor.');
+  }
+  await assertSuccessorAvailable({
+    successorPlanId: input.body.successorPlanId,
+    itemId: input.itemId,
+    excludePlanId: input.planId,
+  });
+
+  const row = await prisma.plan.update({
+    where: { id: input.planId },
+    data: { successorPlanId: input.body.successorPlanId },
+    include: PLAN_INCLUDE,
+  });
+  return toPlanDTO(row, []);
+}
+
+export async function deletePlan(input: { itemId: string; planId: string }): Promise<void> {
+  const existing = await prisma.plan.findFirst({
+    where: { id: input.planId, itemId: input.itemId, deletedAt: null },
+    include: { ballEvents: { select: { id: true } } },
+  });
+  if (!existing) throw new ApiException('NOT_FOUND', 404, 'Plan not found.');
+
+  // ball_events は append-only なので CASCADE 削除できない (FK ON DELETE RESTRICT)
+  // → アプリ層で「ball_events が付いた予定は物理削除拒否」する。Phase 0 のシンプル運用。
+  if (existing.ballEvents.length > 0) {
+    throw new ApiException(
+      'PLAN_HAS_EVENTS',
+      409,
+      'Plan has ball events; cancel instead of deleting (not yet supported).',
+    );
+  }
+
+  // この plan を successor として指す先行 plan があれば自動的に SET NULL される (FK 設定済み)
+  await prisma.plan.delete({ where: { id: input.planId } });
+}

--- a/packages/db/prisma/migrations/20260526000001_init_plans/migration.sql
+++ b/packages/db/prisma/migrations/20260526000001_init_plans/migration.sql
@@ -1,0 +1,150 @@
+-- =============================================================================
+-- Migration: 20260526000001_init_plans
+-- Sub-Phase 0.3: plans / ball_events
+-- 設計書: docs/design/02-database.md §2.4.5, §2.4.6, §2.6
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- CreateTable: plans
+-- -----------------------------------------------------------------------------
+CREATE TABLE "plans" (
+    "id" UUID NOT NULL DEFAULT uuidv7(),
+    "item_id" UUID NOT NULL,
+    "plan_type" TEXT NOT NULL DEFAULT 'toss',
+    "title" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "scheduled_date" DATE NOT NULL,
+    "due_date" DATE,
+    "from_member_id" UUID,
+    "to_member_id" UUID,
+    "successor_plan_id" UUID,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "memo" TEXT,
+    "completed_at" TIMESTAMPTZ,
+    "deleted_at" TIMESTAMPTZ,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "plans_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "ck_plans_plan_type" CHECK ("plan_type" IN ('toss')),
+    CONSTRAINT "ck_plans_category" CHECK ("category" IN (
+        'wireframe', 'design', 'coding', 'review', 'meeting', 'other'
+    )),
+    CONSTRAINT "ck_plans_status" CHECK ("status" IN ('active', 'completed', 'canceled')),
+    CONSTRAINT "ck_plans_title_length" CHECK (char_length("title") BETWEEN 1 AND 255),
+    CONSTRAINT "ck_plans_no_self_successor" CHECK (
+        "successor_plan_id" IS NULL OR "successor_plan_id" <> "id"
+    ),
+    CONSTRAINT "ck_plans_due_date_range" CHECK (
+        "due_date" IS NULL OR "due_date" >= "scheduled_date"
+    ),
+    CONSTRAINT "ck_plans_toss_members" CHECK (
+        "plan_type" <> 'toss'
+        OR ("from_member_id" IS NOT NULL
+            AND "to_member_id" IS NOT NULL
+            AND "from_member_id" <> "to_member_id")
+    )
+);
+
+COMMENT ON TABLE "plans" IS '予定 (Phase 0 は plan_type=toss のみ)';
+COMMENT ON COLUMN "plans"."successor_plan_id" IS '完了時に自動 TOSS される後続予定 (UNIQUE, 自己参照禁止)';
+
+-- -----------------------------------------------------------------------------
+-- CreateTable: ball_events  (append-only)
+-- -----------------------------------------------------------------------------
+CREATE TABLE "ball_events" (
+    "id" UUID NOT NULL DEFAULT uuidv7(),
+    "plan_id" UUID NOT NULL,
+    "event_type" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'human',
+    "actor_member_id" UUID,
+    "actor_user_id" UUID,
+    "occurred_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "note" TEXT,
+
+    CONSTRAINT "ball_events_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "ck_be_event_type" CHECK ("event_type" IN ('tossed', 'completed')),
+    CONSTRAINT "ck_be_source" CHECK ("source" IN ('human', 'auto_chain')),
+    -- human のときは actor 両方 NOT NULL、auto_chain のときは両方 NULL
+    CONSTRAINT "ck_be_actor_consistency" CHECK (
+        ("source" = 'human'
+         AND "actor_member_id" IS NOT NULL
+         AND "actor_user_id" IS NOT NULL)
+        OR
+        ("source" = 'auto_chain'
+         AND "actor_member_id" IS NULL
+         AND "actor_user_id" IS NULL)
+    )
+);
+
+COMMENT ON TABLE "ball_events" IS 'ボール責任移動履歴 (append-only)';
+
+-- -----------------------------------------------------------------------------
+-- Indexes
+-- -----------------------------------------------------------------------------
+CREATE UNIQUE INDEX "uq_plans_successor_plan_id" ON "plans"("successor_plan_id");
+CREATE INDEX "idx_plans_item_scheduled" ON "plans"("item_id", "scheduled_date");
+CREATE INDEX "idx_plans_from_member" ON "plans"("from_member_id");
+CREATE INDEX "idx_plans_to_member" ON "plans"("to_member_id");
+CREATE INDEX "idx_plans_category" ON "plans"("category");
+CREATE INDEX "idx_plans_status_scheduled" ON "plans"("status", "scheduled_date");
+
+CREATE INDEX "idx_be_plan_occurred_desc" ON "ball_events"("plan_id", "occurred_at" DESC);
+CREATE INDEX "idx_be_source" ON "ball_events"("source");
+
+-- -----------------------------------------------------------------------------
+-- Foreign keys
+-- -----------------------------------------------------------------------------
+ALTER TABLE "plans"
+  ADD CONSTRAINT "fk_plans_item_id"
+  FOREIGN KEY ("item_id") REFERENCES "project_items"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "plans"
+  ADD CONSTRAINT "fk_plans_from_member_id"
+  FOREIGN KEY ("from_member_id") REFERENCES "project_members"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "plans"
+  ADD CONSTRAINT "fk_plans_to_member_id"
+  FOREIGN KEY ("to_member_id") REFERENCES "project_members"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "plans"
+  ADD CONSTRAINT "fk_plans_successor_plan_id"
+  FOREIGN KEY ("successor_plan_id") REFERENCES "plans"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "ball_events"
+  ADD CONSTRAINT "fk_be_plan_id"
+  FOREIGN KEY ("plan_id") REFERENCES "plans"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "ball_events"
+  ADD CONSTRAINT "fk_be_actor_member_id"
+  FOREIGN KEY ("actor_member_id") REFERENCES "project_members"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "ball_events"
+  ADD CONSTRAINT "fk_be_actor_user_id"
+  FOREIGN KEY ("actor_user_id") REFERENCES "users"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- -----------------------------------------------------------------------------
+-- Triggers
+-- (関数 trakon_set_updated_at / trakon_reject_mutation は init_auth で作成済み)
+-- -----------------------------------------------------------------------------
+
+-- plans.updated_at 自動更新
+CREATE TRIGGER trg_plans_set_updated_at
+  BEFORE UPDATE ON "plans"
+  FOR EACH ROW EXECUTE FUNCTION trakon_set_updated_at();
+
+-- ball_events append-only 強制 (UPDATE/DELETE 拒否)
+CREATE TRIGGER trg_ball_events_no_update
+  BEFORE UPDATE ON "ball_events"
+  FOR EACH ROW EXECUTE FUNCTION trakon_reject_mutation();
+
+CREATE TRIGGER trg_ball_events_no_delete
+  BEFORE DELETE ON "ball_events"
+  FOR EACH ROW EXECUTE FUNCTION trakon_reject_mutation();

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -43,6 +43,7 @@ model User {
   auditLogs       AuditLog[]
   projectsCreated Project[]       @relation("ProjectsCreatedBy")
   memberships     ProjectMember[]
+  ballEvents      BallEvent[]
 
   @@index([authUserId], map: "idx_users_auth_user_id")
   @@map("users")
@@ -99,9 +100,12 @@ model ProjectMember {
   createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt        DateTime  @default(now()) @map("updated_at") @db.Timestamptz
 
-  project     Project      @relation(fields: [projectId], references: [id], onDelete: Cascade, map: "fk_pm_project_id")
-  user        User?        @relation(fields: [userId], references: [id], onDelete: SetNull, map: "fk_pm_user_id")
-  invitations Invitation[]
+  project           Project      @relation(fields: [projectId], references: [id], onDelete: Cascade, map: "fk_pm_project_id")
+  user              User?        @relation(fields: [userId], references: [id], onDelete: SetNull, map: "fk_pm_user_id")
+  invitations       Invitation[]
+  plansFrom         Plan[]       @relation("PlanFromMember")
+  plansTo           Plan[]       @relation("PlanToMember")
+  ballEventsAsActor BallEvent[]
 
   @@unique([projectId, email], map: "uq_pm_project_email")
   @@index([projectId, sortOrder], map: "idx_pm_project_sort")
@@ -127,9 +131,78 @@ model ProjectItem {
   updatedAt DateTime  @default(now()) @map("updated_at") @db.Timestamptz
 
   project Project @relation(fields: [projectId], references: [id], onDelete: Cascade, map: "fk_pi_project_id")
+  plans   Plan[]
 
   @@index([projectId, sortOrder], map: "idx_pi_project_sort")
   @@map("project_items")
+}
+
+// -----------------------------------------------------------------------------
+// plans — 予定 (Phase 0 は plan_type='toss' のみ)
+// 設計書 §2.4.5
+// -----------------------------------------------------------------------------
+model Plan {
+  id              String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  itemId          String    @map("item_id") @db.Uuid
+  /// 'toss' (Phase 0 / CHECK 制約)
+  planType        String    @default("toss") @map("plan_type")
+  title           String
+  /// 'wireframe' | 'design' | 'coding' | 'review' | 'meeting' | 'other' (CHECK 制約)
+  category        String
+  scheduledDate   DateTime  @map("scheduled_date") @db.Date
+  dueDate         DateTime? @map("due_date") @db.Date
+  fromMemberId    String?   @map("from_member_id") @db.Uuid
+  toMemberId      String?   @map("to_member_id") @db.Uuid
+  /// 後続紐付け (UNIQUE, 自己参照 CHECK で禁止)
+  successorPlanId String?   @unique(map: "uq_plans_successor_plan_id") @map("successor_plan_id") @db.Uuid
+  /// 'active' | 'completed' | 'canceled' (CHECK 制約)
+  status          String    @default("active")
+  memo            String?
+  completedAt     DateTime? @map("completed_at") @db.Timestamptz
+  deletedAt       DateTime? @map("deleted_at") @db.Timestamptz
+  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt       DateTime  @default(now()) @map("updated_at") @db.Timestamptz
+
+  item        ProjectItem    @relation(fields: [itemId], references: [id], onDelete: Cascade, map: "fk_plans_item_id")
+  fromMember  ProjectMember? @relation("PlanFromMember", fields: [fromMemberId], references: [id], onDelete: Restrict, map: "fk_plans_from_member_id")
+  toMember    ProjectMember? @relation("PlanToMember", fields: [toMemberId], references: [id], onDelete: Restrict, map: "fk_plans_to_member_id")
+  successor   Plan?          @relation("PlanSuccessor", fields: [successorPlanId], references: [id], onDelete: SetNull, map: "fk_plans_successor_plan_id")
+  predecessor Plan?          @relation("PlanSuccessor")
+  ballEvents  BallEvent[]
+
+  @@index([itemId, scheduledDate], map: "idx_plans_item_scheduled")
+  @@index([fromMemberId], map: "idx_plans_from_member")
+  @@index([toMemberId], map: "idx_plans_to_member")
+  @@index([category], map: "idx_plans_category")
+  @@index([status, scheduledDate], map: "idx_plans_status_scheduled")
+  @@map("plans")
+}
+
+// -----------------------------------------------------------------------------
+// ball_events — ボール責任移動履歴 (append-only)
+// 設計書 §2.4.6
+// -----------------------------------------------------------------------------
+model BallEvent {
+  id            String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  planId        String   @map("plan_id") @db.Uuid
+  /// 'tossed' | 'completed' (CHECK 制約)
+  eventType     String   @map("event_type")
+  /// 'human' | 'auto_chain' (CHECK 制約 + actor_consistency)
+  source        String   @default("human")
+  /// source='auto_chain' のときは NULL (system actor)
+  actorMemberId String?  @map("actor_member_id") @db.Uuid
+  /// source='auto_chain' のときは NULL (system actor)
+  actorUserId   String?  @map("actor_user_id") @db.Uuid
+  occurredAt    DateTime @default(now()) @map("occurred_at") @db.Timestamptz
+  note          String?
+
+  plan        Plan           @relation(fields: [planId], references: [id], onDelete: Restrict, map: "fk_be_plan_id")
+  actorMember ProjectMember? @relation(fields: [actorMemberId], references: [id], onDelete: Restrict, map: "fk_be_actor_member_id")
+  actorUser   User?          @relation(fields: [actorUserId], references: [id], onDelete: SetNull, map: "fk_be_actor_user_id")
+
+  @@index([planId, occurredAt(sort: Desc)], map: "idx_be_plan_occurred_desc")
+  @@index([source], map: "idx_be_source")
+  @@map("ball_events")
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,17 +9,19 @@
     ".": "./src/index.ts",
     "./constants": "./src/constants/index.ts",
     "./types": "./src/types/index.ts",
-    "./schemas": "./src/schemas/index.ts"
+    "./schemas": "./src/schemas/index.ts",
+    "./domain": "./src/domain/ballHolder.ts"
   },
   "scripts": {
     "lint": "echo '(shared) no lint configured yet'",
     "type-check": "tsc --noEmit",
-    "test": "echo '(shared) no tests yet'"
+    "test": "vitest run"
   },
   "dependencies": {
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.4"
   }
 }

--- a/packages/shared/src/domain/ballHolder.test.ts
+++ b/packages/shared/src/domain/ballHolder.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveBallHolder, pickLatestBallEvent } from './ballHolder.js';
+
+describe('deriveBallHolder', () => {
+  const plan = {
+    fromMemberId: 'from-1',
+    toMemberId: 'to-1',
+    status: 'active' as const,
+  };
+
+  it('returns from member with ready state when no events', () => {
+    const r = deriveBallHolder(plan, null);
+    expect(r).toEqual({ memberId: 'from-1', state: 'ready' });
+  });
+
+  it('returns to member with tossed state on latest tossed event', () => {
+    const r = deriveBallHolder(plan, {
+      eventType: 'tossed',
+      source: 'human',
+      occurredAt: '2026-06-01T00:00:00Z',
+    });
+    expect(r).toEqual({ memberId: 'to-1', state: 'tossed' });
+  });
+
+  it('returns to member with completed state on completed event', () => {
+    const r = deriveBallHolder(plan, {
+      eventType: 'completed',
+      source: 'human',
+      occurredAt: '2026-06-02T00:00:00Z',
+    });
+    expect(r).toEqual({ memberId: 'to-1', state: 'completed' });
+  });
+
+  it('auto_chain tossed is treated same as human tossed', () => {
+    const r = deriveBallHolder(plan, {
+      eventType: 'tossed',
+      source: 'auto_chain',
+      occurredAt: '2026-06-03T00:00:00Z',
+    });
+    expect(r.state).toBe('tossed');
+  });
+});
+
+describe('pickLatestBallEvent', () => {
+  it('returns null on empty', () => {
+    expect(pickLatestBallEvent([])).toBeNull();
+  });
+
+  it('picks the event with the largest occurredAt', () => {
+    const a = { eventType: 'tossed' as const, source: 'human' as const, occurredAt: '2026-06-01T00:00:00Z' };
+    const b = { eventType: 'completed' as const, source: 'human' as const, occurredAt: '2026-06-02T00:00:00Z' };
+    const c = { eventType: 'tossed' as const, source: 'auto_chain' as const, occurredAt: '2026-06-01T12:00:00Z' };
+    expect(pickLatestBallEvent([a, b, c])).toBe(b);
+  });
+});

--- a/packages/shared/src/domain/ballHolder.ts
+++ b/packages/shared/src/domain/ballHolder.ts
@@ -1,0 +1,52 @@
+/**
+ * Ball Holder 導出 (FE/BE 共通)
+ * 設計書 §2.6
+ */
+
+export type PlanState = 'ready' | 'tossed' | 'completed';
+
+export type BallEventLike = {
+  eventType: 'tossed' | 'completed';
+  source: 'human' | 'auto_chain';
+  occurredAt: string | Date;
+};
+
+export type PlanLike = {
+  fromMemberId: string | null;
+  toMemberId: string | null;
+  status: 'active' | 'completed' | 'canceled';
+};
+
+export type BallHolderResult = {
+  /** 現在のホルダー member_id (NULL は導出不能ケース) */
+  memberId: string | null;
+  state: PlanState;
+};
+
+/**
+ * plans + 最新の ball_events から Ball Holder を導出する。
+ *
+ *   - イベント未発生: from_member が Ball Holder, state = 'ready'
+ *   - 最新 = tossed: to_member が Ball Holder, state = 'tossed'
+ *   - 最新 = completed: to_member が Ball Holder (完了者), state = 'completed'
+ */
+export function deriveBallHolder(plan: PlanLike, latestEvent?: BallEventLike | null): BallHolderResult {
+  if (!latestEvent) {
+    return { memberId: plan.fromMemberId, state: 'ready' };
+  }
+  if (latestEvent.eventType === 'tossed') {
+    return { memberId: plan.toMemberId, state: 'tossed' };
+  }
+  return { memberId: plan.toMemberId, state: 'completed' };
+}
+
+/**
+ * `ball_events` の配列から「最新のイベント」を取り出す。
+ * occurredAt の降順ソートを前提としない (呼び出し側でソートしていない可能性に備え)。
+ */
+export function pickLatestBallEvent<T extends BallEventLike>(events: T[]): T | null {
+  if (events.length === 0) return null;
+  return events.reduce((latest, ev) =>
+    new Date(ev.occurredAt) > new Date(latest.occurredAt) ? ev : latest,
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from './constants/index.js';
 export * from './types/index.js';
 export * from './schemas/index.js';
+export * from './domain/ballHolder.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.4
+        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.41)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.3)
 
 packages:
 


### PR DESCRIPTION
## Summary

Phase 0 中核機能の **DB + BE 全体** を一気にまとめた PR。FE は次 PR B（SC-06/07/08 + 楽観更新）で実装します。

## DB（packages/db）

- Prisma に **plans / ball_events** を追加
- マイグレーション `20260526000001_init_plans`：
  - **CHECK 制約**：
    - `ck_plans_plan_type` (`toss` のみ、Phase 1 で ALTER 拡張)
    - `ck_plans_category` (6 値：wireframe/design/coding/review/meeting/other)
    - `ck_plans_status` (active/completed/canceled)
    - `ck_plans_no_self_successor` (自己参照禁止)
    - `ck_plans_toss_members` (toss は from / to 両方 NOT NULL、かつ異なる)
    - `ck_be_event_type` / `ck_be_source` / **`ck_be_actor_consistency`** (human → actor 両方 NOT NULL、auto_chain → 両方 NULL)
  - **UNIQUE**：`uq_plans_successor_plan_id`（後続は 1 つの先行からのみ指される）
  - **FK / ON DELETE**：item → CASCADE / members → RESTRICT / successor → SET NULL / ball_events.plan → RESTRICT
  - **Trigger**：plans.updated_at 自動更新 / ball_events **append-only**（UPDATE / DELETE 拒否）
  - インデックス：item+scheduled_date / from・to_member / category / status+scheduled_date / ball_events plan+occurred_at DESC

## shared（packages/shared）

- `domain/ballHolder.ts`：`deriveBallHolder()` / `pickLatestBallEvent()` を **FE/BE 共通公開**
  - 設計書 §2.6 のシンプル算出に従う：
    - latest event なし → `fromMember` がホルダー
    - 最新 `tossed` / `completed` → `toMember` がホルダー
  - 楽観更新（PR B）と BE 双方で同じ関数を呼ぶ
- `vitest` を shared にも導入（6 tests passing）

## BE（apps/web/server）

- **middleware/itemAuth.ts**：`requireItemInProject()` で `:itemId` が `:projectId` 配下か検証し 404 集約
- **schemas/plans.ts**：createPlanBody / updatePlanBody / setSuccessorBody / tossBody / listPlansQuery
- **services/plans.ts**：
  - list / get / create / update / delete / **setSuccessor**
  - 同一 item 内の successor のみ許可、UNIQUE 違反前にアプリ層で 422 を返す
  - delete は ball_events が無いケースのみ実行可（Phase 0 シンプル運用、append-only 整合性のため。キャンセル機能は Phase 1 で）
- **services/ballActions.ts**：
  - **`tossPlan`**：トランザクション内で `ball_events` (tossed/human) 追記 + 任意 to_member 上書き + audit_logs (`toss`)
  - **`completePlan`**：トランザクション内で `ball_events` (completed/human) 追記 + plans.status='completed' + audit_logs (`complete`)
  - **自動連鎖（v1.1）**：`successor_plan_id` が active かつ未 toss なら system actor で `ball_events` (tossed / **auto_chain**) を追記、`auto_toss` を audit_logs に記録
  - 認可：Ball Holder（= 最新ホルダー）or プロジェクトディレクター。それ以外は **403 FORBIDDEN**
- ルート 8 本を `/projects/:projectId/items/:itemId/plans` 配下に統合

## エラーコード（追加分）

| HTTP | コード | ケース |
|---|---|---|
| 403 | `FORBIDDEN` | Ball Holder / ディレクター以外の TOSS・完了 |
| 409 | `ALREADY_TOSSED` | 既に TOSS 済みの plan に再 toss |
| 409 | `PLAN_HAS_EVENTS` | ball_events が付いた plan の物理削除 |
| 422 | `PLAN_NOT_ACTIVE` | active 以外の plan に対する操作 |
| 422 | `INVALID_MEMBER` / `INVALID_TO_MEMBER` | from / to が同プロジェクト外 |
| 422 | `SUCCESSOR_OUT_OF_SCOPE` | successor が同 item 外 |
| 422 | `SUCCESSOR_ALREADY_USED` | successor が既に別 plan に使われている |
| 422 | `SELF_SUCCESSOR` | 自己参照（DB の CHECK と二重防御） |

## Tests

- `shared/domain/ballHolder.test.ts` 6 ケース（ready / tossed / completed / auto_chain / pickLatest）
- `apps/web/server/schemas/plans.test.ts` 8 ケース（categoy 6 値・from=to 拒否・dueDate 拒否等）
- `apps/web/server/routes/v1/plans.test.ts` 3 ケース（認証なし 401）
- 全体 **39 tests passing**

## 検証

- [x] `pnpm type-check` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test` 通過（39 tests passing）
- [x] `pnpm build` 通過
- [ ] **ローカル E2E**：Supabase + Inbucket 起動後、HTTP クライアントから POST → TOSS → complete → 自動連鎖を確認

## 次（PR B）

- FE：SC-06 縦型カレンダー（CSS Grid、土日・祝日・本日強調）
- FE：SC-07 予定作成・編集モーダル（URL 同期、useFieldArray、successor 設定）
- FE：SC-08 ボール詳細・TOSS・完了モーダル（楽観更新で Ball Holder 即時切替）
- DnD は Sub-Phase 0.3 では含めず、Sub-Phase 0.4 のメンバーかんばん（SC-17）でまとめて導入

🤖 Generated with [Claude Code](https://claude.com/claude-code)