### PR TITLE
Sub-Phase 0.4: SC-09 ダッシュボード + SC-17 メンバーかんばん (DnD)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "@holiday-jp/holiday_jp": "^2.4.1",
     "@hono/node-server": "^1.13.7",
     "@hookform/resolvers": "^3.9.1",

--- a/apps/web/server/app.ts
+++ b/apps/web/server/app.ts
@@ -4,6 +4,7 @@ import { secureHeaders } from 'hono/secure-headers';
 
 import { errorMiddleware, notFoundHandler } from './middleware/error.js';
 import { authRoute } from './routes/v1/auth.js';
+import { dashboardRoute } from './routes/v1/dashboard.js';
 import { healthRoute } from './routes/v1/healthz.js';
 import { invitationsRoute } from './routes/v1/invitations.js';
 import { projectsRoute } from './routes/v1/projects.js';
@@ -18,6 +19,7 @@ export function createApp() {
   app.route('/api/v1/auth', authRoute);
   app.route('/api/v1/projects', projectsRoute);
   app.route('/api/v1/invitations', invitationsRoute);
+  app.route('/api/v1/users/me', dashboardRoute);
 
   app.notFound(notFoundHandler);
   app.onError(errorMiddleware);

--- a/apps/web/server/routes/v1/dashboard.test.ts
+++ b/apps/web/server/routes/v1/dashboard.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+
+describe('dashboard route', () => {
+  beforeAll(() => {
+    process.env.SUPABASE_URL = 'http://127.0.0.1:54321';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key-1234567890';
+  });
+
+  it('requires authentication for GET /users/me/dashboard', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/users/me/dashboard');
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('AUTH_MISSING');
+  });
+});

--- a/apps/web/server/routes/v1/dashboard.ts
+++ b/apps/web/server/routes/v1/dashboard.ts
@@ -1,0 +1,20 @@
+import { Hono } from 'hono';
+
+import { requireAuth } from '../../middleware/auth.js';
+import { attachCurrentUserId } from '../../middleware/projectAuth.js';
+import { dashboardQuerySchema } from '../../schemas/dashboard.js';
+import { getDashboard } from '../../services/dashboard.js';
+
+/**
+ * `/api/v1/users/me/dashboard`
+ *  - SC-09 ダッシュボード: 今日アクティブな予定をプロジェクト × メンバー で階層集計
+ */
+export const dashboardRoute = new Hono()
+  .use('*', requireAuth())
+  .use('*', attachCurrentUserId())
+  .get('/dashboard', async (c) => {
+    const query = dashboardQuerySchema.parse({ today: c.req.query('today') });
+    const userId = c.get('currentUserId');
+    const dto = await getDashboard({ currentUserId: userId, query });
+    return c.json({ data: dto });
+  });

--- a/apps/web/server/schemas/dashboard.test.ts
+++ b/apps/web/server/schemas/dashboard.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { dashboardQuerySchema } from './dashboard.js';
+
+describe('dashboardQuerySchema', () => {
+  it('accepts empty query', () => {
+    expect(dashboardQuerySchema.safeParse({}).success).toBe(true);
+  });
+
+  it('accepts well-formed YYYY-MM-DD', () => {
+    expect(dashboardQuerySchema.safeParse({ today: '2026-05-25' }).success).toBe(true);
+  });
+
+  it('rejects malformed today', () => {
+    expect(dashboardQuerySchema.safeParse({ today: '2026/05/25' }).success).toBe(false);
+  });
+});

--- a/apps/web/server/schemas/dashboard.ts
+++ b/apps/web/server/schemas/dashboard.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const dashboardQuerySchema = z.object({
+  today: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'today must be YYYY-MM-DD')
+    .optional(),
+});
+export type DashboardQuery = z.infer<typeof dashboardQuerySchema>;

--- a/apps/web/server/services/dashboard.ts
+++ b/apps/web/server/services/dashboard.ts
@@ -1,0 +1,188 @@
+import { prisma } from '@trakon/db';
+import { deriveBallHolder, pickLatestBallEvent } from '@trakon/shared';
+
+import type { DashboardQuery } from '../schemas/dashboard.js';
+
+export type DashboardTaskDTO = {
+  planId: string;
+  projectId: string;
+  itemId: string;
+  itemName: string;
+  title: string;
+  category: 'wireframe' | 'design' | 'coding' | 'review' | 'meeting' | 'other';
+  scheduledDate: string;
+  dueDate: string | null;
+  ballState: 'ready' | 'tossed' | 'completed';
+  isOverdue: boolean;
+};
+
+export type DashboardMemberSectionDTO = {
+  member: {
+    id: string;
+    name: string;
+    organizationName: string;
+    memberType: 'client' | 'production';
+  };
+  tasks: DashboardTaskDTO[];
+};
+
+export type DashboardProjectGroupDTO = {
+  id: string;
+  name: string;
+  memberSections: DashboardMemberSectionDTO[];
+};
+
+export type DashboardDTO = {
+  today: string;
+  summary: {
+    todayTaskCount: number;
+    overdueCount: number;
+  };
+  projects: DashboardProjectGroupDTO[];
+};
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+function todayInJst(): string {
+  const now = new Date();
+  const jst = new Date(now.getTime() + JST_OFFSET_MS);
+  return jst.toISOString().slice(0, 10);
+}
+
+function toDateOnly(d: Date | null | undefined): string | null {
+  return d ? d.toISOString().slice(0, 10) : null;
+}
+
+/**
+ * SC-09 ダッシュボード: 自分が参加するプロジェクト × メンバー × 今日アクティブな予定 の階層集計。
+ * 設計書 §3.6 GET /users/me/dashboard / §4.4 SC-09
+ */
+export async function getDashboard(input: {
+  currentUserId: string;
+  query: DashboardQuery;
+}): Promise<DashboardDTO> {
+  const today = input.query.today ?? todayInJst();
+  const todayDate = new Date(`${today}T00:00:00Z`);
+
+  // 1) 自分が参加するプロジェクト一覧
+  const projects = await prisma.project.findMany({
+    where: {
+      deletedAt: null,
+      members: { some: { userId: input.currentUserId, deletedAt: null } },
+    },
+    orderBy: [{ updatedAt: 'desc' }],
+    include: {
+      members: {
+        where: { deletedAt: null },
+        orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+      },
+      items: { where: { deletedAt: null }, select: { id: true, name: true } },
+    },
+  });
+
+  if (projects.length === 0) {
+    return {
+      today,
+      summary: { todayTaskCount: 0, overdueCount: 0 },
+      projects: [],
+    };
+  }
+
+  // 2) 全プロジェクトの今日アクティブな予定をまとめて取得 (active かつ scheduled <= today)
+  const itemIds = projects.flatMap((p) => p.items.map((it) => it.id));
+
+  const plans = itemIds.length
+    ? await prisma.plan.findMany({
+        where: {
+          itemId: { in: itemIds },
+          deletedAt: null,
+          status: 'active',
+          // 今日以前に scheduled かつ未完了
+          scheduledDate: { lte: todayDate },
+        },
+        include: {
+          ballEvents: {
+            orderBy: { occurredAt: 'desc' },
+            take: 1,
+          },
+        },
+      })
+    : [];
+
+  // itemId -> itemName / projectId のマッピング
+  const itemMap = new Map<string, { name: string; projectId: string }>();
+  for (const p of projects) {
+    for (const it of p.items) itemMap.set(it.id, { name: it.name, projectId: p.id });
+  }
+
+  let todayTaskCount = 0;
+  let overdueCount = 0;
+
+  // memberId -> tasks
+  const tasksByMember = new Map<string, DashboardTaskDTO[]>();
+  for (const plan of plans) {
+    const item = itemMap.get(plan.itemId);
+    if (!item) continue;
+    const latest = pickLatestBallEvent(
+      plan.ballEvents.map((e) => ({
+        eventType: e.eventType as 'tossed' | 'completed',
+        source: e.source as 'human' | 'auto_chain',
+        occurredAt: e.occurredAt,
+      })),
+    );
+    const holder = deriveBallHolder(
+      {
+        fromMemberId: plan.fromMemberId,
+        toMemberId: plan.toMemberId,
+        status: plan.status as 'active' | 'completed' | 'canceled',
+      },
+      latest,
+    );
+    if (!holder.memberId || holder.state === 'completed') continue;
+
+    const dueDate = toDateOnly(plan.dueDate);
+    const isOverdue = !!dueDate && dueDate < today;
+    if (isOverdue) overdueCount += 1;
+    todayTaskCount += 1;
+
+    const task: DashboardTaskDTO = {
+      planId: plan.id,
+      projectId: item.projectId,
+      itemId: plan.itemId,
+      itemName: item.name,
+      title: plan.title,
+      category: plan.category as DashboardTaskDTO['category'],
+      scheduledDate: toDateOnly(plan.scheduledDate)!,
+      dueDate,
+      ballState: holder.state,
+      isOverdue,
+    };
+    const arr = tasksByMember.get(holder.memberId) ?? [];
+    arr.push(task);
+    tasksByMember.set(holder.memberId, arr);
+  }
+
+  // 3) プロジェクト → メンバー → 予定 の階層を組み立て
+  const projectGroups: DashboardProjectGroupDTO[] = projects
+    .map((p) => {
+      const memberSections: DashboardMemberSectionDTO[] = p.members
+        .map((m) => ({
+          member: {
+            id: m.id,
+            name: m.name,
+            organizationName: m.organizationName,
+            memberType: m.memberType as 'client' | 'production',
+          },
+          tasks: tasksByMember.get(m.id) ?? [],
+        }))
+        .filter((s) => s.tasks.length > 0);
+      return { id: p.id, name: p.name, memberSections };
+    })
+    .filter((g) => g.memberSections.length > 0);
+
+  return {
+    today,
+    summary: { todayTaskCount, overdueCount },
+    projects: projectGroups,
+  };
+}

--- a/apps/web/src/app/DashboardPage.tsx
+++ b/apps/web/src/app/DashboardPage.tsx
@@ -1,54 +1,210 @@
-import { useCurrentUser } from '@/features/auth/useCurrentUser';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { supabase } from '@/lib/supabase';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { format, parseISO } from 'date-fns';
+import { ja } from 'date-fns/locale';
+import { AlertTriangle, CheckCircle2, ListChecks } from 'lucide-react';
+
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/components/ui/utils';
+import { CATEGORY_STYLE } from '@/features/plans/categoryColor';
+import {
+  dashboardApi,
+  dashboardQueryKey,
+  type DashboardMemberSection,
+  type DashboardTask,
+} from '@/features/dashboard/api';
 
 /**
- * Sub-Phase 0.1: ダッシュボードはプレースホルダ。
- * 本実装は Sub-Phase 0.4 (SC-09) で行う。
+ * SC-09 ダッシュボード (/dashboard)
+ * 設計書 §4.4 SC-09 + §3.6 GET /users/me/dashboard
  */
 export function DashboardPage() {
-  const { data } = useCurrentUser();
-  const user = data && !data.requiresProfileCompletion ? data.user : null;
+  const { data, isLoading, error } = useQuery({
+    queryKey: dashboardQueryKey.base(),
+    queryFn: () => dashboardApi.get(),
+  });
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-12">
-      <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold tracking-tight">TRAKON</h1>
-        <Button variant="outline" size="sm" onClick={() => supabase.auth.signOut()}>
-          サインアウト
-        </Button>
+    <div className="mx-auto max-w-5xl space-y-6 px-8 py-10">
+      <header>
+        <h1 className="text-xl font-semibold tracking-tight">ダッシュボード</h1>
+        <p className="text-sm text-muted-foreground">
+          {data
+            ? `${format(parseISO(data.today), 'yyyy年 M月d日 (E)', { locale: ja })} 時点で進行中のボール`
+            : '今日のボールを集計中…'}
+        </p>
       </header>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">ようこそ</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2 text-sm">
-          {user ? (
-            <>
-              <p>
-                <span className="text-muted-foreground">表示名 / </span>
-                <span className="font-medium">{user.displayName}</span>
-              </p>
-              <p>
-                <span className="text-muted-foreground">メール / </span>
-                <span className="font-medium">{user.email}</span>
-              </p>
-              <p>
-                <span className="text-muted-foreground">認証方式 / </span>
-                <span className="font-medium">{user.primaryAuthMethod}</span>
-              </p>
-            </>
+      {isLoading && <Loading />}
+      {error && (
+        <Card>
+          <CardContent className="py-6 text-sm text-destructive">
+            ダッシュボードの取得に失敗しました。
+          </CardContent>
+        </Card>
+      )}
+
+      {data && (
+        <>
+          <SummaryCards
+            todayCount={data.summary.todayTaskCount}
+            overdueCount={data.summary.overdueCount}
+          />
+
+          {data.projects.length === 0 ? (
+            <Card>
+              <CardContent className="flex flex-col items-center gap-2 py-12 text-center text-sm text-muted-foreground">
+                <CheckCircle2 className="size-6 text-emerald-500" />
+                今日のタスクはありません。
+              </CardContent>
+            </Card>
           ) : (
-            <p className="text-muted-foreground">ユーザー情報を取得中…</p>
+            <ul className="space-y-5">
+              {data.projects.map((p) => (
+                <li key={p.id}>
+                  <h2 className="mb-2 flex items-center gap-2 text-sm font-semibold">
+                    <span className="inline-block size-2 rounded-full bg-primary" />
+                    <Link to={`/projects/${p.id}/edit`} className="hover:underline">
+                      {p.name}
+                    </Link>
+                    <span className="text-xs font-normal text-muted-foreground">
+                      ({p.memberSections.reduce((s, m) => s + m.tasks.length, 0)} 件)
+                    </span>
+                  </h2>
+                  <ul className="space-y-3">
+                    {p.memberSections.map((s) => (
+                      <li key={s.member.id}>
+                        <MemberSection projectId={p.id} section={s} />
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ul>
           )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+function SummaryCards({
+  todayCount,
+  overdueCount,
+}: {
+  todayCount: number;
+  overdueCount: number;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <Card>
+        <CardContent className="flex items-center gap-3 py-4">
+          <ListChecks className="size-5 text-primary" />
+          <div>
+            <p className="text-xs text-muted-foreground">今日のタスク</p>
+            <p className="text-2xl font-semibold">{todayCount}</p>
+          </div>
         </CardContent>
       </Card>
+      <Card
+        className={cn(
+          overdueCount > 0 ? 'border-rose-300 bg-rose-50' : '',
+        )}
+      >
+        <CardContent className="flex items-center gap-3 py-4">
+          <AlertTriangle
+            className={cn(
+              'size-5',
+              overdueCount > 0 ? 'text-rose-500' : 'text-muted-foreground',
+            )}
+          />
+          <div>
+            <p className="text-xs text-muted-foreground">期限超過</p>
+            <p
+              className={cn(
+                'text-2xl font-semibold',
+                overdueCount > 0 && 'text-rose-700',
+              )}
+            >
+              {overdueCount}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
 
-      <p className="text-sm text-muted-foreground">
-        ダッシュボード本体は Sub-Phase 0.4 で実装します。
-      </p>
-    </main>
+function MemberSection({
+  projectId,
+  section,
+}: {
+  projectId: string;
+  section: DashboardMemberSection;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-3">
+      <div className="mb-2 flex items-center gap-2 text-xs">
+        <span className="font-medium">{section.member.name}</span>
+        <span className="text-muted-foreground">
+          ({section.member.organizationName || '—'})
+        </span>
+        <Badge variant="secondary" className="ml-auto">
+          {section.tasks.length} 件
+        </Badge>
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {section.tasks.map((t) => (
+          <TaskCard key={t.planId} projectId={projectId} task={t} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TaskCard({ projectId, task }: { projectId: string; task: DashboardTask }) {
+  const style = CATEGORY_STYLE[task.category];
+  return (
+    <Link
+      to={`/projects/${projectId}/items/${task.itemId}?modal=ball-detail&planId=${task.planId}`}
+      className={cn(
+        'block rounded-md border px-3 py-2 text-xs transition-colors',
+        task.isOverdue
+          ? 'border-rose-400 bg-rose-50 text-rose-700 hover:bg-rose-100'
+          : `${style.bg} ${style.border} ${style.text} hover:brightness-95`,
+      )}
+    >
+      <div className="mb-1 flex items-center gap-1">
+        <Badge variant="secondary" className="px-1 py-0 text-[10px]">
+          {style.label}
+        </Badge>
+        {task.isOverdue && (
+          <Badge variant="destructive" className="px-1 py-0 text-[10px]">
+            期限超過
+          </Badge>
+        )}
+      </div>
+      <p className="line-clamp-2 font-medium">{task.title}</p>
+      <p className="mt-0.5 line-clamp-1 text-[11px] opacity-80">{task.itemName}</p>
+      {task.dueDate && (
+        <p className="mt-1 text-[10px] opacity-70">期日 {task.dueDate}</p>
+      )}
+    </Link>
+  );
+}
+
+function Loading() {
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-3">
+        <Skeleton className="h-20 rounded-xl" />
+        <Skeleton className="h-20 rounded-xl" />
+      </div>
+      <Skeleton className="h-40 rounded-xl" />
+      <Skeleton className="h-40 rounded-xl" />
+    </div>
   );
 }

--- a/apps/web/src/features/dashboard/api.ts
+++ b/apps/web/src/features/dashboard/api.ts
@@ -1,0 +1,52 @@
+import { apiRequest } from '@/lib/api';
+import type { PlanCategory } from '@/features/plans/api';
+
+export type DashboardTask = {
+  planId: string;
+  projectId: string;
+  itemId: string;
+  itemName: string;
+  title: string;
+  category: PlanCategory;
+  scheduledDate: string;
+  dueDate: string | null;
+  ballState: 'ready' | 'tossed' | 'completed';
+  isOverdue: boolean;
+};
+
+export type DashboardMemberSection = {
+  member: {
+    id: string;
+    name: string;
+    organizationName: string;
+    memberType: 'client' | 'production';
+  };
+  tasks: DashboardTask[];
+};
+
+export type DashboardProjectGroup = {
+  id: string;
+  name: string;
+  memberSections: DashboardMemberSection[];
+};
+
+export type Dashboard = {
+  today: string;
+  summary: {
+    todayTaskCount: number;
+    overdueCount: number;
+  };
+  projects: DashboardProjectGroup[];
+};
+
+export const dashboardApi = {
+  get: (today?: string) => {
+    const q = today ? `?today=${today}` : '';
+    return apiRequest<Dashboard>(`/users/me/dashboard${q}`);
+  },
+};
+
+export const dashboardQueryKey = {
+  base: (today?: string) =>
+    today ? (['dashboard', today] as const) : (['dashboard'] as const),
+};

--- a/apps/web/src/features/plans/MemberKanbanTab.tsx
+++ b/apps/web/src/features/plans/MemberKanbanTab.tsx
@@ -1,0 +1,351 @@
+import { useEffect } from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { format } from 'date-fns';
+import { CheckCircle2, GripVertical, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/components/ui/utils';
+import { ApiClientError } from '@/lib/api';
+import { projectsApi, projectsQueryKey } from '@/features/projects/api';
+import type { ProjectMember } from '@/features/projects/membersApi';
+import { plansApi, plansQueryKey, type Plan } from './api';
+import { CATEGORY_STYLE } from './categoryColor';
+
+/**
+ * SC-17 メンバーかんばん
+ *  - 上部の制作物セレクタで対象 item を選び、その plans をメンバー別にかんばん表示
+ *  - メンバー列間で DnD すると、ドロップ先メンバーへ TOSS (toMemberId 指定)
+ *  - 完了は各カードの「完了する」ボタンで (DnD ではない、シンプル化)
+ */
+export function MemberKanbanTab({
+  projectId,
+  members,
+  selectedItemId,
+  onChangeItem,
+}: {
+  projectId: string;
+  members: ProjectMember[];
+  selectedItemId: string | null;
+  onChangeItem: (itemId: string) => void;
+}) {
+  const itemsQuery = useQuery({
+    queryKey: projectsQueryKey.items(projectId),
+    queryFn: () => projectsApi.listItems(projectId),
+  });
+
+  // 制作物未指定なら最初の制作物を自動選択
+  useEffect(() => {
+    if (!selectedItemId && itemsQuery.data && itemsQuery.data.length > 0) {
+      onChangeItem(itemsQuery.data[0]!.id);
+    }
+  }, [selectedItemId, itemsQuery.data, onChangeItem]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-base">メンバーかんばん</CardTitle>
+          {itemsQuery.data && itemsQuery.data.length > 0 && (
+            <div className="w-64">
+              <Select
+                value={selectedItemId ?? itemsQuery.data[0]?.id ?? ''}
+                onValueChange={onChangeItem}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="制作物を選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  {itemsQuery.data.map((it) => (
+                    <SelectItem key={it.id} value={it.id}>
+                      {it.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {itemsQuery.isLoading || !selectedItemId ? (
+          <Skeleton className="h-64 w-full rounded-md" />
+        ) : (
+          <KanbanBoard
+            projectId={projectId}
+            itemId={selectedItemId}
+            members={members}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// -----------------------------------------------------------------------------
+function KanbanBoard({
+  projectId,
+  itemId,
+  members,
+}: {
+  projectId: string;
+  itemId: string;
+  members: ProjectMember[];
+}) {
+  const qc = useQueryClient();
+  const plansQuery = useQuery({
+    queryKey: plansQueryKey.list(projectId, itemId),
+    queryFn: () => plansApi.list(projectId, itemId),
+  });
+
+  const tossMut = useMutation({
+    mutationFn: ({ planId, toMemberId }: { planId: string; toMemberId: string }) =>
+      plansApi.toss(projectId, itemId, planId, { toMemberId }),
+    onMutate: async ({ planId, toMemberId }) => {
+      await qc.cancelQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+      const prev = qc.getQueryData<Plan[]>(plansQueryKey.list(projectId, itemId));
+      if (prev) {
+        const toMember = members.find((m) => m.id === toMemberId);
+        qc.setQueryData<Plan[]>(
+          plansQueryKey.list(projectId, itemId),
+          prev.map((p) =>
+            p.id === planId
+              ? {
+                  ...p,
+                  toMember: toMember
+                    ? {
+                        id: toMember.id,
+                        name: toMember.name,
+                        organizationName: toMember.organizationName,
+                        memberType: toMember.memberType,
+                      }
+                    : p.toMember,
+                  ballHolder: toMember
+                    ? {
+                        id: toMember.id,
+                        name: toMember.name,
+                        organizationName: toMember.organizationName,
+                        memberType: toMember.memberType,
+                      }
+                    : p.ballHolder,
+                  ballState: 'tossed',
+                }
+              : p,
+          ),
+        );
+      }
+      return { prev };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.prev) {
+        qc.setQueryData(plansQueryKey.list(projectId, itemId), ctx.prev);
+      }
+      toast.error(err instanceof ApiClientError ? err.message : 'TOSS に失敗しました');
+    },
+    onSuccess: () => toast.success('TOSS しました'),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+    },
+  });
+
+  const completeMut = useMutation({
+    mutationFn: (planId: string) => plansApi.complete(projectId, itemId, planId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+      toast.success('完了しました');
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '完了に失敗しました'),
+  });
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  );
+
+  const onDragEnd = (e: DragEndEvent) => {
+    const planId = String(e.active.id);
+    const overMemberId = e.over?.id ? String(e.over.id) : null;
+    if (!overMemberId) return;
+    const plan = plansQuery.data?.find((p) => p.id === planId);
+    if (!plan) return;
+    if (plan.ballHolder?.id === overMemberId) return; // 自列に戻すだけは無視
+    tossMut.mutate({ planId, toMemberId: overMemberId });
+  };
+
+  if (plansQuery.isLoading) return <Skeleton className="h-64 w-full rounded-md" />;
+  if (plansQuery.error)
+    return (
+      <p className="text-sm text-destructive">予定の取得に失敗しました</p>
+    );
+
+  const plans = plansQuery.data ?? [];
+  // active な予定のみ表示。完了済みは隠す（完了済みは SC-06 やダッシュボードで参照）
+  const plansByHolder = new Map<string, Plan[]>();
+  for (const p of plans) {
+    if (p.status !== 'active' || !p.ballHolder) continue;
+    const arr = plansByHolder.get(p.ballHolder.id) ?? [];
+    arr.push(p);
+    plansByHolder.set(p.ballHolder.id, arr);
+  }
+
+  return (
+    <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+      <div className="flex gap-3 overflow-x-auto pb-2">
+        {members.map((m) => (
+          <MemberColumn
+            key={m.id}
+            member={m}
+            plans={plansByHolder.get(m.id) ?? []}
+            tossing={tossMut.isPending}
+            completing={completeMut.isPending}
+            onComplete={(planId) => completeMut.mutate(planId)}
+          />
+        ))}
+      </div>
+    </DndContext>
+  );
+}
+
+// -----------------------------------------------------------------------------
+function MemberColumn({
+  member,
+  plans,
+  tossing,
+  completing,
+  onComplete,
+}: {
+  member: ProjectMember;
+  plans: Plan[];
+  tossing: boolean;
+  completing: boolean;
+  onComplete: (planId: string) => void;
+}) {
+  const { isOver, setNodeRef } = useDroppable({ id: member.id });
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        'flex min-w-[260px] max-w-[280px] flex-col rounded-md border border-border bg-muted/30 p-2 transition-colors',
+        isOver && 'border-primary/60 bg-primary/5',
+        tossing && 'opacity-95',
+      )}
+    >
+      <div className="mb-2 sticky top-0 z-10 rounded-md bg-card px-2 py-1.5">
+        <p className="text-sm font-medium leading-tight">{member.name}</p>
+        <p className="text-[10px] text-muted-foreground">
+          {member.organizationName || '—'}
+        </p>
+        <div className="mt-1 flex items-center gap-1 text-[10px] text-muted-foreground">
+          <Badge variant="secondary" className="px-1 py-0 text-[10px]">
+            担当 {plans.length} 件
+          </Badge>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        {plans.length === 0 ? (
+          <div className="rounded-md border border-dashed border-border bg-background p-3 text-center text-[11px] text-muted-foreground">
+            ボールはありません
+          </div>
+        ) : (
+          plans.map((p) => (
+            <DraggablePlanCard
+              key={p.id}
+              plan={p}
+              completing={completing}
+              onComplete={onComplete}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DraggablePlanCard({
+  plan,
+  completing,
+  onComplete,
+}: {
+  plan: Plan;
+  completing: boolean;
+  onComplete: (planId: string) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: plan.id,
+  });
+  const style = transform
+    ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` }
+    : undefined;
+  const cat = CATEGORY_STYLE[plan.category];
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        'rounded-md border bg-card shadow-sm',
+        cat.border,
+        isDragging && 'opacity-60',
+      )}
+    >
+      <div
+        className={cn(
+          'flex items-center gap-1 rounded-t-md px-2 py-1 text-[10px]',
+          cat.bg,
+          cat.text,
+        )}
+        {...listeners}
+        {...attributes}
+        role="button"
+        tabIndex={0}
+      >
+        <GripVertical className="size-3 opacity-60" />
+        <span>{cat.label}</span>
+        <Badge variant="secondary" className="ml-auto px-1 py-0 text-[10px]">
+          {plan.ballState === 'tossed' ? 'TOSS済' : '準備中'}
+        </Badge>
+      </div>
+      <div className="px-2 py-1.5 text-xs">
+        <p className="line-clamp-2 font-medium">{plan.title}</p>
+        <p className="mt-0.5 text-[10px] text-muted-foreground">
+          {format(new Date(plan.scheduledDate), 'M/d')}
+          {plan.dueDate ? ` 〜 期日 ${format(new Date(plan.dueDate), 'M/d')}` : ''}
+        </p>
+        <div className="mt-1.5 flex justify-end">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 gap-1 text-[11px]"
+            onClick={() => onComplete(plan.id)}
+            disabled={completing}
+          >
+            {completing ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <CheckCircle2 className="size-3" />
+            )}
+            完了する
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/projects/MembersPage.tsx
+++ b/apps/web/src/features/projects/MembersPage.tsx
@@ -4,7 +4,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Loader2, Mail, Plus, Trash2, UsersRound, ArrowLeft } from 'lucide-react';
+import { Loader2, Mail, Plus, Trash2, UsersRound, ArrowLeft, KanbanSquare } from 'lucide-react';
+import { MemberKanbanTab } from '@/features/plans/MemberKanbanTab';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -60,11 +61,18 @@ export function MembersPage() {
   const { projectId } = useParams<{ projectId: string }>();
   const [params, setParams] = useSearchParams();
   const tab = params.get('tab') === 'manage' ? 'manage' : 'kanban';
+  const selectedItemId = params.get('itemId');
+
+  const membersQuery = useQuery({
+    queryKey: membersQueryKey.list(projectId ?? ''),
+    queryFn: () => membersApi.list(projectId!),
+    enabled: !!projectId,
+  });
 
   if (!projectId) return <NotFound projectId={undefined} />;
 
   return (
-    <div className="mx-auto max-w-4xl space-y-5 px-8 py-10">
+    <div className="mx-auto max-w-6xl space-y-5 px-8 py-10">
       <header className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-semibold tracking-tight">参加者</h1>
@@ -91,21 +99,27 @@ export function MembersPage() {
       >
         <TabsList>
           <TabsTrigger value="kanban">
-            <UsersRound className="size-4" />
+            <KanbanSquare className="size-4" />
             メンバー
           </TabsTrigger>
-          <TabsTrigger value="manage">管理</TabsTrigger>
+          <TabsTrigger value="manage">
+            <UsersRound className="size-4" />
+            管理
+          </TabsTrigger>
         </TabsList>
       </Tabs>
 
       {tab === 'kanban' ? (
-        <Card>
-          <CardContent className="py-12 text-center text-sm text-muted-foreground">
-            メンバーかんばん（SC-17）は Sub-Phase 0.4 で実装予定です。
-            <br />
-            参加者の追加・編集は「管理」タブから行えます。
-          </CardContent>
-        </Card>
+        <MemberKanbanTab
+          projectId={projectId}
+          members={membersQuery.data ?? []}
+          selectedItemId={selectedItemId}
+          onChangeItem={(itemId) => {
+            const sp = new URLSearchParams(params);
+            sp.set('itemId', itemId);
+            setParams(sp, { replace: true });
+          }}
+        />
       ) : (
         <ManageTab projectId={projectId} />
       )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,12 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@18.3.1)
       '@holiday-jp/holiday_jp':
         specifier: ^2.4.1
         version: 2.5.1
@@ -325,6 +331,22 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@edge-runtime/format@2.2.1':
     resolution: {integrity: sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==}
@@ -3803,6 +3825,24 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
 
   '@edge-runtime/format@2.2.1': {}
 


### PR DESCRIPTION
## Summary

Phase 0 残り 2 サブフェーズの 1 つ目。ダッシュボードと メンバーかんばん を一気に実装。

## BE（apps/web/server）

- `schemas/dashboard.ts`：`today=YYYY-MM-DD` 任意クエリ
- `services/dashboard.ts`：
  - 自分が参加するプロジェクトを集計
  - 各プロジェクトの **active** な plans を `deriveBallHolder` で Ball Holder 別に振り分け
  - `scheduled_date <= today` の未完了予定のみ抽出
  - `summary: { todayTaskCount, overdueCount }` を計算
  - 階層: project → memberSection → tasks
- `routes/v1/dashboard.ts`：`GET /api/v1/users/me/dashboard`（JWT 必須）

## FE（apps/web/src）

### SC-09 ダッシュボード `/dashboard`

- サマリーカード 2 枚（**今日のタスク** / **期限超過**）
- プロジェクト → メンバー → 予定カードの階層ビュー
- 予定カードクリック → `/projects/:pid/items/:iid?modal=ball-detail&planId=` に遷移（既存 SC-08 モーダル再利用）
- 期限超過カードは赤背景、6 カテゴリ配色を流用
- 空状態 / ローディング / エラー UI

### SC-17 メンバーかんばん `/projects/:projectId/members?tab=kanban`

- `@dnd-kit/core` + `@dnd-kit/utilities` を導入
- 上部の制作物セレクタで対象 item を切替（`?itemId=`）
- メンバーごとに 1 列、Ball Holder 別に **active な予定**をカード表示
- **別メンバー列へのドラッグ&ドロップ** → `POST /toss { toMemberId }`（楽観更新で即時切替、失敗時ロールバック）
- カード内の **「完了する」ボタン** で `POST /complete`（DnD ではない、シンプル化）
- カードヘッダーに 6 カテゴリ配色 + 状態バッジ（準備中 / TOSS済）
- `MembersPage` の既定タブを kanban に、`MemberKanbanTab` を結線

## 設計書差分メモ

- **DnD ライブラリ**：設計書 §4.10 は **react-dnd** 推奨ですが、React 18 + Vite 6 親和性と API のシンプルさを優先して **`@dnd-kit/core`** を採用しました。操作セマンティクス（TOSS / 完了）は変えていません
- **かんばん列構造**：プロトタイプは 2 次元（状態行 × メンバー列）ですが、Phase 0 はシンプル化して **メンバー列のみ**（縦に active 予定を積む）にしています。完了は「完了する」ボタンで実行、完了済みは SC-06 縦型カレンダーや SC-09 ダッシュボードで参照
- **ダッシュボードの集計範囲**：active かつ `scheduled_date <= today` の予定（完了済みは除外）

## 検証

- [x] `pnpm type-check` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test` 通過（**43 tests passing**）
- [x] `pnpm build` 通過
- [ ] **ローカル E2E**：プロジェクト作成 → 予定追加 → ダッシュボードに表示される → かんばんで TOSS / 完了が動く

## 次（最終サブフェーズ）

Sub-Phase 0.5: **非会員 URL 共有**（PR #4 で前倒し済みのスコープ）
- DB: `share_links` テーブル
- BE: 共有リンク発行 / 検証 / クライアント側 TOSS/完了
- FE: SC-16 共有リンク管理 + `/share/:token` 非ログイン操作画面

その後 Sub-Phase 0.6（仕上げ・Resend 本実装・本番デプロイ・監視）で Phase 0 完了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)