### PR TITLE
Sub-Phase 0.3 PR B: SC-06 縦型カレンダー / SC-07 / SC-08 + 楽観更新 (FE)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@holiday-jp/holiday_jp": "^2.4.1",
     "@hono/node-server": "^1.13.7",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",
@@ -29,6 +30,7 @@
     "@trakon/shared": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "hono": "^4.6.12",
     "jose": "^5.9.6",
     "lucide-react": "^0.460.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,6 +6,7 @@ import { SidebarLayout } from './app/SidebarLayout';
 import { RequireAuth } from './features/auth/RequireAuth';
 import { SC01LoginPage } from './features/auth/SC01LoginPage';
 import { InvitationAcceptPage } from './features/invitations/InvitationAcceptPage';
+import { ItemSchedulePage } from './features/plans/ItemSchedulePage';
 import { MembersPage } from './features/projects/MembersPage';
 import { ProjectCreatePage } from './features/projects/ProjectCreatePage';
 import { ProjectEditPage } from './features/projects/ProjectEditPage';
@@ -30,7 +31,11 @@ export function App() {
         <Route path="/projects/new" element={<ProjectCreatePage />} />
         <Route path="/projects/:projectId/edit" element={<ProjectEditPage />} />
         <Route path="/projects/:projectId/members" element={<MembersPage />} />
-        {/* 詳細画面 (SC-06 縦型カレンダー) は Sub-Phase 0.3 で実装。当面は edit に飛ばす */}
+        <Route
+          path="/projects/:projectId/items/:itemId"
+          element={<ItemSchedulePage />}
+        />
+        {/* /projects/:projectId は当面 edit に飛ばす (詳細ダッシュボードは Phase 1) */}
         <Route path="/projects/:projectId" element={<ProjectRedirectToEdit />} />
       </Route>
 

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "./utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "resize-none border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-input-background px-3 py-2 text-base transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -1,0 +1,305 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { format } from 'date-fns';
+import { CheckCircle2, Loader2, Pencil, Send, Trash2, Zap } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ApiClientError } from '@/lib/api';
+import { useCurrentUser } from '@/features/auth/useCurrentUser';
+import type { ProjectMember } from '@/features/projects/membersApi';
+import { plansApi, plansQueryKey, type BallEvent } from './api';
+import { CATEGORY_STYLE } from './categoryColor';
+import { useCompletePlan, useTossPlan } from './useOptimisticBallAction';
+
+/**
+ * SC-08 ボール詳細・TOSS/完了モーダル
+ *  - ボール状態・履歴表示
+ *  - 認可: Ball Holder 本人 or ディレクター
+ */
+export function BallDetailModal({
+  projectId,
+  itemId,
+  planId,
+  members,
+  onClose,
+  onEdit,
+}: {
+  projectId: string;
+  itemId: string;
+  planId: string;
+  members: ProjectMember[];
+  onClose: () => void;
+  onEdit: () => void;
+}) {
+  const qc = useQueryClient();
+  const [deleting, setDeleting] = useState(false);
+
+  const { data: currentUser } = useCurrentUser();
+  const myUserId = currentUser && !currentUser.requiresProfileCompletion ? currentUser.user.id : null;
+  const myMember = members.find((m) => m.userId === myUserId);
+
+  const detailQuery = useQuery({
+    queryKey: plansQueryKey.detail(projectId, itemId, planId),
+    queryFn: () => plansApi.get(projectId, itemId, planId),
+  });
+
+  const tossMut = useTossPlan({ projectId, itemId, planId });
+  const completeMut = useCompletePlan({ projectId, itemId, planId });
+
+  const deleteMut = useMutation({
+    mutationFn: () => plansApi.remove(projectId, itemId, planId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+      toast.success('予定を削除しました');
+      setDeleting(false);
+      onClose();
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '削除に失敗しました'),
+  });
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg">
+        {detailQuery.isLoading && <DetailSkeleton />}
+        {detailQuery.error && (
+          <DialogHeader>
+            <DialogTitle>取得に失敗しました</DialogTitle>
+            <DialogDescription>時間をおいて再度お試しください。</DialogDescription>
+          </DialogHeader>
+        )}
+        {detailQuery.data &&
+          (() => {
+            const { plan, events } = detailQuery.data;
+            const isBallHolder =
+              !!plan.ballHolder && !!myMember && plan.ballHolder.id === myMember.id;
+            const canAct = plan.status === 'active' && (isBallHolder /* director は BE 側で許可 */);
+            const style = CATEGORY_STYLE[plan.category];
+
+            const handleToss = () => tossMut.mutate(undefined);
+            const handleComplete = () => completeMut.mutate();
+
+            return (
+              <>
+                <DialogHeader>
+                  <DialogTitle className="flex items-center gap-2">
+                    <Badge variant="secondary" className={`${style.bg} ${style.text}`}>
+                      {style.label}
+                    </Badge>
+                    {plan.title}
+                  </DialogTitle>
+                  <DialogDescription>
+                    {format(new Date(plan.scheduledDate), 'yyyy/M/d')}
+                    {plan.dueDate && ` 〜 期日 ${format(new Date(plan.dueDate), 'yyyy/M/d')}`}
+                  </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-3 text-sm">
+                  <BallHolderBanner plan={plan} />
+
+                  <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+                    <dt className="text-muted-foreground">FROM</dt>
+                    <dd>
+                      {plan.fromMember
+                        ? `${plan.fromMember.name} (${plan.fromMember.organizationName || '—'})`
+                        : '—'}
+                    </dd>
+                    <dt className="text-muted-foreground">TO</dt>
+                    <dd>
+                      {plan.toMember
+                        ? `${plan.toMember.name} (${plan.toMember.organizationName || '—'})`
+                        : '—'}
+                    </dd>
+                  </dl>
+                  {plan.memo && (
+                    <div className="rounded-md border border-border bg-muted/40 p-3 text-xs whitespace-pre-wrap">
+                      {plan.memo}
+                    </div>
+                  )}
+                  <Section title="履歴">
+                    <EventTimeline events={events} />
+                  </Section>
+                </div>
+
+                <DialogFooter className="flex w-full justify-between gap-2 sm:justify-between">
+                  <div className="flex gap-1">
+                    {plan.status === 'active' && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={onEdit}
+                        aria-label="編集"
+                      >
+                        <Pencil className="size-4" />
+                      </Button>
+                    )}
+                    {plan.status === 'active' && events.length === 0 && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setDeleting(true)}
+                        aria-label="削除"
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    )}
+                  </div>
+                  <div className="flex gap-2">
+                    {plan.ballState === 'ready' && canAct && (
+                      <Button onClick={handleToss} disabled={tossMut.isPending}>
+                        {tossMut.isPending ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <Send className="size-4" />
+                        )}
+                        TOSS する
+                      </Button>
+                    )}
+                    {plan.ballState === 'tossed' && canAct && (
+                      <Button
+                        onClick={handleComplete}
+                        disabled={completeMut.isPending}
+                      >
+                        {completeMut.isPending ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <CheckCircle2 className="size-4" />
+                        )}
+                        完了する
+                      </Button>
+                    )}
+                    <Button variant="outline" onClick={onClose}>
+                      閉じる
+                    </Button>
+                  </div>
+                </DialogFooter>
+              </>
+            );
+          })()}
+      </DialogContent>
+
+      <AlertDialog open={deleting} onOpenChange={(o) => !o && setDeleting(false)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>予定を削除しますか？</AlertDialogTitle>
+            <AlertDialogDescription>
+              この操作は取り消せません。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                deleteMut.mutate();
+              }}
+              disabled={deleteMut.isPending}
+            >
+              削除する
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Dialog>
+  );
+}
+
+function BallHolderBanner({
+  plan,
+}: {
+  plan: { ballHolder: { name: string } | null; ballState: 'ready' | 'tossed' | 'completed'; status: string };
+}) {
+  if (plan.status === 'completed') {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 p-2 text-xs text-emerald-700">
+        <CheckCircle2 className="size-4" /> 完了済み
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 p-2 text-xs">
+      <span className="text-muted-foreground">現在のホルダー</span>
+      <span className="font-medium">{plan.ballHolder?.name ?? '—'}</span>
+      <Badge variant="secondary" className="ml-auto">
+        {plan.ballState === 'tossed' ? 'TOSS 済み' : 'TOSS 待ち'}
+      </Badge>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h3 className="mb-1.5 text-xs font-medium text-muted-foreground">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function EventTimeline({ events }: { events: BallEvent[] }) {
+  if (events.length === 0) {
+    return <p className="text-xs text-muted-foreground">まだイベントはありません。</p>;
+  }
+  return (
+    <ol className="space-y-1.5">
+      {events.map((e) => (
+        <li
+          key={e.id}
+          className="flex items-center gap-2 rounded-md border border-border px-2 py-1 text-xs"
+        >
+          {e.eventType === 'tossed' ? (
+            <Send className="size-3.5 text-sky-600" />
+          ) : (
+            <CheckCircle2 className="size-3.5 text-emerald-600" />
+          )}
+          <span className="font-medium">
+            {e.eventType === 'tossed' ? 'TOSS' : '完了'}
+          </span>
+          {e.source === 'auto_chain' && (
+            <Badge variant="secondary" className="px-1 py-0 text-[10px]">
+              <Zap className="size-3" />
+              自動連鎖
+            </Badge>
+          )}
+          <span className="text-muted-foreground">
+            by {e.actor?.name ?? 'system'}
+          </span>
+          <span className="ml-auto text-muted-foreground">
+            {format(new Date(e.occurredAt), 'yyyy/M/d HH:mm')}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function DetailSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-6 w-1/2" />
+      <Skeleton className="h-20 w-full" />
+      <Skeleton className="h-20 w-full" />
+    </div>
+  );
+}

--- a/apps/web/src/features/plans/CreatePlanModal.tsx
+++ b/apps/web/src/features/plans/CreatePlanModal.tsx
@@ -1,0 +1,303 @@
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ApiClientError } from '@/lib/api';
+import type { ProjectMember } from '@/features/projects/membersApi';
+import {
+  PLAN_CATEGORIES,
+  plansApi,
+  plansQueryKey,
+  type Plan,
+  type PlanCategory,
+} from './api';
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD 形式');
+
+const schema = z
+  .object({
+    title: z.string().trim().min(1, '予定名は必須').max(255),
+    category: z.enum(PLAN_CATEGORIES.map((c) => c.value) as [PlanCategory, ...PlanCategory[]]),
+    scheduledDate: isoDate,
+    dueDate: z.union([isoDate, z.literal('')]).optional(),
+    fromMemberId: z.string().uuid('FROM を選択してください'),
+    toMemberId: z.string().uuid('TO を選択してください'),
+    successorPlanId: z.string().optional(),
+    memo: z.string().max(2000).optional(),
+  })
+  .refine((v) => v.fromMemberId !== v.toMemberId, {
+    path: ['toMemberId'],
+    message: 'FROM と TO は異なるメンバーを選んでください',
+  })
+  .refine((v) => !v.dueDate || v.dueDate >= v.scheduledDate, {
+    path: ['dueDate'],
+    message: '期日は開始日以降にしてください',
+  });
+type FormValues = z.infer<typeof schema>;
+
+export function CreatePlanModal({
+  projectId,
+  itemId,
+  members,
+  plans,
+  mode,
+  defaultDate,
+  defaultFromMemberId,
+  planId,
+  onClose,
+}: {
+  projectId: string;
+  itemId: string;
+  members: ProjectMember[];
+  plans: Plan[];
+  mode: 'create' | 'edit';
+  defaultDate?: string;
+  defaultFromMemberId?: string;
+  planId?: string;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const editingPlan = mode === 'edit' && planId ? plans.find((p) => p.id === planId) : undefined;
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      title: '',
+      category: 'other',
+      scheduledDate: defaultDate ?? new Date().toISOString().slice(0, 10),
+      dueDate: '',
+      fromMemberId: defaultFromMemberId ?? '',
+      toMemberId: '',
+      successorPlanId: '',
+      memo: '',
+    },
+  });
+
+  useEffect(() => {
+    if (editingPlan) {
+      form.reset({
+        title: editingPlan.title,
+        category: editingPlan.category,
+        scheduledDate: editingPlan.scheduledDate,
+        dueDate: editingPlan.dueDate ?? '',
+        fromMemberId: editingPlan.fromMember?.id ?? '',
+        toMemberId: editingPlan.toMember?.id ?? '',
+        successorPlanId: editingPlan.successorPlanId ?? '',
+        memo: editingPlan.memo ?? '',
+      });
+    }
+  }, [editingPlan, form]);
+
+  const createMut = useMutation({
+    mutationFn: (v: FormValues) =>
+      plansApi.create(projectId, itemId, {
+        title: v.title,
+        category: v.category,
+        scheduledDate: v.scheduledDate,
+        dueDate: v.dueDate || undefined,
+        fromMemberId: v.fromMemberId,
+        toMemberId: v.toMemberId,
+        successorPlanId: v.successorPlanId || undefined,
+        memo: v.memo || undefined,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+      toast.success('予定を作成しました');
+      onClose();
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '作成に失敗しました'),
+  });
+
+  const updateMut = useMutation({
+    mutationFn: (v: FormValues) => {
+      if (!editingPlan) throw new Error('No plan to update');
+      return plansApi.update(projectId, itemId, editingPlan.id, {
+        title: v.title,
+        category: v.category,
+        scheduledDate: v.scheduledDate,
+        dueDate: v.dueDate || null,
+        memo: v.memo ?? null,
+      });
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+      toast.success('予定を更新しました');
+      onClose();
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '更新に失敗しました'),
+  });
+
+  const submitting = createMut.isPending || updateMut.isPending;
+  const onSubmit = (v: FormValues) => (mode === 'edit' ? updateMut.mutate(v) : createMut.mutate(v));
+
+  const successorCandidates = plans.filter(
+    (p) => p.id !== editingPlan?.id && p.status === 'active',
+  );
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{mode === 'edit' ? '予定を編集' : '予定を追加'}</DialogTitle>
+          <DialogDescription>
+            {mode === 'edit'
+              ? '日付やメモなどの基本情報を変更します（TOSS 後は FROM/TO の変更不可）'
+              : 'カレンダー上に予定（ボール）を作成します'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form id="plan-form" onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
+          <Field label="予定名" error={form.formState.errors.title?.message}>
+            <Input {...form.register('title')} autoFocus />
+          </Field>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="カテゴリ" error={form.formState.errors.category?.message}>
+              <SelectField
+                value={form.watch('category')}
+                onChange={(v) => form.setValue('category', v as PlanCategory)}
+                options={PLAN_CATEGORIES.map((c) => ({ value: c.value, label: c.label }))}
+              />
+            </Field>
+            <Field label="開始日" error={form.formState.errors.scheduledDate?.message}>
+              <Input type="date" {...form.register('scheduledDate')} />
+            </Field>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Field
+              label="FROM (現在のホルダー)"
+              error={form.formState.errors.fromMemberId?.message}
+            >
+              <SelectField
+                value={form.watch('fromMemberId') || undefined}
+                onChange={(v) => form.setValue('fromMemberId', v)}
+                disabled={mode === 'edit'}
+                options={members.map((m) => ({ value: m.id, label: `${m.name} (${m.organizationName || '—'})` }))}
+                placeholder="選択"
+              />
+            </Field>
+            <Field label="TO (次の担当)" error={form.formState.errors.toMemberId?.message}>
+              <SelectField
+                value={form.watch('toMemberId') || undefined}
+                onChange={(v) => form.setValue('toMemberId', v)}
+                disabled={mode === 'edit'}
+                options={members.map((m) => ({ value: m.id, label: `${m.name} (${m.organizationName || '—'})` }))}
+                placeholder="選択"
+              />
+            </Field>
+          </div>
+
+          <Field label="期日 (任意)" error={form.formState.errors.dueDate?.message}>
+            <Input type="date" {...form.register('dueDate')} />
+          </Field>
+
+          <Field
+            label="後続の予定 (任意)"
+            hint="この予定が完了したら自動的に次の予定が TOSS されます"
+          >
+            <SelectField
+              value={form.watch('successorPlanId') || undefined}
+              onChange={(v) => form.setValue('successorPlanId', v === '__none__' ? '' : v)}
+              disabled={mode === 'edit'}
+              options={[
+                { value: '__none__', label: '紐付けない' },
+                ...successorCandidates.map((p) => ({ value: p.id, label: p.title })),
+              ]}
+              placeholder="紐付けない"
+            />
+          </Field>
+
+          <Field label="メモ (任意)">
+            <Textarea {...form.register('memo')} rows={3} />
+          </Field>
+        </form>
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onClose} disabled={submitting}>
+            キャンセル
+          </Button>
+          <Button form="plan-form" type="submit" disabled={submitting}>
+            {submitting && <Loader2 className="size-4 animate-spin" />}
+            {mode === 'edit' ? '保存' : '追加'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  error,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  error?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label>{label}</Label>
+      {children}
+      {hint && !error && <p className="text-[11px] text-muted-foreground">{hint}</p>}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+function SelectField({
+  value,
+  onChange,
+  options,
+  placeholder,
+  disabled,
+}: {
+  value?: string;
+  onChange: (v: string) => void;
+  options: { value: string; label: string }[];
+  placeholder?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <Select value={value} onValueChange={onChange} disabled={disabled}>
+      <SelectTrigger>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((o) => (
+          <SelectItem key={o.value} value={o.value}>
+            {o.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -1,0 +1,410 @@
+import { useMemo } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import {
+  addDays,
+  differenceInDays,
+  format,
+  isSameDay,
+  isWeekend,
+  parseISO,
+} from 'date-fns';
+import { isHoliday } from '@holiday-jp/holiday_jp';
+import { ArrowLeft, Plus, CheckCircle2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/components/ui/utils';
+import { projectsApi, projectsQueryKey } from '@/features/projects/api';
+import { membersApi, membersQueryKey, type ProjectMember } from '@/features/projects/membersApi';
+import { plansApi, plansQueryKey, type Plan } from './api';
+import { CATEGORY_STYLE } from './categoryColor';
+import { PlanModalsHost } from './PlanModalsHost';
+
+/**
+ * SC-06 縦型スケジュール (/projects/:projectId/items/:itemId)
+ *  - 縦軸: プロジェクト期間内の日付
+ *  - 横軸: プロジェクトメンバー (受諾済み + 招待中)
+ *  - 予定チップは FROM メンバー列に配置、TO はバッジで明示
+ *  - セルクリック → SC-07 作成モーダル / チップクリック → SC-08 詳細モーダル
+ */
+export function ItemSchedulePage() {
+  const { projectId, itemId } = useParams<{ projectId: string; itemId: string }>();
+  if (!projectId || !itemId) {
+    return <NotFound />;
+  }
+  return <Inner projectId={projectId} itemId={itemId} />;
+}
+
+function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
+  const [, setParams] = useSearchParams();
+
+  const projectQuery = useQuery({
+    queryKey: projectsQueryKey.detail(projectId),
+    queryFn: () => projectsApi.get(projectId),
+  });
+  const itemsQuery = useQuery({
+    queryKey: projectsQueryKey.items(projectId),
+    queryFn: () => projectsApi.listItems(projectId),
+  });
+  const membersQuery = useQuery({
+    queryKey: membersQueryKey.list(projectId),
+    queryFn: () => membersApi.list(projectId),
+  });
+  const plansQuery = useQuery({
+    queryKey: plansQueryKey.list(projectId, itemId),
+    queryFn: () => plansApi.list(projectId, itemId),
+  });
+
+  const project = projectQuery.data;
+  const item = itemsQuery.data?.find((i) => i.id === itemId);
+  const members = useMemo(
+    () => (membersQuery.data ?? []).slice().sort((a, b) => a.sortOrder - b.sortOrder),
+    [membersQuery.data],
+  );
+  const plans = useMemo(() => plansQuery.data ?? [], [plansQuery.data]);
+
+  const days = useMemo(() => {
+    if (!project) return [];
+    const start = parseISO(project.startDate);
+    const end = parseISO(project.endDate);
+    const count = Math.max(0, differenceInDays(end, start) + 1);
+    return Array.from({ length: count }, (_, i) => addDays(start, i));
+  }, [project]);
+
+  // memberId -> column index
+  const memberIndex = useMemo(() => {
+    const map = new Map<string, number>();
+    members.forEach((m, i) => map.set(m.id, i));
+    return map;
+  }, [members]);
+
+  // 日付セルごとに「FROM メンバー列に乗せる plans」を割り当て
+  const plansByCell = useMemo(() => {
+    // key = `${YYYY-MM-DD}|${memberId}`
+    const map = new Map<string, Plan[]>();
+    for (const p of plans) {
+      if (!p.fromMember) continue;
+      const key = `${p.scheduledDate}|${p.fromMember.id}`;
+      const arr = map.get(key) ?? [];
+      arr.push(p);
+      map.set(key, arr);
+    }
+    return map;
+  }, [plans]);
+
+  const loading =
+    projectQuery.isLoading ||
+    itemsQuery.isLoading ||
+    membersQuery.isLoading ||
+    plansQuery.isLoading;
+  const loadFailed = projectQuery.error || itemsQuery.error || membersQuery.error;
+
+  if (loading) return <PageSkeleton />;
+  if (!project || !item || loadFailed) return <NotFound />;
+
+  const openCreateModal = (date: Date, fromMemberId?: string) => {
+    setParams(
+      (sp) => {
+        sp.set('modal', 'create-plan');
+        sp.set('date', format(date, 'yyyy-MM-dd'));
+        if (fromMemberId) sp.set('fromMemberId', fromMemberId);
+        sp.delete('planId');
+        return sp;
+      },
+      { replace: true },
+    );
+  };
+  const openDetailModal = (planId: string) => {
+    setParams(
+      (sp) => {
+        sp.set('modal', 'ball-detail');
+        sp.set('planId', planId);
+        sp.delete('date');
+        sp.delete('fromMemberId');
+        return sp;
+      },
+      { replace: true },
+    );
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex items-center justify-between border-b border-border px-8 py-4">
+        <div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Link to={`/projects/${projectId}/edit`} className="hover:text-foreground">
+              {project.name}
+            </Link>
+            <span>/</span>
+            <span>{item.name}</span>
+          </div>
+          <h1 className="text-lg font-semibold tracking-tight">{item.name}</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" asChild>
+            <Link to={`/projects/${projectId}/edit`}>
+              <ArrowLeft className="size-4" />
+              プロジェクト設定へ
+            </Link>
+          </Button>
+          <Button size="sm" onClick={() => openCreateModal(new Date())}>
+            <Plus className="size-4" />
+            予定を追加
+          </Button>
+        </div>
+      </header>
+
+      {members.length === 0 ? (
+        <div className="m-8 rounded-md border border-dashed border-border p-12 text-center text-sm text-muted-foreground">
+          まずは参加者を追加してください。
+          <div className="mt-3">
+            <Button size="sm" variant="outline" asChild>
+              <Link to={`/projects/${projectId}/members?tab=manage`}>参加者管理を開く</Link>
+            </Button>
+          </div>
+        </div>
+      ) : days.length === 0 ? (
+        <p className="m-8 text-sm text-muted-foreground">プロジェクト期間が設定されていません。</p>
+      ) : (
+        <ScheduleGrid
+          days={days}
+          members={members}
+          plansByCell={plansByCell}
+          onCellClick={openCreateModal}
+          onPlanClick={openDetailModal}
+          memberIndex={memberIndex}
+        />
+      )}
+
+      <PlanModalsHost
+        projectId={projectId}
+        itemId={itemId}
+        members={members}
+        plans={plans}
+      />
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Schedule grid
+// -----------------------------------------------------------------------------
+function ScheduleGrid({
+  days,
+  members,
+  plansByCell,
+  onCellClick,
+  onPlanClick,
+  memberIndex,
+}: {
+  days: Date[];
+  members: ProjectMember[];
+  plansByCell: Map<string, Plan[]>;
+  onCellClick: (date: Date, fromMemberId?: string) => void;
+  onPlanClick: (planId: string) => void;
+  memberIndex: Map<string, number>;
+}) {
+  const gridStyle = {
+    gridTemplateColumns: `100px repeat(${members.length}, minmax(160px, 1fr))`,
+  };
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="grid" style={gridStyle}>
+        {/* ヘッダー行 */}
+        <div className="sticky top-0 z-20 border-b border-r border-border bg-background" />
+        {members.map((m) => (
+          <div
+            key={m.id}
+            className="sticky top-0 z-20 border-b border-r border-border bg-background px-3 py-2 text-xs"
+          >
+            <div className="font-medium text-foreground">{m.name}</div>
+            <div className="truncate text-[10px] text-muted-foreground">
+              {m.organizationName || '—'}
+            </div>
+          </div>
+        ))}
+
+        {/* 日付行 */}
+        {days.map((d) => {
+          const dateStr = format(d, 'yyyy-MM-dd');
+          const weekend = isWeekend(d);
+          const holiday = isHoliday(d);
+          const today = isSameDay(d, new Date());
+          const cellTone = today
+            ? 'bg-amber-50'
+            : holiday
+              ? 'bg-rose-50/60'
+              : weekend
+                ? 'bg-slate-50'
+                : 'bg-background';
+          return (
+            <DayRow
+              key={dateStr}
+              date={d}
+              dateStr={dateStr}
+              members={members}
+              plansByCell={plansByCell}
+              cellTone={cellTone}
+              today={today}
+              holiday={holiday}
+              weekend={weekend}
+              onCellClick={onCellClick}
+              onPlanClick={onPlanClick}
+              memberIndex={memberIndex}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function DayRow({
+  date,
+  dateStr,
+  members,
+  plansByCell,
+  cellTone,
+  today,
+  holiday,
+  weekend,
+  onCellClick,
+  onPlanClick,
+  memberIndex: _memberIndex,
+}: {
+  date: Date;
+  dateStr: string;
+  members: ProjectMember[];
+  plansByCell: Map<string, Plan[]>;
+  cellTone: string;
+  today: boolean;
+  holiday: boolean;
+  weekend: boolean;
+  onCellClick: (date: Date, fromMemberId?: string) => void;
+  onPlanClick: (planId: string) => void;
+  memberIndex: Map<string, number>;
+}) {
+  const weekday = format(date, 'EEEEE'); // 短い曜日
+  const dayLabel = format(date, 'M/d');
+  return (
+    <>
+      <div
+        className={cn(
+          'sticky left-0 z-10 flex flex-col items-center justify-center border-b border-r border-border px-2 py-3 text-xs',
+          cellTone,
+          today && 'font-semibold text-amber-700',
+          holiday && 'text-rose-600',
+        )}
+      >
+        <span>{dayLabel}</span>
+        <span
+          className={cn(
+            'text-[10px]',
+            weekend ? 'text-slate-500' : 'text-muted-foreground',
+            holiday && 'text-rose-500',
+          )}
+        >
+          {weekday}
+        </span>
+      </div>
+      {members.map((m) => {
+        const key = `${dateStr}|${m.id}`;
+        const cellPlans = plansByCell.get(key) ?? [];
+        return (
+          <button
+            key={key}
+            type="button"
+            onClick={() => onCellClick(date, m.id)}
+            className={cn(
+              'group min-h-[64px] border-b border-r border-border p-1 text-left transition-colors',
+              cellTone,
+              'hover:bg-accent/40',
+            )}
+          >
+            <div className="flex flex-col gap-1">
+              {cellPlans.map((p) => (
+                <PlanChip
+                  key={p.id}
+                  plan={p}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onPlanClick(p.id);
+                  }}
+                />
+              ))}
+            </div>
+          </button>
+        );
+      })}
+    </>
+  );
+}
+
+function PlanChip({
+  plan,
+  onClick,
+}: {
+  plan: Plan;
+  onClick: (e: React.MouseEvent) => void;
+}) {
+  const style = CATEGORY_STYLE[plan.category];
+  const completed = plan.status === 'completed';
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(e as unknown as React.MouseEvent);
+        }
+      }}
+      className={cn(
+        'cursor-pointer rounded-md border px-2 py-1 text-xs shadow-sm transition-colors',
+        completed
+          ? 'border-slate-200 bg-slate-100/80 text-slate-500 line-through'
+          : `${style.bg} ${style.border} ${style.text} hover:brightness-95`,
+      )}
+    >
+      <div className="flex items-center justify-between gap-1">
+        <span className="line-clamp-1 font-medium">{plan.title}</span>
+        {completed && <CheckCircle2 className="size-3 shrink-0 text-emerald-500" />}
+      </div>
+      <div className="mt-0.5 flex items-center gap-1 text-[10px] opacity-90">
+        <Badge variant="secondary" className="px-1 py-0 text-[10px]">
+          {style.label}
+        </Badge>
+        {plan.toMember && (
+          <span className="line-clamp-1">→ {plan.toMember.name}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+function PageSkeleton() {
+  return (
+    <div className="space-y-3 p-8">
+      <Skeleton className="h-8 w-1/3" />
+      <Skeleton className="h-[60vh] w-full rounded-md" />
+    </div>
+  );
+}
+
+function NotFound() {
+  return (
+    <div className="mx-auto max-w-3xl px-8 py-20 text-center text-sm text-muted-foreground">
+      ページが見つかりませんでした。
+      <div className="mt-3">
+        <Button asChild variant="outline" size="sm">
+          <Link to="/projects">プロジェクト一覧へ</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/plans/PlanModalsHost.tsx
+++ b/apps/web/src/features/plans/PlanModalsHost.tsx
@@ -1,0 +1,74 @@
+import { useSearchParams } from 'react-router-dom';
+
+import type { ProjectMember } from '@/features/projects/membersApi';
+import { CreatePlanModal } from './CreatePlanModal';
+import { BallDetailModal } from './BallDetailModal';
+import type { Plan } from './api';
+
+/**
+ * URL の `?modal=...` を見て SC-07 / SC-08 を出し分けるホスト。
+ * 各モーダルは閉じる時に URL の modal 系パラメータを掃除する。
+ */
+export function PlanModalsHost({
+  projectId,
+  itemId,
+  members,
+  plans,
+}: {
+  projectId: string;
+  itemId: string;
+  members: ProjectMember[];
+  plans: Plan[];
+}) {
+  const [params, setParams] = useSearchParams();
+  const modal = params.get('modal');
+
+  const closeModal = () => {
+    setParams(
+      (sp) => {
+        for (const k of ['modal', 'date', 'fromMemberId', 'planId']) sp.delete(k);
+        return sp;
+      },
+      { replace: true },
+    );
+  };
+
+  if (modal === 'create-plan' || modal === 'edit-plan') {
+    return (
+      <CreatePlanModal
+        projectId={projectId}
+        itemId={itemId}
+        members={members}
+        plans={plans}
+        mode={modal === 'edit-plan' ? 'edit' : 'create'}
+        defaultDate={params.get('date') ?? undefined}
+        defaultFromMemberId={params.get('fromMemberId') ?? undefined}
+        planId={params.get('planId') ?? undefined}
+        onClose={closeModal}
+      />
+    );
+  }
+
+  if (modal === 'ball-detail' && params.get('planId')) {
+    return (
+      <BallDetailModal
+        projectId={projectId}
+        itemId={itemId}
+        planId={params.get('planId')!}
+        members={members}
+        onClose={closeModal}
+        onEdit={() => {
+          setParams(
+            (sp) => {
+              sp.set('modal', 'edit-plan');
+              return sp;
+            },
+            { replace: true },
+          );
+        }}
+      />
+    );
+  }
+
+  return null;
+}

--- a/apps/web/src/features/plans/api.ts
+++ b/apps/web/src/features/plans/api.ts
@@ -1,0 +1,141 @@
+import { apiRequest } from '@/lib/api';
+
+// =============================================================================
+// 型定義 (BE の DTO と対応)
+// =============================================================================
+
+export type PlanCategory =
+  | 'wireframe'
+  | 'design'
+  | 'coding'
+  | 'review'
+  | 'meeting'
+  | 'other';
+
+export const PLAN_CATEGORIES: { value: PlanCategory; label: string }[] = [
+  { value: 'wireframe', label: 'ワイヤーフレーム' },
+  { value: 'design', label: 'デザイン' },
+  { value: 'coding', label: 'コーディング' },
+  { value: 'review', label: 'レビュー' },
+  { value: 'meeting', label: '打ち合わせ' },
+  { value: 'other', label: 'その他' },
+];
+
+export type MemberRef = {
+  id: string;
+  name: string;
+  organizationName: string;
+  memberType: 'client' | 'production';
+};
+
+export type BallEvent = {
+  id: string;
+  eventType: 'tossed' | 'completed';
+  source: 'human' | 'auto_chain';
+  actor: MemberRef | null;
+  occurredAt: string;
+  note: string | null;
+};
+
+export type Plan = {
+  id: string;
+  itemId: string;
+  planType: 'toss';
+  title: string;
+  category: PlanCategory;
+  scheduledDate: string; // YYYY-MM-DD
+  dueDate: string | null;
+  fromMember: MemberRef | null;
+  toMember: MemberRef | null;
+  successorPlanId: string | null;
+  status: 'active' | 'completed' | 'canceled';
+  memo: string | null;
+  ballHolder: MemberRef | null;
+  ballState: 'ready' | 'tossed' | 'completed';
+  latestEvent: BallEvent | null;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PlanDetail = {
+  plan: Plan;
+  events: BallEvent[];
+};
+
+export type BallActionResult = {
+  plan: Plan;
+  autoTossed: Plan | null;
+};
+
+export type CreatePlanInput = {
+  title: string;
+  category: PlanCategory;
+  scheduledDate: string;
+  dueDate?: string;
+  fromMemberId: string;
+  toMemberId: string;
+  successorPlanId?: string;
+  memo?: string;
+};
+
+export type UpdatePlanInput = Partial<{
+  title: string;
+  category: PlanCategory;
+  scheduledDate: string;
+  dueDate: string | null;
+  memo: string | null;
+}>;
+
+// =============================================================================
+// API client
+// =============================================================================
+
+function basePath(projectId: string, itemId: string) {
+  return `/projects/${projectId}/items/${itemId}/plans`;
+}
+
+export const plansApi = {
+  list: (projectId: string, itemId: string, query?: { from?: string; to?: string }) => {
+    const sp = new URLSearchParams();
+    if (query?.from) sp.set('from', query.from);
+    if (query?.to) sp.set('to', query.to);
+    const q = sp.toString() ? `?${sp.toString()}` : '';
+    return apiRequest<Plan[]>(`${basePath(projectId, itemId)}${q}`);
+  },
+  get: (projectId: string, itemId: string, planId: string) =>
+    apiRequest<PlanDetail>(`${basePath(projectId, itemId)}/${planId}`),
+  create: (projectId: string, itemId: string, body: CreatePlanInput) =>
+    apiRequest<Plan>(`${basePath(projectId, itemId)}`, { method: 'POST', body }),
+  update: (projectId: string, itemId: string, planId: string, body: UpdatePlanInput) =>
+    apiRequest<Plan>(`${basePath(projectId, itemId)}/${planId}`, { method: 'PATCH', body }),
+  remove: (projectId: string, itemId: string, planId: string) =>
+    apiRequest<void>(`${basePath(projectId, itemId)}/${planId}`, { method: 'DELETE' }),
+  setSuccessor: (
+    projectId: string,
+    itemId: string,
+    planId: string,
+    successorPlanId: string | null,
+  ) =>
+    apiRequest<Plan>(`${basePath(projectId, itemId)}/${planId}/successor`, {
+      method: 'PATCH',
+      body: { successorPlanId },
+    }),
+  toss: (projectId: string, itemId: string, planId: string, body?: { toMemberId?: string }) =>
+    apiRequest<BallActionResult>(`${basePath(projectId, itemId)}/${planId}/toss`, {
+      method: 'POST',
+      body: body ?? {},
+    }),
+  complete: (projectId: string, itemId: string, planId: string) =>
+    apiRequest<BallActionResult>(`${basePath(projectId, itemId)}/${planId}/complete`, {
+      method: 'POST',
+      body: {},
+    }),
+};
+
+export const plansQueryKey = {
+  list: (projectId: string, itemId: string) =>
+    ['projects', projectId, 'items', itemId, 'plans'] as const,
+  detail: (projectId: string, itemId: string, planId: string) =>
+    ['projects', projectId, 'items', itemId, 'plans', planId] as const,
+};

--- a/apps/web/src/features/plans/categoryColor.ts
+++ b/apps/web/src/features/plans/categoryColor.ts
@@ -1,0 +1,47 @@
+import type { PlanCategory } from './api';
+
+/**
+ * カテゴリ 6 値の配色 (Tailwind クラス)。
+ * 設計書 SC-07 / SC-08 のカテゴリ表示。完了状態は別途グレーアウト。
+ */
+export const CATEGORY_STYLE: Record<
+  PlanCategory,
+  { bg: string; text: string; border: string; label: string }
+> = {
+  wireframe: {
+    bg: 'bg-violet-50',
+    text: 'text-violet-700',
+    border: 'border-violet-200',
+    label: 'ワイヤー',
+  },
+  design: {
+    bg: 'bg-sky-50',
+    text: 'text-sky-700',
+    border: 'border-sky-200',
+    label: 'デザイン',
+  },
+  coding: {
+    bg: 'bg-emerald-50',
+    text: 'text-emerald-700',
+    border: 'border-emerald-200',
+    label: 'コーディング',
+  },
+  review: {
+    bg: 'bg-amber-50',
+    text: 'text-amber-700',
+    border: 'border-amber-200',
+    label: 'レビュー',
+  },
+  meeting: {
+    bg: 'bg-yellow-50',
+    text: 'text-yellow-700',
+    border: 'border-yellow-200',
+    label: '打ち合わせ',
+  },
+  other: {
+    bg: 'bg-slate-50',
+    text: 'text-slate-700',
+    border: 'border-slate-200',
+    label: 'その他',
+  },
+};

--- a/apps/web/src/features/plans/useOptimisticBallAction.ts
+++ b/apps/web/src/features/plans/useOptimisticBallAction.ts
@@ -1,0 +1,125 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deriveBallHolder } from '@trakon/shared';
+import { toast } from 'sonner';
+
+import { ApiClientError } from '@/lib/api';
+import { plansApi, plansQueryKey, type BallActionResult, type Plan } from './api';
+
+/**
+ * TOSS / 完了の楽観更新フック。
+ * - onMutate で plans 一覧キャッシュを deriveBallHolder で先回り更新
+ * - onError でロールバック
+ * - onSettled で再フェッチ (BE 真値で正当化)
+ *
+ * 設計書 §4.7 Ball Holder 楽観更新
+ */
+function applyOptimistic(plan: Plan, eventType: 'tossed' | 'completed'): Plan {
+  const optimisticEvent = {
+    eventType,
+    source: 'human' as const,
+    occurredAt: new Date().toISOString(),
+  };
+  const holder = deriveBallHolder(
+    {
+      fromMemberId: plan.fromMember?.id ?? null,
+      toMemberId: plan.toMember?.id ?? null,
+      status: plan.status,
+    },
+    optimisticEvent,
+  );
+  const newHolder =
+    holder.memberId === plan.fromMember?.id
+      ? plan.fromMember
+      : holder.memberId === plan.toMember?.id
+        ? plan.toMember
+        : null;
+  return {
+    ...plan,
+    ballHolder: newHolder,
+    ballState: holder.state,
+    status: eventType === 'completed' ? 'completed' : plan.status,
+    latestEvent: {
+      id: 'optimistic',
+      eventType,
+      source: 'human',
+      actor: null,
+      occurredAt: optimisticEvent.occurredAt,
+      note: null,
+    },
+  };
+}
+
+export function useTossPlan(input: { projectId: string; itemId: string; planId: string }) {
+  const qc = useQueryClient();
+  const listKey = plansQueryKey.list(input.projectId, input.itemId);
+  const detailKey = plansQueryKey.detail(input.projectId, input.itemId, input.planId);
+
+  return useMutation<BallActionResult, ApiClientError, { toMemberId?: string } | undefined, { previousList?: Plan[] }>({
+    mutationFn: (body) => plansApi.toss(input.projectId, input.itemId, input.planId, body),
+    onMutate: async () => {
+      await qc.cancelQueries({ queryKey: listKey });
+      const previousList = qc.getQueryData<Plan[]>(listKey);
+      if (previousList) {
+        qc.setQueryData<Plan[]>(
+          listKey,
+          previousList.map((p) =>
+            p.id === input.planId ? applyOptimistic(p, 'tossed') : p,
+          ),
+        );
+      }
+      return { previousList };
+    },
+    onError: (err, _vars, context) => {
+      if (context?.previousList) {
+        qc.setQueryData(listKey, context.previousList);
+      }
+      toast.error(err instanceof ApiClientError ? err.message : 'TOSS に失敗しました');
+    },
+    onSuccess: () => {
+      toast.success('TOSS しました');
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: listKey });
+      qc.invalidateQueries({ queryKey: detailKey });
+    },
+  });
+}
+
+export function useCompletePlan(input: { projectId: string; itemId: string; planId: string }) {
+  const qc = useQueryClient();
+  const listKey = plansQueryKey.list(input.projectId, input.itemId);
+  const detailKey = plansQueryKey.detail(input.projectId, input.itemId, input.planId);
+
+  return useMutation<BallActionResult, ApiClientError, void, { previousList?: Plan[] }>({
+    mutationFn: () => plansApi.complete(input.projectId, input.itemId, input.planId),
+    onMutate: async () => {
+      await qc.cancelQueries({ queryKey: listKey });
+      const previousList = qc.getQueryData<Plan[]>(listKey);
+      if (previousList) {
+        qc.setQueryData<Plan[]>(
+          listKey,
+          previousList.map((p) =>
+            p.id === input.planId ? applyOptimistic(p, 'completed') : p,
+          ),
+        );
+      }
+      return { previousList };
+    },
+    onError: (err, _vars, context) => {
+      if (context?.previousList) {
+        qc.setQueryData(listKey, context.previousList);
+      }
+      toast.error(err instanceof ApiClientError ? err.message : '完了に失敗しました');
+    },
+    onSuccess: (result) => {
+      toast.success('完了しました');
+      if (result.autoTossed) {
+        toast.message('後続の予定に自動 TOSS しました');
+      }
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: listKey });
+      qc.invalidateQueries({ queryKey: detailKey });
+    },
+  });
+}

--- a/apps/web/src/features/projects/ProjectEditPage.tsx
+++ b/apps/web/src/features/projects/ProjectEditPage.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Loader2, Pencil, Plus, Trash2, Users, ArrowLeft, AlertCircle } from 'lucide-react';
+import { Loader2, Pencil, Plus, Trash2, Users, ArrowLeft, AlertCircle, CalendarDays } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -227,6 +227,12 @@ function ItemsSection({
             <li key={it.id} className="flex items-center justify-between gap-2 py-2">
               <div className="text-sm">{it.name}</div>
               <div className="flex gap-1">
+                <Button variant="ghost" size="sm" asChild>
+                  <Link to={`/projects/${projectId}/items/${it.id}`}>
+                    <CalendarDays className="size-4" />
+                    スケジュール
+                  </Link>
+                </Button>
                 <Button
                   variant="ghost"
                   size="icon"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@holiday-jp/holiday_jp':
+        specifier: ^2.4.1
+        version: 2.5.1
       '@hono/node-server':
         specifier: ^1.13.7
         version: 1.19.14(hono@4.12.22)
@@ -69,6 +72,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.3.0
       hono:
         specifier: ^4.6.12
         version: 4.12.22
@@ -688,6 +694,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@holiday-jp/holiday_jp@2.5.1':
+    resolution: {integrity: sha512-KuXfzsp0xlP830WDZRbsHj99wJzamx4fS55usUJFz+oHZmZ4gJfVdyiyv/rIWK+O7RgfHSi5j5Ajy0ZK/Vlnyg==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -1867,6 +1876,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns@4.3.0:
+    resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -4002,6 +4014,8 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@holiday-jp/holiday_jp@2.5.1': {}
+
   '@hono/node-server@1.19.14(hono@4.12.22)':
     dependencies:
       hono: 4.12.22
@@ -5205,6 +5219,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns@4.3.0: {}
 
   debug@4.4.3:
     dependencies:


### PR DESCRIPTION
## Summary

Sub-Phase 0.3 の **FE 一式**。PR #9（DB+BE）で実装した plans / TOSS / 完了 / 自動連鎖を画面化します。これで Sub-Phase 0.3 完了 ✅

## 依存追加

- `date-fns`：日付計算（プロジェクト期間内の日付列挙、表示フォーマット）
- `@holiday-jp/holiday_jp`：日本の祝日判定（FE 直接、ライブラリ計算なので外部 fetch なし）
- shadcn `textarea` をプロトタイプから流用（SC-07 メモ用）

## 共通基盤

- **`features/plans/api.ts`**：plans CRUD + TOSS / complete / successor 設定の `apiRequest` ラッパー + TanStack Query キー設計（`['projects', pid, 'items', iid, 'plans']`）
- **`features/plans/categoryColor.ts`**：カテゴリ 6 値の Tailwind 配色を集約
- **`features/plans/useOptimisticBallAction.ts`**：
  - `@trakon/shared` の `deriveBallHolder()` を呼び `onMutate` で一覧キャッシュを先回り更新
  - `onError` でロールバック、`onSettled` で再フェッチ（設計書 §4.7）
  - TOSS / 完了の両方で利用

## 画面

### SC-06 縦型スケジュール `/projects/:projectId/items/:itemId`

- **CSS Grid**：左に sticky 日付列（100px）+ メンバー列（minmax 160px）
- 土日（slate-50）/ 祝日（rose-50）/ 本日（amber-50）でセル背景を切り替え
- 予定チップは **FROM メンバー列**に配置、TO はチップ内バッジで明示
- セルクリック → SC-07（`?modal=create-plan&date=...&fromMemberId=...`）
- チップクリック → SC-08（`?modal=ball-detail&planId=...`）
- 参加者ゼロ・期間未設定の場合は誘導文を表示

### SC-07 予定作成・編集モーダル

- RHF + Zod、6 カテゴリ Select、successor 任意紐付け
- `create` / `edit` は `?modal=create-plan` / `edit-plan` で切替
- 編集時は **FROM / TO / successor を disabled**（TOSS 後の整合性のため）
- 期日は scheduledDate 以降、FROM ≠ TO のクライアントバリデーション

### SC-08 ボール詳細・TOSS / 完了モーダル

- Ball Holder バナー、FROM / TO、メモ、履歴（`ball_events` タイムライン）
- `source='auto_chain'` イベントは **「自動連鎖」バッジ + ⚡ アイコン**で強調
- TOSS / 完了ボタンは Ball Holder **本人にのみ表示**（BE 側でも再認可、ディレクター操作は BE で許可）
- 完了時は自動連鎖の有無に応じて追加トースト「後続の予定に自動 TOSS しました」
- 履歴なしの予定は削除可、編集モーダルへの導線あり

### PlanModalsHost

`?modal=` 値でモーダルを出し分けるホスト。閉じる時に URL の modal 系パラメータを掃除し、ブラウザ戻るで自然に閉じる。

## ナビ

- **ProjectEditPage** の制作物一覧に「スケジュール」リンクを追加
- **App.tsx** に `/projects/:projectId/items/:itemId` ルート追加

## 検証

- [x] `pnpm type-check` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test` 通過（39 tests passing）
- [x] `pnpm build` 通過
- [ ] **ローカル E2E**：プロジェクト作成 → 制作物開く → セルクリックで作成 → チップクリックで TOSS → 完了で自動連鎖を確認

## これで Sub-Phase 0.3 完了 ✅

マージ後、**Sub-Phase 0.4（ダッシュボード SC-09 + メンバーかんばん SC-17 + DnD）** に進みます。DnD はここで `@dnd-kit` または `react-dnd` を採用予定（プロトタイプは `react-dnd`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)