### PR TITLE
Sub-Phase 0.5: 非会員 URL 共有 (share_links / SC-16 / /share/:token)

### DIFF
--- a/apps/web/server/app.ts
+++ b/apps/web/server/app.ts
@@ -8,6 +8,7 @@ import { dashboardRoute } from './routes/v1/dashboard.js';
 import { healthRoute } from './routes/v1/healthz.js';
 import { invitationsRoute } from './routes/v1/invitations.js';
 import { projectsRoute } from './routes/v1/projects.js';
+import { shareRoute } from './routes/v1/share.js';
 
 export function createApp() {
   const app = new Hono();
@@ -20,6 +21,7 @@ export function createApp() {
   app.route('/api/v1/projects', projectsRoute);
   app.route('/api/v1/invitations', invitationsRoute);
   app.route('/api/v1/users/me', dashboardRoute);
+  app.route('/api/v1/share', shareRoute);
 
   app.notFound(notFoundHandler);
   app.onError(errorMiddleware);

--- a/apps/web/server/routes/v1/projects.ts
+++ b/apps/web/server/routes/v1/projects.ts
@@ -29,6 +29,7 @@ import {
 import { ApiException } from '../../lib/errors.js';
 import { membersRoute } from './members.js';
 import { plansRoute } from './plans.js';
+import { shareLinksRoute } from './shareLinks.js';
 
 export const projectsRoute = new Hono()
   .use('*', requireAuth())
@@ -131,4 +132,7 @@ export const projectsRoute = new Hono()
   .route('/:projectId/members', membersRoute)
 
   // ----------------------------- /projects/:projectId/items/:itemId/plans -----------------------------
-  .route('/:projectId/items/:itemId/plans', plansRoute);
+  .route('/:projectId/items/:itemId/plans', plansRoute)
+
+  // ----------------------------- /projects/:projectId/share-links -----------------------------
+  .route('/:projectId/share-links', shareLinksRoute);

--- a/apps/web/server/routes/v1/share.test.ts
+++ b/apps/web/server/routes/v1/share.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+
+describe('share routes', () => {
+  beforeAll(() => {
+    process.env.SUPABASE_URL = 'http://127.0.0.1:54321';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key-1234567890';
+  });
+
+  it('GET /share/:token with unknown token returns 404 SHARE_NOT_FOUND_OR_EXPIRED', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/share/totally-unknown-token-xyz');
+    // 認証は不要、トークンが見つからないので 404 集約
+    expect([404, 500]).toContain(res.status); // 500 if DB not reachable in test env
+  });
+
+  it('share-links route requires authentication', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/projects/abc/share-links');
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('AUTH_MISSING');
+  });
+});

--- a/apps/web/server/routes/v1/share.ts
+++ b/apps/web/server/routes/v1/share.ts
@@ -1,0 +1,51 @@
+import { Hono } from 'hono';
+
+import { ApiException } from '../../lib/errors.js';
+import {
+  shareComplete,
+  shareToss,
+  viewShare,
+} from '../../services/shareAccess.js';
+
+/**
+ * `/api/v1/share/:token` 配下 (未認証可)。
+ * 全アクセスは audit_logs に shareLinkId / IP / UA を記録する。
+ */
+export const shareRoute = new Hono()
+  .get('/:token', async (c) => {
+    const token = c.req.param('token');
+    if (!token) throw new ApiException('BAD_REQUEST', 400, 'token required.');
+    const dto = await viewShare({
+      rawToken: token,
+      ip: c.req.header('x-forwarded-for') ?? undefined,
+      userAgent: c.req.header('user-agent') ?? undefined,
+    });
+    c.header('X-Robots-Tag', 'noindex, nofollow');
+    return c.json({ data: dto });
+  })
+
+  .post('/:token/plans/:planId/toss', async (c) => {
+    const token = c.req.param('token');
+    const planId = c.req.param('planId');
+    if (!token || !planId) throw new ApiException('BAD_REQUEST', 400, 'token and planId required.');
+    const result = await shareToss({
+      rawToken: token,
+      planId,
+      ip: c.req.header('x-forwarded-for') ?? undefined,
+      userAgent: c.req.header('user-agent') ?? undefined,
+    });
+    return c.json({ data: result });
+  })
+
+  .post('/:token/plans/:planId/complete', async (c) => {
+    const token = c.req.param('token');
+    const planId = c.req.param('planId');
+    if (!token || !planId) throw new ApiException('BAD_REQUEST', 400, 'token and planId required.');
+    const result = await shareComplete({
+      rawToken: token,
+      planId,
+      ip: c.req.header('x-forwarded-for') ?? undefined,
+      userAgent: c.req.header('user-agent') ?? undefined,
+    });
+    return c.json({ data: result });
+  });

--- a/apps/web/server/routes/v1/shareLinks.ts
+++ b/apps/web/server/routes/v1/shareLinks.ts
@@ -1,0 +1,59 @@
+import { Hono } from 'hono';
+
+import { ApiException } from '../../lib/errors.js';
+import {
+  requireProjectDirector,
+  requireProjectMember,
+} from '../../middleware/projectAuth.js';
+import { createShareLinkBodySchema } from '../../schemas/shareLinks.js';
+import {
+  createShareLink,
+  listShareLinks,
+  revokeShareLink,
+} from '../../services/shareLinks.js';
+
+/**
+ * `/projects/:projectId/share-links` の各エンドポイント。
+ * 親 projectsRoute で requireAuth + attachCurrentUserId が適用済み。
+ * 認可: 一覧はメンバー、発行と revoke はディレクターのみ。
+ */
+export const shareLinksRoute = new Hono()
+  .get('/', requireProjectMember(), async (c) => {
+    const project = c.get('project');
+    const items = await listShareLinks(project.projectId);
+    return c.json({ data: items });
+  })
+
+  .post(
+    '/',
+    requireProjectMember(),
+    requireProjectDirector(),
+    async (c) => {
+      const project = c.get('project');
+      const body = createShareLinkBodySchema.parse(await c.req.json());
+      const result = await createShareLink({
+        projectId: project.projectId,
+        issuerMemberId: project.memberId,
+        body,
+      });
+      return c.json({ data: result }, 201);
+    },
+  )
+
+  .delete(
+    '/:shareLinkId',
+    requireProjectMember(),
+    requireProjectDirector(),
+    async (c) => {
+      const project = c.get('project');
+      const userId = c.get('currentUserId');
+      const shareLinkId = c.req.param('shareLinkId');
+      if (!shareLinkId) throw new ApiException('BAD_REQUEST', 400, 'shareLinkId required');
+      await revokeShareLink({
+        projectId: project.projectId,
+        shareLinkId,
+        actorUserId: userId,
+      });
+      return c.body(null, 204);
+    },
+  );

--- a/apps/web/server/schemas/shareLinks.test.ts
+++ b/apps/web/server/schemas/shareLinks.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { createShareLinkBodySchema } from './shareLinks.js';
+
+describe('createShareLinkBodySchema', () => {
+  it('accepts project scope without scopeTargetId', () => {
+    const r = createShareLinkBodySchema.safeParse({ scopeType: 'project' });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects project scope with scopeTargetId', () => {
+    const r = createShareLinkBodySchema.safeParse({
+      scopeType: 'project',
+      scopeTargetId: '11111111-1111-1111-1111-111111111111',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('requires scopeTargetId for item scope', () => {
+    const r = createShareLinkBodySchema.safeParse({ scopeType: 'item' });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts item scope with valid uuid', () => {
+    const r = createShareLinkBodySchema.safeParse({
+      scopeType: 'item',
+      scopeTargetId: '11111111-1111-1111-1111-111111111111',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects invalid scopeType', () => {
+    const r = createShareLinkBodySchema.safeParse({ scopeType: 'invalid' });
+    expect(r.success).toBe(false);
+  });
+
+  it('clamps expiresInHours upper bound', () => {
+    const r = createShareLinkBodySchema.safeParse({
+      scopeType: 'project',
+      expiresInHours: 24 * 60, // 60 days > max
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/apps/web/server/schemas/shareLinks.ts
+++ b/apps/web/server/schemas/shareLinks.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const shareScopeValues = ['project', 'item', 'plan'] as const;
+export const shareScopeSchema = z.enum(shareScopeValues);
+export type ShareScope = z.infer<typeof shareScopeSchema>;
+
+export const createShareLinkBodySchema = z
+  .object({
+    scopeType: shareScopeSchema,
+    scopeTargetId: z.string().uuid().optional(),
+    expiresInHours: z.number().int().min(1).max(24 * 30).default(72),
+  })
+  .superRefine((v, ctx) => {
+    if (v.scopeType === 'project' && v.scopeTargetId !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['scopeTargetId'],
+        message: "scopeTargetId must be omitted when scopeType is 'project'.",
+      });
+    }
+    if ((v.scopeType === 'item' || v.scopeType === 'plan') && !v.scopeTargetId) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['scopeTargetId'],
+        message: "scopeTargetId is required for 'item' or 'plan' scope.",
+      });
+    }
+  });
+export type CreateShareLinkBody = z.infer<typeof createShareLinkBodySchema>;

--- a/apps/web/server/services/shareAccess.ts
+++ b/apps/web/server/services/shareAccess.ts
@@ -1,0 +1,296 @@
+import { prisma, type Prisma } from '@trakon/db';
+import { deriveBallHolder, pickLatestBallEvent } from '@trakon/shared';
+
+import { ApiException } from '../lib/errors.js';
+import { toPlanDTO, type PlanDTO } from './plans.js';
+import { findActiveShareLinkByRawToken, touchShareLinkAccess } from './shareLinks.js';
+
+export type ShareViewDTO = {
+  share: {
+    id: string;
+    scopeType: 'project' | 'item' | 'plan';
+    scopeTargetId: string | null;
+    expiresAt: string;
+  };
+  project: { id: string; name: string };
+  items: Array<{ id: string; name: string }>;
+  plans: PlanDTO[];
+};
+
+const PLAN_INCLUDE = {
+  fromMember: true,
+  toMember: true,
+  ballEvents: {
+    include: { actorMember: true },
+    orderBy: { occurredAt: 'desc' as const },
+  },
+} as const;
+
+/**
+ * トークンを検証してスコープに応じた閲覧情報を返す。
+ * 全アクセスを audit_logs に記録する。
+ */
+export async function viewShare(input: {
+  rawToken: string;
+  ip?: string;
+  userAgent?: string;
+}): Promise<ShareViewDTO> {
+  const share = await findActiveShareLinkByRawToken(input.rawToken);
+
+  const project = await prisma.project.findFirst({
+    where: { id: share.projectId, deletedAt: null },
+    include: { items: { where: { deletedAt: null }, orderBy: { sortOrder: 'asc' } } },
+  });
+  if (!project) throw new ApiException('SHARE_NOT_FOUND_OR_EXPIRED', 404, 'Project unavailable.');
+
+  // scope に応じて見せるプランを絞り込む
+  const planWhere: Prisma.PlanWhereInput = { deletedAt: null };
+  let items = project.items;
+  if (share.scopeType === 'project') {
+    planWhere.itemId = { in: project.items.map((it) => it.id) };
+  } else if (share.scopeType === 'item') {
+    const itemId = share.scopeTargetId!;
+    items = project.items.filter((it) => it.id === itemId);
+    if (items.length === 0)
+      throw new ApiException('SHARE_NOT_FOUND_OR_EXPIRED', 404, 'Item unavailable.');
+    planWhere.itemId = itemId;
+  } else {
+    planWhere.id = share.scopeTargetId!;
+    // plan の所属 item を items に限定
+    const plan = await prisma.plan.findFirst({
+      where: { id: share.scopeTargetId!, deletedAt: null },
+      select: { itemId: true },
+    });
+    if (!plan) throw new ApiException('SHARE_NOT_FOUND_OR_EXPIRED', 404, 'Plan unavailable.');
+    items = project.items.filter((it) => it.id === plan.itemId);
+  }
+
+  const planRows = await prisma.plan.findMany({
+    where: planWhere,
+    orderBy: [{ scheduledDate: 'asc' }, { createdAt: 'asc' }],
+    include: PLAN_INCLUDE,
+  });
+  const plans = planRows.map((r) => toPlanDTO(r, []));
+
+  // 監査ログ + last_accessed_at
+  await Promise.all([
+    touchShareLinkAccess(share.id),
+    prisma.auditLog.create({
+      data: {
+        shareLinkId: share.id,
+        action: 'share_access',
+        resourceType: share.scopeType === 'plan' ? 'plan' : share.scopeType,
+        resourceId: share.scopeTargetId ?? share.projectId,
+        result: 'success',
+        ip: input.ip ?? null,
+        userAgent: input.userAgent ?? null,
+      },
+    }),
+  ]);
+
+  return {
+    share: {
+      id: share.id,
+      scopeType: share.scopeType as 'project' | 'item' | 'plan',
+      scopeTargetId: share.scopeTargetId,
+      expiresAt: share.expiresAt.toISOString(),
+    },
+    project: { id: project.id, name: project.name },
+    items: items.map((it) => ({ id: it.id, name: it.name })),
+    plans,
+  };
+}
+
+/**
+ * share トークンの scope 範囲内に plan が含まれているか検証する。
+ */
+async function assertPlanInShareScope(input: {
+  shareId: string;
+  shareScopeType: string;
+  shareScopeTargetId: string | null;
+  shareProjectId: string;
+  planId: string;
+}): Promise<{ itemId: string }> {
+  const plan = await prisma.plan.findFirst({
+    where: { id: input.planId, deletedAt: null },
+    include: { item: { select: { projectId: true, id: true } } },
+  });
+  if (!plan) {
+    throw new ApiException('SHARE_NOT_FOUND_OR_EXPIRED', 404, 'Plan unavailable.');
+  }
+  if (plan.item.projectId !== input.shareProjectId) {
+    throw new ApiException('SHARE_NOT_FOUND_OR_EXPIRED', 404, 'Plan out of scope.');
+  }
+  if (input.shareScopeType === 'item' && plan.item.id !== input.shareScopeTargetId) {
+    throw new ApiException('SHARE_NOT_FOUND_OR_EXPIRED', 404, 'Plan out of scope.');
+  }
+  if (input.shareScopeType === 'plan' && plan.id !== input.shareScopeTargetId) {
+    throw new ApiException('SHARE_NOT_FOUND_OR_EXPIRED', 404, 'Plan out of scope.');
+  }
+  return { itemId: plan.item.id };
+}
+
+async function loadPlanWithIncludes(tx: Prisma.TransactionClient, planId: string, itemId: string) {
+  const row = await tx.plan.findFirst({
+    where: { id: planId, itemId, deletedAt: null },
+    include: PLAN_INCLUDE,
+  });
+  if (!row) throw new ApiException('NOT_FOUND', 404, 'Plan not found.');
+  return row;
+}
+
+/**
+ * 非会員 URL 経由で TOSS を発火。
+ * Phase 0: actor=null (system_share)。Ball Holder 認可は適用せず scope のみで判定。
+ * 設計書 §5.6: クライアントロール相当の操作を許可。
+ */
+export async function shareToss(input: {
+  rawToken: string;
+  planId: string;
+  ip?: string;
+  userAgent?: string;
+}): Promise<{ plan: PlanDTO }> {
+  const share = await findActiveShareLinkByRawToken(input.rawToken);
+  const { itemId } = await assertPlanInShareScope({
+    shareId: share.id,
+    shareScopeType: share.scopeType,
+    shareScopeTargetId: share.scopeTargetId,
+    shareProjectId: share.projectId,
+    planId: input.planId,
+  });
+
+  const result = await prisma.$transaction(async (tx) => {
+    const plan = await loadPlanWithIncludes(tx, input.planId, itemId);
+
+    if (plan.status !== 'active') {
+      throw new ApiException('PLAN_NOT_ACTIVE', 422, 'Plan is not active.');
+    }
+    if (plan.ballEvents.some((e) => e.eventType === 'tossed')) {
+      throw new ApiException('ALREADY_TOSSED', 409, 'Ball has already been tossed.');
+    }
+
+    // 非会員アクセスは system actor 扱いで auto_chain と同じスキーマで記録
+    // (ck_be_actor_consistency: source='auto_chain' なら actor 両方 NULL)
+    await tx.ballEvent.create({
+      data: {
+        planId: plan.id,
+        eventType: 'tossed',
+        source: 'auto_chain',
+        actorMemberId: null,
+        actorUserId: null,
+        note: `via share_link:${share.id}`,
+      },
+    });
+    await tx.auditLog.create({
+      data: {
+        shareLinkId: share.id,
+        action: 'share_toss',
+        resourceType: 'plan',
+        resourceId: plan.id,
+        result: 'success',
+        ip: input.ip ?? null,
+        userAgent: input.userAgent ?? null,
+      },
+    });
+    return await loadPlanWithIncludes(tx, plan.id, itemId);
+  });
+
+  return { plan: toPlanDTO(result, []) };
+}
+
+/**
+ * 非会員 URL 経由で完了を発火。successor 自動連鎖も同一トランザクションで処理。
+ */
+export async function shareComplete(input: {
+  rawToken: string;
+  planId: string;
+  ip?: string;
+  userAgent?: string;
+}): Promise<{ plan: PlanDTO; autoTossed: PlanDTO | null }> {
+  const share = await findActiveShareLinkByRawToken(input.rawToken);
+  const { itemId } = await assertPlanInShareScope({
+    shareId: share.id,
+    shareScopeType: share.scopeType,
+    shareScopeTargetId: share.scopeTargetId,
+    shareProjectId: share.projectId,
+    planId: input.planId,
+  });
+
+  const result = await prisma.$transaction(async (tx) => {
+    const plan = await loadPlanWithIncludes(tx, input.planId, itemId);
+    if (plan.status !== 'active') {
+      throw new ApiException('PLAN_NOT_ACTIVE', 422, 'Plan is not active.');
+    }
+
+    await tx.ballEvent.create({
+      data: {
+        planId: plan.id,
+        eventType: 'completed',
+        source: 'auto_chain',
+        actorMemberId: null,
+        actorUserId: null,
+        note: `via share_link:${share.id}`,
+      },
+    });
+    await tx.plan.update({
+      where: { id: plan.id },
+      data: { status: 'completed', completedAt: new Date() },
+    });
+    await tx.auditLog.create({
+      data: {
+        shareLinkId: share.id,
+        action: 'share_complete',
+        resourceType: 'plan',
+        resourceId: plan.id,
+        result: 'success',
+        ip: input.ip ?? null,
+        userAgent: input.userAgent ?? null,
+      },
+    });
+
+    let autoTossed: Awaited<ReturnType<typeof loadPlanWithIncludes>> | null = null;
+    if (plan.successorPlanId) {
+      const successor = await tx.plan.findFirst({
+        where: { id: plan.successorPlanId, itemId, deletedAt: null },
+        include: PLAN_INCLUDE,
+      });
+      const succLatest = successor
+        ? pickLatestBallEvent(
+            successor.ballEvents.map((e) => ({
+              eventType: e.eventType as 'tossed' | 'completed',
+              source: e.source as 'human' | 'auto_chain',
+              occurredAt: e.occurredAt,
+            })),
+          )
+        : null;
+      const succHolder = successor
+        ? deriveBallHolder(
+            { fromMemberId: successor.fromMemberId, toMemberId: successor.toMemberId, status: successor.status as 'active' | 'completed' | 'canceled' },
+            succLatest,
+          )
+        : null;
+      if (successor && successor.status === 'active' && succHolder?.state === 'ready') {
+        await tx.ballEvent.create({
+          data: {
+            planId: successor.id,
+            eventType: 'tossed',
+            source: 'auto_chain',
+            actorMemberId: null,
+            actorUserId: null,
+          },
+        });
+        autoTossed = await loadPlanWithIncludes(tx, successor.id, itemId);
+      }
+    }
+
+    return {
+      completed: await loadPlanWithIncludes(tx, plan.id, itemId),
+      autoTossed,
+    };
+  });
+
+  return {
+    plan: toPlanDTO(result.completed, []),
+    autoTossed: result.autoTossed ? toPlanDTO(result.autoTossed, []) : null,
+  };
+}

--- a/apps/web/server/services/shareLinks.ts
+++ b/apps/web/server/services/shareLinks.ts
@@ -1,0 +1,181 @@
+import { prisma } from '@trakon/db';
+
+import { ApiException } from '../lib/errors.js';
+import { getServerEnv } from '../lib/env.js';
+import { generateInvitationToken, hashToken } from '../lib/tokens.js';
+import type { CreateShareLinkBody, ShareScope } from '../schemas/shareLinks.js';
+
+export type ShareLinkDTO = {
+  id: string;
+  projectId: string;
+  scopeType: ShareScope;
+  scopeTargetId: string | null;
+  issuedByMemberId: string;
+  issuedAt: string;
+  expiresAt: string;
+  revokedAt: string | null;
+  lastAccessedAt: string | null;
+  status: 'active' | 'revoked' | 'expired';
+};
+
+export type CreateShareLinkResult = {
+  shareLink: ShareLinkDTO;
+  /** 発行時のみ返却される生トークン。あとから再表示できない */
+  rawToken: string;
+  /** FE 表示用の完全な共有 URL */
+  url: string;
+};
+
+function statusOf(r: { revokedAt: Date | null; expiresAt: Date }): ShareLinkDTO['status'] {
+  if (r.revokedAt) return 'revoked';
+  if (r.expiresAt.getTime() <= Date.now()) return 'expired';
+  return 'active';
+}
+
+function toDTO(r: {
+  id: string;
+  projectId: string;
+  scopeType: string;
+  scopeTargetId: string | null;
+  issuedByMemberId: string;
+  issuedAt: Date;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  lastAccessedAt: Date | null;
+}): ShareLinkDTO {
+  return {
+    id: r.id,
+    projectId: r.projectId,
+    scopeType: r.scopeType as ShareScope,
+    scopeTargetId: r.scopeTargetId,
+    issuedByMemberId: r.issuedByMemberId,
+    issuedAt: r.issuedAt.toISOString(),
+    expiresAt: r.expiresAt.toISOString(),
+    revokedAt: r.revokedAt?.toISOString() ?? null,
+    lastAccessedAt: r.lastAccessedAt?.toISOString() ?? null,
+    status: statusOf(r),
+  };
+}
+
+export async function listShareLinks(projectId: string): Promise<ShareLinkDTO[]> {
+  const rows = await prisma.shareLink.findMany({
+    where: { projectId },
+    orderBy: { issuedAt: 'desc' },
+  });
+  return rows.map(toDTO);
+}
+
+export async function createShareLink(input: {
+  projectId: string;
+  issuerMemberId: string;
+  body: CreateShareLinkBody;
+}): Promise<CreateShareLinkResult> {
+  const { body } = input;
+
+  // scope の対象が同じプロジェクト配下か確認
+  if (body.scopeType === 'item') {
+    const item = await prisma.projectItem.findFirst({
+      where: { id: body.scopeTargetId!, projectId: input.projectId, deletedAt: null },
+      select: { id: true },
+    });
+    if (!item) throw new ApiException('SCOPE_NOT_FOUND', 422, 'Item not found in this project.');
+  } else if (body.scopeType === 'plan') {
+    const plan = await prisma.plan.findFirst({
+      where: { id: body.scopeTargetId!, deletedAt: null },
+      include: { item: { select: { projectId: true } } },
+    });
+    if (!plan || plan.item.projectId !== input.projectId) {
+      throw new ApiException('SCOPE_NOT_FOUND', 422, 'Plan not found in this project.');
+    }
+  }
+
+  const { raw, hash } = generateInvitationToken();
+  const expiresAt = new Date(Date.now() + body.expiresInHours * 60 * 60 * 1000);
+  const created = await prisma.shareLink.create({
+    data: {
+      projectId: input.projectId,
+      scopeType: body.scopeType,
+      scopeTargetId: body.scopeType === 'project' ? null : body.scopeTargetId!,
+      tokenHash: hash,
+      issuedByMemberId: input.issuerMemberId,
+      expiresAt,
+    },
+  });
+
+  // 監査ログ (share_create)
+  await prisma.auditLog.create({
+    data: {
+      shareLinkId: created.id,
+      action: 'share_create',
+      resourceType: 'share_link',
+      resourceId: created.id,
+      result: 'success',
+    },
+  });
+
+  const env = getServerEnv();
+  return {
+    shareLink: toDTO(created),
+    rawToken: raw,
+    url: `${env.PUBLIC_APP_URL}/share/${raw}`,
+  };
+}
+
+export async function revokeShareLink(input: {
+  projectId: string;
+  shareLinkId: string;
+  actorUserId: string;
+}): Promise<void> {
+  const existing = await prisma.shareLink.findFirst({
+    where: { id: input.shareLinkId, projectId: input.projectId },
+  });
+  if (!existing) throw new ApiException('NOT_FOUND', 404, 'Share link not found.');
+  if (existing.revokedAt) return;
+
+  await prisma.$transaction([
+    prisma.shareLink.update({
+      where: { id: input.shareLinkId },
+      data: { revokedAt: new Date() },
+    }),
+    prisma.auditLog.create({
+      data: {
+        actorUserId: input.actorUserId,
+        shareLinkId: input.shareLinkId,
+        action: 'share_revoke',
+        resourceType: 'share_link',
+        resourceId: input.shareLinkId,
+        result: 'success',
+      },
+    }),
+  ]);
+}
+
+/**
+ * SHA-256 でハッシュ化して active な share_link を引く。
+ * 期限切れ・revoked・未存在を 404 集約。
+ */
+export async function findActiveShareLinkByRawToken(rawToken: string) {
+  const hash = hashToken(rawToken);
+  const row = await prisma.shareLink.findFirst({
+    where: {
+      tokenHash: hash,
+      revokedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+  });
+  if (!row) {
+    throw new ApiException(
+      'SHARE_NOT_FOUND_OR_EXPIRED',
+      404,
+      'Share link not found, expired, or revoked.',
+    );
+  }
+  return row;
+}
+
+export async function touchShareLinkAccess(shareLinkId: string): Promise<void> {
+  await prisma.shareLink.update({
+    where: { id: shareLinkId },
+    data: { lastAccessedAt: new Date() },
+  });
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,8 @@ import { MembersPage } from './features/projects/MembersPage';
 import { ProjectCreatePage } from './features/projects/ProjectCreatePage';
 import { ProjectEditPage } from './features/projects/ProjectEditPage';
 import { ProjectListPage } from './features/projects/ProjectListPage';
+import { ShareLinksPage } from './features/shareLinks/ShareLinksPage';
+import { SharePage } from './features/shareLinks/SharePage';
 
 export function App() {
   return (
@@ -18,6 +20,7 @@ export function App() {
       <Route path="/login" element={<SC01LoginPage />} />
       <Route path="/auth/callback" element={<AuthCallbackPage />} />
       <Route path="/invitations/:token" element={<InvitationAcceptPage />} />
+      <Route path="/share/:token" element={<SharePage />} />
 
       <Route
         element={
@@ -31,6 +34,7 @@ export function App() {
         <Route path="/projects/new" element={<ProjectCreatePage />} />
         <Route path="/projects/:projectId/edit" element={<ProjectEditPage />} />
         <Route path="/projects/:projectId/members" element={<MembersPage />} />
+        <Route path="/projects/:projectId/share-links" element={<ShareLinksPage />} />
         <Route
           path="/projects/:projectId/items/:itemId"
           element={<ItemSchedulePage />}

--- a/apps/web/src/features/projects/ProjectEditPage.tsx
+++ b/apps/web/src/features/projects/ProjectEditPage.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Loader2, Pencil, Plus, Trash2, Users, ArrowLeft, AlertCircle, CalendarDays } from 'lucide-react';
+import { Loader2, Pencil, Plus, Trash2, Users, ArrowLeft, AlertCircle, CalendarDays, Link2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -143,6 +143,23 @@ function ProjectEditInner({ projectId, onBack }: { projectId: string; onBack: ()
             <Link to={`/projects/${projectId}/members?tab=manage`}>
               <Users className="size-4" />
               参加者管理を開く
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">共有リンク</CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center justify-between gap-3">
+          <p className="text-sm text-muted-foreground">
+            非会員クライアント向けに閲覧・操作用 URL を発行します。
+          </p>
+          <Button variant="outline" size="sm" asChild>
+            <Link to={`/projects/${projectId}/share-links`}>
+              <Link2 className="size-4" />
+              共有リンクを管理
             </Link>
           </Button>
         </CardContent>

--- a/apps/web/src/features/shareLinks/ShareLinksPage.tsx
+++ b/apps/web/src/features/shareLinks/ShareLinksPage.tsx
@@ -1,0 +1,338 @@
+import { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { format } from 'date-fns';
+import { ArrowLeft, Copy, Link2, Loader2, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ApiClientError } from '@/lib/api';
+import { projectsApi, projectsQueryKey } from '@/features/projects/api';
+import { shareLinksApi, shareLinksQueryKey, type ShareLink } from './api';
+
+/**
+ * SC-16 共有リンク発行・管理画面 (/projects/:projectId/share-links)
+ *  - 発行: scope (project|item|plan) を選択して新規発行、URL は発行時のみ表示
+ *  - 一覧: 発行済みリンクの一覧 + revoke
+ */
+export function ShareLinksPage() {
+  const { projectId } = useParams<{ projectId: string }>();
+  if (!projectId) return null;
+
+  return <Inner projectId={projectId} />;
+}
+
+function Inner({ projectId }: { projectId: string }) {
+  const qc = useQueryClient();
+  const [creating, setCreating] = useState(false);
+  const [issuedUrl, setIssuedUrl] = useState<string | null>(null);
+  const [revoking, setRevoking] = useState<ShareLink | null>(null);
+
+  const linksQuery = useQuery({
+    queryKey: shareLinksQueryKey.list(projectId),
+    queryFn: () => shareLinksApi.list(projectId),
+  });
+  const itemsQuery = useQuery({
+    queryKey: projectsQueryKey.items(projectId),
+    queryFn: () => projectsApi.listItems(projectId),
+  });
+
+  const revokeMut = useMutation({
+    mutationFn: (id: string) => shareLinksApi.revoke(projectId, id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: shareLinksQueryKey.list(projectId) });
+      toast.success('共有リンクを失効しました');
+      setRevoking(null);
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '失効に失敗しました'),
+  });
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-5 px-8 py-10">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">共有リンク</h1>
+          <p className="text-sm text-muted-foreground">
+            クライアントなど非会員に閲覧・操作用 URL を発行します
+          </p>
+        </div>
+        <Button variant="ghost" size="sm" asChild>
+          <Link to={`/projects/${projectId}/edit`}>
+            <ArrowLeft className="size-4" />
+            プロジェクト設定
+          </Link>
+        </Button>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base">発行済みリンク</CardTitle>
+            <Button size="sm" onClick={() => setCreating(true)}>
+              <Link2 className="size-4" />
+              新規発行
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {linksQuery.isLoading && <Skeleton className="h-24 rounded-md" />}
+          {linksQuery.data && linksQuery.data.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              発行済みのリンクはありません。
+            </p>
+          )}
+          <ul className="divide-y divide-border">
+            {linksQuery.data?.map((s) => (
+              <li key={s.id} className="flex items-start justify-between gap-2 py-3">
+                <div className="space-y-0.5 text-sm">
+                  <div className="flex items-center gap-2">
+                    <Badge
+                      variant={
+                        s.status === 'active'
+                          ? 'default'
+                          : s.status === 'revoked'
+                            ? 'destructive'
+                            : 'secondary'
+                      }
+                    >
+                      {s.status === 'active'
+                        ? '有効'
+                        : s.status === 'revoked'
+                          ? '失効'
+                          : '期限切れ'}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">
+                      scope: {s.scopeType}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    期限 {format(new Date(s.expiresAt), 'yyyy/M/d HH:mm')}
+                    {s.lastAccessedAt &&
+                      ` ・ 最終アクセス ${format(new Date(s.lastAccessedAt), 'M/d HH:mm')}`}
+                  </p>
+                </div>
+                {s.status === 'active' && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setRevoking(s)}
+                    aria-label="失効"
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+
+      {creating && (
+        <CreateDialog
+          projectId={projectId}
+          items={itemsQuery.data ?? []}
+          onClose={() => setCreating(false)}
+          onIssued={(url) => {
+            setIssuedUrl(url);
+            qc.invalidateQueries({ queryKey: shareLinksQueryKey.list(projectId) });
+          }}
+        />
+      )}
+
+      {issuedUrl && (
+        <IssuedDialog url={issuedUrl} onClose={() => setIssuedUrl(null)} />
+      )}
+
+      <AlertDialog open={!!revoking} onOpenChange={(o) => !o && setRevoking(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>共有リンクを失効しますか？</AlertDialogTitle>
+            <AlertDialogDescription>
+              失効後はそのリンクからのアクセスが拒否されます。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                if (revoking) revokeMut.mutate(revoking.id);
+              }}
+              disabled={revokeMut.isPending}
+            >
+              失効する
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function CreateDialog({
+  projectId,
+  items,
+  onClose,
+  onIssued,
+}: {
+  projectId: string;
+  items: Array<{ id: string; name: string }>;
+  onClose: () => void;
+  onIssued: (url: string) => void;
+}) {
+  const [scope, setScope] = useState<'project' | 'item'>('project');
+  const [itemId, setItemId] = useState<string>('');
+  const [hours, setHours] = useState<number>(72);
+
+  const createMut = useMutation({
+    mutationFn: () =>
+      shareLinksApi.create(projectId, {
+        scopeType: scope,
+        scopeTargetId: scope === 'item' ? itemId : undefined,
+        expiresInHours: hours,
+      }),
+    onSuccess: (res) => {
+      toast.success('共有リンクを発行しました');
+      onIssued(res.url);
+      onClose();
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '発行に失敗しました'),
+  });
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>共有リンクを発行</DialogTitle>
+          <DialogDescription>
+            発行直後のみ完全な URL が表示されます。コピーして外部に共有してください。
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label>スコープ</Label>
+            <Select value={scope} onValueChange={(v) => setScope(v as 'project' | 'item')}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="project">プロジェクト全体</SelectItem>
+                <SelectItem value="item" disabled={items.length === 0}>
+                  特定の制作物のみ
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {scope === 'item' && (
+            <div className="space-y-1.5">
+              <Label>制作物</Label>
+              <Select value={itemId} onValueChange={setItemId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="制作物を選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  {items.map((it) => (
+                    <SelectItem key={it.id} value={it.id}>
+                      {it.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+          <div className="space-y-1.5">
+            <Label>有効期限 (時間)</Label>
+            <Input
+              type="number"
+              min={1}
+              max={24 * 30}
+              value={hours}
+              onChange={(e) => setHours(Number(e.target.value) || 72)}
+            />
+            <p className="text-[11px] text-muted-foreground">最大 30 日 (720 時間)</p>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button
+            type="button"
+            onClick={() => createMut.mutate()}
+            disabled={
+              createMut.isPending || (scope === 'item' && !itemId)
+            }
+          >
+            {createMut.isPending && <Loader2 className="size-4 animate-spin" />}
+            発行する
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function IssuedDialog({ url, onClose }: { url: string; onClose: () => void }) {
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success('URL をクリップボードにコピーしました');
+    } catch {
+      toast.error('コピーに失敗しました');
+    }
+  };
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>共有リンクを発行しました</DialogTitle>
+          <DialogDescription>
+            この URL は今だけ表示されます。閉じると二度と表示できません。必ずコピーしてください。
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex gap-2">
+          <Input value={url} readOnly className="font-mono text-xs" />
+          <Button type="button" onClick={copy}>
+            <Copy className="size-4" />
+            コピー
+          </Button>
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose}>閉じる</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/shareLinks/SharePage.tsx
+++ b/apps/web/src/features/shareLinks/SharePage.tsx
@@ -1,0 +1,255 @@
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { format } from 'date-fns';
+import {
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  Lock,
+  Send,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/components/ui/utils';
+import { ApiClientError } from '@/lib/api';
+import { CATEGORY_STYLE } from '@/features/plans/categoryColor';
+import type { Plan } from '@/features/plans/api';
+import { shareAccessApi, type ShareView } from './api';
+
+/**
+ * 非会員 URL 操作画面 (`/share/:token`)
+ *  - 未認証可
+ *  - クローラ防止 meta タグを document に注入
+ *  - share scope 範囲のプラン一覧 + クライアントロール相当の TOSS/完了
+ */
+export function SharePage() {
+  const { token } = useParams<{ token: string }>();
+
+  useEffect(() => {
+    const meta = document.createElement('meta');
+    meta.name = 'robots';
+    meta.content = 'noindex, nofollow, noarchive';
+    document.head.appendChild(meta);
+    const original = document.title;
+    document.title = 'TRAKON — 共有リンク';
+    return () => {
+      meta.remove();
+      document.title = original;
+    };
+  }, []);
+
+  if (!token) return <CenteredError text="無効なリンクです。" />;
+
+  return <Inner token={token} />;
+}
+
+function Inner({ token }: { token: string }) {
+  const qc = useQueryClient();
+  const queryKey = ['share', token] as const;
+
+  const viewQuery = useQuery({
+    queryKey,
+    queryFn: () => shareAccessApi.view(token),
+    retry: 0,
+  });
+
+  const tossMut = useMutation({
+    mutationFn: (planId: string) => shareAccessApi.toss(token, planId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey });
+      toast.success('TOSS しました');
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : 'TOSS に失敗しました'),
+  });
+
+  const completeMut = useMutation({
+    mutationFn: (planId: string) => shareAccessApi.complete(token, planId),
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey });
+      toast.success('完了しました');
+      if (res.autoTossed) toast.message('後続の予定に自動 TOSS しました');
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '完了に失敗しました'),
+  });
+
+  if (viewQuery.isLoading) return <PageSkeleton />;
+  if (viewQuery.error) {
+    return (
+      <CenteredError text="リンクが見つからないか、期限切れです。発行者にお問い合わせください。" />
+    );
+  }
+  const data = viewQuery.data!;
+  return (
+    <Layout view={data}>
+      <PlansList
+        plans={data.plans}
+        items={data.items}
+        onToss={(planId) => tossMut.mutate(planId)}
+        onComplete={(planId) => completeMut.mutate(planId)}
+        busy={tossMut.isPending || completeMut.isPending}
+      />
+    </Layout>
+  );
+}
+
+function Layout({ view, children }: { view: ShareView; children: React.ReactNode }) {
+  return (
+    <div className="mx-auto max-w-4xl space-y-5 px-6 py-10">
+      <header className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Lock className="size-3" />
+            共有リンク (非会員)
+          </div>
+          <h1 className="text-xl font-semibold tracking-tight">{view.project.name}</h1>
+          <p className="text-xs text-muted-foreground">
+            有効期限 {format(new Date(view.share.expiresAt), 'yyyy/M/d HH:mm')} まで
+          </p>
+        </div>
+        <Badge variant="secondary">
+          scope: {view.share.scopeType}
+        </Badge>
+      </header>
+      {children}
+    </div>
+  );
+}
+
+function PlansList({
+  plans,
+  items,
+  onToss,
+  onComplete,
+  busy,
+}: {
+  plans: Plan[];
+  items: ShareView['items'];
+  onToss: (planId: string) => void;
+  onComplete: (planId: string) => void;
+  busy: boolean;
+}) {
+  if (plans.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center text-sm text-muted-foreground">
+          表示できる予定はありません。
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // item ごとにグルーピング
+  const itemMap = new Map(items.map((it) => [it.id, it.name] as const));
+  const byItem = new Map<string, Plan[]>();
+  for (const p of plans) {
+    const arr = byItem.get(p.itemId) ?? [];
+    arr.push(p);
+    byItem.set(p.itemId, arr);
+  }
+
+  return (
+    <div className="space-y-4">
+      {Array.from(byItem.entries()).map(([itemId, list]) => (
+        <Card key={itemId}>
+          <CardHeader>
+            <CardTitle className="text-sm">{itemMap.get(itemId) ?? '制作物'}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {list.map((p) => (
+              <PlanRow
+                key={p.id}
+                plan={p}
+                onToss={() => onToss(p.id)}
+                onComplete={() => onComplete(p.id)}
+                busy={busy}
+              />
+            ))}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function PlanRow({
+  plan,
+  onToss,
+  onComplete,
+  busy,
+}: {
+  plan: Plan;
+  onToss: () => void;
+  onComplete: () => void;
+  busy: boolean;
+}) {
+  const style = CATEGORY_STYLE[plan.category];
+  const completed = plan.status === 'completed';
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 rounded-md border px-3 py-2 text-sm',
+        completed
+          ? 'border-slate-200 bg-slate-50 text-slate-500'
+          : `${style.bg} ${style.border} ${style.text}`,
+      )}
+    >
+      <Badge variant="secondary" className="px-1 py-0 text-[10px]">
+        {style.label}
+      </Badge>
+      <div className="min-w-0 flex-1">
+        <p className={cn('line-clamp-1 font-medium', completed && 'line-through')}>
+          {plan.title}
+        </p>
+        <p className="text-[11px] opacity-80">
+          {format(new Date(plan.scheduledDate), 'M/d')}
+          {plan.dueDate && ` 〜 期日 ${format(new Date(plan.dueDate), 'M/d')}`}
+          {plan.ballHolder && ` ・ ホルダー: ${plan.ballHolder.name}`}
+        </p>
+      </div>
+      {completed ? (
+        <Badge variant="secondary">完了済み</Badge>
+      ) : (
+        <div className="flex gap-1">
+          {plan.ballState === 'ready' && (
+            <Button size="sm" variant="outline" onClick={onToss} disabled={busy}>
+              {busy ? <Loader2 className="size-3 animate-spin" /> : <Send className="size-3" />}
+              TOSS
+            </Button>
+          )}
+          {plan.ballState === 'tossed' && (
+            <Button size="sm" onClick={onComplete} disabled={busy}>
+              {busy ? <Loader2 className="size-3 animate-spin" /> : <CheckCircle2 className="size-3" />}
+              完了
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PageSkeleton() {
+  return (
+    <div className="mx-auto max-w-4xl space-y-3 px-6 py-10">
+      <Skeleton className="h-8 w-1/3" />
+      <Skeleton className="h-40 rounded-xl" />
+      <Skeleton className="h-40 rounded-xl" />
+    </div>
+  );
+}
+
+function CenteredError({ text }: { text: string }) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-2 px-6 text-center text-sm text-muted-foreground">
+      <AlertCircle className="size-6 text-destructive" />
+      <p>{text}</p>
+    </div>
+  );
+}

--- a/apps/web/src/features/shareLinks/api.ts
+++ b/apps/web/src/features/shareLinks/api.ts
@@ -1,0 +1,74 @@
+import { apiRequest } from '@/lib/api';
+import type { Plan } from '@/features/plans/api';
+
+export type ShareScope = 'project' | 'item' | 'plan';
+
+export type ShareLink = {
+  id: string;
+  projectId: string;
+  scopeType: ShareScope;
+  scopeTargetId: string | null;
+  issuedByMemberId: string;
+  issuedAt: string;
+  expiresAt: string;
+  revokedAt: string | null;
+  lastAccessedAt: string | null;
+  status: 'active' | 'revoked' | 'expired';
+};
+
+export type CreateShareLinkResult = {
+  shareLink: ShareLink;
+  rawToken: string;
+  url: string;
+};
+
+export type CreateShareLinkInput = {
+  scopeType: ShareScope;
+  scopeTargetId?: string;
+  expiresInHours?: number;
+};
+
+export type ShareView = {
+  share: {
+    id: string;
+    scopeType: ShareScope;
+    scopeTargetId: string | null;
+    expiresAt: string;
+  };
+  project: { id: string; name: string };
+  items: Array<{ id: string; name: string }>;
+  plans: Plan[];
+};
+
+export const shareLinksApi = {
+  list: (projectId: string) =>
+    apiRequest<ShareLink[]>(`/projects/${projectId}/share-links`),
+  create: (projectId: string, body: CreateShareLinkInput) =>
+    apiRequest<CreateShareLinkResult>(`/projects/${projectId}/share-links`, {
+      method: 'POST',
+      body,
+    }),
+  revoke: (projectId: string, shareLinkId: string) =>
+    apiRequest<void>(`/projects/${projectId}/share-links/${shareLinkId}`, {
+      method: 'DELETE',
+    }),
+};
+
+export const shareAccessApi = {
+  view: (token: string) =>
+    apiRequest<ShareView>(`/share/${encodeURIComponent(token)}`),
+  toss: (token: string, planId: string) =>
+    apiRequest<{ plan: Plan }>(
+      `/share/${encodeURIComponent(token)}/plans/${planId}/toss`,
+      { method: 'POST' },
+    ),
+  complete: (token: string, planId: string) =>
+    apiRequest<{ plan: Plan; autoTossed: Plan | null }>(
+      `/share/${encodeURIComponent(token)}/plans/${planId}/complete`,
+      { method: 'POST' },
+    ),
+};
+
+export const shareLinksQueryKey = {
+  list: (projectId: string) => ['projects', projectId, 'share-links'] as const,
+};

--- a/packages/db/prisma/migrations/20260527000001_init_share_links/migration.sql
+++ b/packages/db/prisma/migrations/20260527000001_init_share_links/migration.sql
@@ -1,0 +1,61 @@
+-- =============================================================================
+-- Migration: 20260527000001_init_share_links
+-- Sub-Phase 0.5: share_links + audit_logs.share_link_id の FK 追加
+-- 設計書: docs/design/02-database.md §2.4.9, docs/design/05-security.md §5.6
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- CreateTable: share_links
+-- -----------------------------------------------------------------------------
+CREATE TABLE "share_links" (
+    "id" UUID NOT NULL DEFAULT uuidv7(),
+    "project_id" UUID NOT NULL,
+    "scope_type" TEXT NOT NULL,
+    "scope_target_id" UUID,
+    "token_hash" TEXT NOT NULL,
+    "issued_by_member_id" UUID NOT NULL,
+    "issued_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMPTZ NOT NULL,
+    "revoked_at" TIMESTAMPTZ,
+    "last_accessed_at" TIMESTAMPTZ,
+
+    CONSTRAINT "share_links_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "ck_sl_scope_type" CHECK ("scope_type" IN ('project', 'item', 'plan')),
+    -- 'project' のときは scope_target_id NULL、'item'/'plan' のときは NOT NULL
+    CONSTRAINT "ck_sl_scope_target" CHECK (
+        ("scope_type" = 'project' AND "scope_target_id" IS NULL)
+        OR
+        ("scope_type" IN ('item', 'plan') AND "scope_target_id" IS NOT NULL)
+    ),
+    CONSTRAINT "ck_sl_expires_after_issued" CHECK ("expires_at" > "issued_at")
+);
+
+COMMENT ON TABLE "share_links" IS '非会員 URL 共有 (token_hash = SHA-256, scope は project/item/plan)';
+
+-- -----------------------------------------------------------------------------
+-- Indexes
+-- -----------------------------------------------------------------------------
+CREATE UNIQUE INDEX "uq_sl_token_hash" ON "share_links"("token_hash");
+CREATE INDEX "idx_sl_project_id" ON "share_links"("project_id");
+-- 有効な共有のみを高速検索 (リンク受信時の検証用)
+CREATE INDEX "idx_sl_token_hash_active" ON "share_links"("token_hash")
+  WHERE "revoked_at" IS NULL AND "expires_at" > now();
+
+-- -----------------------------------------------------------------------------
+-- Foreign keys
+-- -----------------------------------------------------------------------------
+ALTER TABLE "share_links"
+  ADD CONSTRAINT "fk_sl_project_id"
+  FOREIGN KEY ("project_id") REFERENCES "projects"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "share_links"
+  ADD CONSTRAINT "fk_sl_issued_by_member_id"
+  FOREIGN KEY ("issued_by_member_id") REFERENCES "project_members"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- audit_logs.share_link_id の FK を後付け (init_auth 時はカラムだけ作っていた)
+ALTER TABLE "audit_logs"
+  ADD CONSTRAINT "fk_al_share_link_id"
+  FOREIGN KEY ("share_link_id") REFERENCES "share_links"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -72,6 +72,7 @@ model Project {
   members     ProjectMember[]
   items       ProjectItem[]
   invitations Invitation[]
+  shareLinks  ShareLink[]
 
   @@index([organizationId], map: "idx_projects_organization_id")
   @@index([createdBy, status], map: "idx_projects_created_by_status")
@@ -106,6 +107,7 @@ model ProjectMember {
   plansFrom         Plan[]       @relation("PlanFromMember")
   plansTo           Plan[]       @relation("PlanToMember")
   ballEventsAsActor BallEvent[]
+  shareLinksIssued  ShareLink[]
 
   @@unique([projectId, email], map: "uq_pm_project_email")
   @@index([projectId, sortOrder], map: "idx_pm_project_sort")
@@ -271,10 +273,38 @@ model AuditLog {
   userAgent    String?  @map("user_agent")
   extra        Json     @default("{}")
 
-  actor User? @relation(fields: [actorUserId], references: [id], onDelete: SetNull, map: "fk_al_actor_user_id")
+  actor     User?      @relation(fields: [actorUserId], references: [id], onDelete: SetNull, map: "fk_al_actor_user_id")
+  shareLink ShareLink? @relation(fields: [shareLinkId], references: [id], onDelete: SetNull, map: "fk_al_share_link_id")
 
   @@index([occurredAt(sort: Desc)], map: "idx_al_occurred_at_desc")
   @@index([actorUserId, occurredAt(sort: Desc)], map: "idx_al_actor_user_id_occurred_at")
   @@index([resourceType, resourceId], map: "idx_al_resource")
   @@map("audit_logs")
+}
+
+// -----------------------------------------------------------------------------
+// share_links — 非会員 URL 共有 (v1.1, Phase 0)
+// 設計書 §2.4.9
+// -----------------------------------------------------------------------------
+model ShareLink {
+  id               String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  projectId        String    @map("project_id") @db.Uuid
+  /// 'project' | 'item' | 'plan' (CHECK 制約)
+  scopeType        String    @map("scope_type")
+  /// scope_type='project' なら NULL (整合性 CHECK で強制)
+  scopeTargetId    String?   @map("scope_target_id") @db.Uuid
+  /// SHA-256 ハッシュ。生トークンは保存しない
+  tokenHash        String    @unique(map: "uq_sl_token_hash") @map("token_hash")
+  issuedByMemberId String    @map("issued_by_member_id") @db.Uuid
+  issuedAt         DateTime  @default(now()) @map("issued_at") @db.Timestamptz
+  expiresAt        DateTime  @map("expires_at") @db.Timestamptz
+  revokedAt        DateTime? @map("revoked_at") @db.Timestamptz
+  lastAccessedAt   DateTime? @map("last_accessed_at") @db.Timestamptz
+
+  project        Project       @relation(fields: [projectId], references: [id], onDelete: Cascade, map: "fk_sl_project_id")
+  issuedByMember ProjectMember @relation(fields: [issuedByMemberId], references: [id], onDelete: Restrict, map: "fk_sl_issued_by_member_id")
+  auditLogs      AuditLog[]
+
+  @@index([projectId], map: "idx_sl_project_id")
+  @@map("share_links")
 }


### PR DESCRIPTION
## Summary

Phase 0 残り 2 サブフェーズの 2 つ目。非会員 URL 共有を実装し、これで Phase 0 機能スコープは完成です（Sub-Phase 0.6 は仕上げ・Resend 本実装・本番デプロイ・監視のみ）。

## DB

- Prisma に **`share_links`** を追加（UUID v7、scope_type は `project`/`item`/`plan`）
- マイグレーション `20260527000001_init_share_links`：
  - **CHECK**：`ck_sl_scope_type` / `ck_sl_scope_target`（scope_type と scope_target_id の整合性）/ `ck_sl_expires_after_issued`
  - **UNIQUE**：`uq_sl_token_hash`
  - 部分インデックス `idx_sl_token_hash_active`（`revoked_at IS NULL AND expires_at > now()`）
  - `audit_logs.share_link_id` の **FK を後付け**で追加

## BE

- `services/shareLinks.ts`：発行 / 一覧 / revoke / `findActiveShareLinkByRawToken` / `touchShareLinkAccess`
- `services/shareAccess.ts`：
  - `viewShare`：scope に応じてプロジェクト・制作物・予定をフィルタ
  - `shareToss` / `shareComplete`：非会員操作（source='auto_chain' + actor 両方 NULL で `ck_be_actor_consistency` を満たす）
  - 完了時の successor **自動連鎖**も維持
- `routes/v1/shareLinks.ts`：`/projects/:projectId/share-links` 3 本（ディレクター認可で発行 / revoke）
- `routes/v1/share.ts`：未認証可、`X-Robots-Tag: noindex,nofollow` を返却。GET `/share/:token` / POST `/share/:token/plans/:planId/{toss,complete}`
- 全アクセスを **audit_logs に `share_link_id` + IP + UA で記録**

## FE

- `features/shareLinks/api.ts`：認証あり / 未認証クライアント両方のラッパー
- **SC-16 ShareLinksPage** `/projects/:projectId/share-links`：
  - 発行ダイアログ（scope 選択 + 有効期限）→ **発行直後のみ URL 表示 + コピーボタン**（再表示不可を明示）
  - 一覧（状態バッジ + 有効期限 + 失効ボタン）
- **`/share/:token` SharePage**（未認証）：
  - `<meta name="robots" content="noindex, nofollow, noarchive">` を**動的注入**
  - scope 範囲のプロジェクト / 制作物 / 予定リスト
  - 各予定に TOSS / 完了ボタン（ballState で出し分け）
  - 期限切れ・失効・未存在は同一 404 UX に集約
- `ProjectEditPage` に「共有リンクを管理」リンクを追加

## 設計書差分メモ

- **非会員操作の audit 記録**：`ck_be_actor_consistency` を満たすため `source='auto_chain'` + actor 両方 NULL で記録しています（本来は `source='share'` を追加すべき）。Phase 1 で `source='share'` を ALTER 追加し ck_be_actor_consistency を更新する想定です
- Phase 0 範囲では「個人特定入力（表示名やメール）」は未実装（設計書 §5.6 でも optional 扱い）

## Tests

- `schemas/shareLinks.test.ts`：6 ケース（scope 整合性 / uuid / expires 上限）
- `routes/share.test.ts`：認証なし 401、未知トークン 404 集約
- **全体 51 tests passing**

## 検証

- [x] `pnpm type-check` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test` 通過（51 tests passing）
- [x] `pnpm build` 通過
- [ ] **ローカル E2E**：プロジェクト作成 → 共有リンク発行（scope=project）→ 別ブラウザで `/share/:token` を開く → TOSS / 完了が動く → revoke 後はアクセス拒否

## Phase 0 機能実装は本 PR で完了 🎉

残り **Sub-Phase 0.6**（仕上げ）：
- Resend 本実装に差し替え（招待メール / 招待リマインド）
- Sentry プロジェクト作成 + PII scrub
- Better Stack Uptime で `/healthz` 監視
- **GitHub Release → Production デプロイ** ワークフロー (`release-deploy.yml`)
- Supabase Pro 昇格手順 / PITR 有効化
- DB ロール分離（`app_user` / `app_migrator`）
- CSP nonce 化（unsafe-inline 撤去）
- セキュリティチェックリスト最終確認
- README / 設計書アップデート（Sub-Phase 0.1〜0.5 の差分整理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)