### PR TITLE
refactor(supabase): Legacy API keys から新方式 publishable/secret keys へ移行

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,14 +16,18 @@ SERVER_PORT=3001
 
 # --- Supabase ---
 # Local: supabase start で出力される値を貼る
-# Prod : Supabase Dashboard より取得
+# Prod : Supabase Dashboard → Settings → API より取得
+# 新方式 API キー（推奨, sb_publishable_* / sb_secret_*）を使用。
+# Legacy API keys（anon / service_role JWT）は 2026 年末でサポート終了予定。
 SUPABASE_URL=http://127.0.0.1:54321
-SUPABASE_ANON_KEY=
-SUPABASE_SERVICE_ROLE_KEY=
+SUPABASE_SECRET_KEY=
+# 旧名 SUPABASE_SERVICE_ROLE_KEY は deprecated。BE は後方互換あり
+# (SUPABASE_SECRET_KEY が未設定なら SUPABASE_SERVICE_ROLE_KEY にフォールバック)
+# SUPABASE_SERVICE_ROLE_KEY=
 
 # FE 側で参照する公開キー (Vite は VITE_ プレフィックスのみ公開)
 VITE_SUPABASE_URL=http://127.0.0.1:54321
-VITE_SUPABASE_ANON_KEY=
+VITE_SUPABASE_PUBLISHABLE_KEY=
 VITE_API_BASE_URL=/api/v1
 
 # --- Database (Prisma) ---

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -21,7 +21,9 @@ Supabase CLI が必要（未導入の場合 `brew install supabase/tap/supabase`
 supabase start                # Postgres / Auth / Studio / Inbucket をローカル起動
 ```
 
-起動後、Supabase CLI が表示する `service_role key` / `anon key` / `Studio URL` / `Inbucket URL` を控える。
+起動後、Supabase CLI が表示する `Publishable key` (`sb_publishable_*`) / `Secret key` (`sb_secret_*`) / `Studio URL` / `Inbucket URL` を控える。
+
+> 旧 Legacy API keys（`anon` / `service_role` JWT）を使っている場合、BE は `SUPABASE_SERVICE_ROLE_KEY` への後方互換を残しているのでそのまま動く（2026 年末でサポート終了予定）。新方式への切替推奨。
 
 ### 3. 環境変数を `.env.local` に設定
 
@@ -30,8 +32,8 @@ supabase start                # Postgres / Auth / Studio / Inbucket をローカ
 ```bash
 cp .env.example apps/web/.env.local
 # 編集:
-#   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
-#   VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY
+#   SUPABASE_URL, SUPABASE_SECRET_KEY (sb_secret_*)
+#   VITE_SUPABASE_URL, VITE_SUPABASE_PUBLISHABLE_KEY (sb_publishable_*)
 #   DATABASE_URL, DIRECT_URL
 ```
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.1",
-    "@supabase/supabase-js": "^2.46.1",
+    "@supabase/supabase-js": "^2.106.2",
     "@tanstack/react-query": "^5.59.20",
     "@trakon/db": "workspace:*",
     "@trakon/shared": "workspace:*",

--- a/apps/web/server/lib/env.ts
+++ b/apps/web/server/lib/env.ts
@@ -1,23 +1,41 @@
 import { z } from 'zod';
 
-const envSchema = z.object({
-  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
-  APP_ENV: z.enum(['local', 'dev', 'prod', 'test']).default('local'),
-  SUPABASE_URL: z.string().url(),
-  SUPABASE_SERVICE_ROLE_KEY: z.string().min(20),
-  SUPABASE_JWT_AUD: z.string().default('authenticated'),
-  DATABASE_URL: z.string().url().optional(),
-  DIRECT_URL: z.string().url().optional(),
-  SERVER_PORT: z.coerce.number().default(3001),
-  /** 招待 URL の組み立てに使用 (FE オリジン) */
-  PUBLIC_APP_URL: z.string().url().default('http://localhost:5173'),
-  /** Resend 本実装 (未設定なら dummy mailer にフォールバック) */
-  RESEND_API_KEY: z.string().optional(),
-  RESEND_FROM_EMAIL: z.string().optional(),
-  /** Sentry エラー監視 (未設定なら no-op) */
-  SENTRY_DSN: z.string().optional(),
-  SENTRY_ENVIRONMENT: z.string().optional(),
-});
+const envSchema = z
+  .object({
+    NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+    APP_ENV: z.enum(['local', 'dev', 'prod', 'test']).default('local'),
+    SUPABASE_URL: z.string().url(),
+    /**
+     * Supabase secret key (`sb_secret_*`) — 新方式 (推奨)。
+     * 未設定なら deprecated な SUPABASE_SERVICE_ROLE_KEY (JWT) にフォールバック。
+     * Supabase Legacy API keys は 2026 年末でサポート終了予定。
+     */
+    SUPABASE_SECRET_KEY: z.string().min(20).optional(),
+    /** @deprecated 新方式 SUPABASE_SECRET_KEY を使用すること。 */
+    SUPABASE_SERVICE_ROLE_KEY: z.string().min(20).optional(),
+    SUPABASE_JWT_AUD: z.string().default('authenticated'),
+    DATABASE_URL: z.string().url().optional(),
+    DIRECT_URL: z.string().url().optional(),
+    SERVER_PORT: z.coerce.number().default(3001),
+    /** 招待 URL の組み立てに使用 (FE オリジン) */
+    PUBLIC_APP_URL: z.string().url().default('http://localhost:5173'),
+    /** Resend 本実装 (未設定なら dummy mailer にフォールバック) */
+    RESEND_API_KEY: z.string().optional(),
+    RESEND_FROM_EMAIL: z.string().optional(),
+    /** Sentry エラー監視 (未設定なら no-op) */
+    SENTRY_DSN: z.string().optional(),
+    SENTRY_ENVIRONMENT: z.string().optional(),
+  })
+  .refine((d) => Boolean(d.SUPABASE_SECRET_KEY ?? d.SUPABASE_SERVICE_ROLE_KEY), {
+    message:
+      'SUPABASE_SECRET_KEY (推奨, sb_secret_*) または SUPABASE_SERVICE_ROLE_KEY (deprecated) のいずれかが必要',
+    path: ['SUPABASE_SECRET_KEY'],
+  })
+  .transform((d) => ({
+    ...d,
+    // 優先順: SUPABASE_SECRET_KEY → SUPABASE_SERVICE_ROLE_KEY
+    SUPABASE_SECRET_KEY: (d.SUPABASE_SECRET_KEY ?? d.SUPABASE_SERVICE_ROLE_KEY) as string,
+  }));
 
 export type ServerEnv = z.infer<typeof envSchema>;
 

--- a/apps/web/server/lib/supabaseAdmin.ts
+++ b/apps/web/server/lib/supabaseAdmin.ts
@@ -7,7 +7,7 @@ let cached: SupabaseClient | undefined;
 export function getSupabaseAdmin(): SupabaseClient {
   if (cached) return cached;
   const env = getServerEnv();
-  cached = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+  cached = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
   return cached;

--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -1,15 +1,15 @@
 import { createClient } from '@supabase/supabase-js';
 
 const url = import.meta.env.VITE_SUPABASE_URL;
-const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const publishableKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
-if (!url || !anonKey) {
+if (!url || !publishableKey) {
   throw new Error(
-    '[trakon] VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY are required. See .env.example.',
+    '[trakon] VITE_SUPABASE_URL / VITE_SUPABASE_PUBLISHABLE_KEY are required. See .env.example.',
   );
 }
 
-export const supabase = createClient(url, anonKey, {
+export const supabase = createClient(url, publishableKey, {
   auth: {
     persistSession: true,
     autoRefreshToken: true,

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -3,7 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
   readonly VITE_SUPABASE_URL: string;
-  readonly VITE_SUPABASE_ANON_KEY: string;
+  readonly VITE_SUPABASE_PUBLISHABLE_KEY: string;
   readonly VITE_SENTRY_DSN: string;
 }
 

--- a/docs/design/implementation-notes.md
+++ b/docs/design/implementation-notes.md
@@ -16,6 +16,7 @@ Sub-Phase 0.0〜0.6 の実装過程で、基本設計書 v1.1 から意図的に
 | **HIBP / ロックアウト / レート制限** | Phase 1 | **未実装**（設計書通り） | — | Phase 1 で Upstash + Edge Functions 検討 |
 | **Resend 送信失敗時のリトライ** | Phase 1 で Inngest 非同期化 | **同期送信 + 失敗で transaction rollback** | Phase 0 は単純さ優先 | Inngest で非同期化、再送ジョブ追加 |
 | **マイグレーション diff の自動生成** | `prisma migrate dev` 推奨 | **手書き SQL** で CHECK 制約・トリガを明示 | `prisma migrate dev` だけでは CHECK / トリガ / 部分インデックスを自動生成できない | 設計書 §6.9 に追記想定 |
+| **Supabase キー新方式移行（Phase 1 直前）** | 設計書 §6 は Legacy API keys（`anon` JWT / `service_role` JWT）前提 | **新方式 `sb_publishable_*` / `sb_secret_*` へ移行**。BE 側 env は `SUPABASE_SECRET_KEY` 優先 / `SUPABASE_SERVICE_ROLE_KEY` フォールバック、FE 側は `VITE_SUPABASE_PUBLISHABLE_KEY` に完全切替。JWT 署名キーとは独立管理になったため、`server/middleware/auth.ts` の iss/aud/JWKS 検証ロジックは不変 | Supabase Legacy API keys は 2026 年末でサポート終了予定。商用デプロイ前に新方式へ寄せて将来負債を回避。supabase-js は ^2.106.2 へ更新（新キー形式は apikey ヘッダーに渡すだけで透過対応） | 設計書 v1.2 § 6 環境変数表を新方式に書き換え |
 
 ## 設計書 v1.2 で追加・改訂すべき項目（提案）
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -32,7 +32,9 @@ Phase 0 商用リリースに必要な **外部サービスのセットアップ
 
 1. <https://supabase.com/dashboard> で **Tokyo リージョン** にプロジェクト作成
 2. Database → Connection Pooling から `DATABASE_URL`（Transaction）と `DIRECT_URL`（Session）を控える
-3. Settings → API から `Project URL` / `anon key` / `service_role key` を控える
+3. Settings → API から `Project URL` / **`Publishable key`**（`sb_publishable_*`）/ **`Secret key`**（`sb_secret_*`）を控える
+   - **新方式 API キー（Publishable / Secret）を使用すること**。旧 Legacy API keys（`anon` / `service_role` JWT）は 2026 年末でサポート終了予定
+   - BE は旧 `SUPABASE_SERVICE_ROLE_KEY` への後方互換を残しているが、新規プロジェクトは Secret key で投入する
 4. 初回のみ DB ロール分離 SQL を実行（[2.5 節](#25-db-ロール分離)）
 5. Prisma マイグレーションを `migrate deploy` で適用：
    ```bash

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^8.40.0
         version: 8.55.2(react@18.3.1)
       '@supabase/supabase-js':
-        specifier: ^2.46.1
-        version: 2.106.1
+        specifier: ^2.106.2
+        version: 2.106.2
       '@tanstack/react-query':
         specifier: ^5.59.20
         version: 5.100.14(react@18.3.1)
@@ -1595,31 +1595,31 @@ packages:
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
 
-  '@supabase/auth-js@2.106.1':
-    resolution: {integrity: sha512-7eyheXfAGwkB9bZewJPs+N3UYt6kra2JG6mIxNEgbkvcO15PLD1e75PTIUEYYl3zrifm3GrpShVl7QZxKrXO/w==}
+  '@supabase/auth-js@2.106.2':
+    resolution: {integrity: sha512-VcAjUErkHkhC5Jaf+g/G1qbkQrFh8edaCdHa7pxJmHUjkWKjT7UnYCtPA89XV0N0GIYRkEqJZw5V62CtOxTmBQ==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/functions-js@2.106.1':
-    resolution: {integrity: sha512-XbOPnR2mW7jp/EcW447xmGwCa+/Wc00Hkw8t4tUIJjRsHQ4xAESsLKcyLRhRJjJoUnJVXUlC+w0wUxUCM7CG2A==}
+  '@supabase/functions-js@2.106.2':
+    resolution: {integrity: sha512-oRnr0QrL8H+zTO1YyQ1QjiHZU/957jvubbxSJTUm2XLAgzoGGV9Tahfyd+uvLsBLRVmXLtpU3oyCjdQIvkGMOA==}
     engines: {node: '>=20.0.0'}
 
   '@supabase/phoenix@0.4.2':
     resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
 
-  '@supabase/postgrest-js@2.106.1':
-    resolution: {integrity: sha512-Qbn6d2lqiqeaBX1Uko0e/hL90dtQGRN6CG2wMVQtJpRFstlVW45qmUTyTOsiB8dYUWu1fWYo4YzJuDbokGv3tQ==}
+  '@supabase/postgrest-js@2.106.2':
+    resolution: {integrity: sha512-tDOzyPgp9pIRMR2x6C9+uDSJrnXSzxLtt3d7nC+Lrsy3jnJDHYfdQC/xcRyhJE/TOBJ0heSqRKR3UmejDjZxsw==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/realtime-js@2.106.1':
-    resolution: {integrity: sha512-eQCYri5E8KsjpDgC7g28cOOS2britjUWdNSJluFMainqrMRepzjOnaxqXc3RoAz7H0dxmBrfLUNF6NGP8C+YaA==}
+  '@supabase/realtime-js@2.106.2':
+    resolution: {integrity: sha512-LdRGT7DNhyZkPjubUv5bSdAZ0jSEX8wTHvx7htj7+K59TOZRvz4TuQK7tL2RWxyIZVeFMRluL04SzWS61rKnUA==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/storage-js@2.106.1':
-    resolution: {integrity: sha512-HWcLIhqinhWKpOQ3WzglR2unjW0eh9J7yOu3IZrZNIEkraK4La/HDvTqndljGsNw0itPtyHhuKBxRoPG1VUARw==}
+  '@supabase/storage-js@2.106.2':
+    resolution: {integrity: sha512-xgKCSYuev1YarV+iVqr+zlfgSyremnJtn8T0NCT8L4XmMv1CLtESc0Q6kNp8+mKWdX/8ND0nzm7OMKx08kwNAw==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/supabase-js@2.106.1':
-    resolution: {integrity: sha512-gP4HurGkGu7Z3xoOCjtAI17BKKp7jpsmwY0Ssbsks9XQRzJ7ZhK7LxfLdBSYgUdgZCQgjRK+Mr7+cl4Gxrk0Rw==}
+  '@supabase/supabase-js@2.106.2':
+    resolution: {integrity: sha512-2/RZ/1fmJx/MRSEDG2Xk8+J4JVk5clM9V0uSI6kUTrcS32KA89DtqI5RUOC9r6mzY3WBC9qexLjssIHjbLyVJA==}
     engines: {node: '>=20.0.0'}
 
   '@tailwindcss/node@4.3.0':
@@ -5380,37 +5380,37 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
 
-  '@supabase/auth-js@2.106.1':
+  '@supabase/auth-js@2.106.2':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/functions-js@2.106.1':
+  '@supabase/functions-js@2.106.2':
     dependencies:
       tslib: 2.8.1
 
   '@supabase/phoenix@0.4.2': {}
 
-  '@supabase/postgrest-js@2.106.1':
+  '@supabase/postgrest-js@2.106.2':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/realtime-js@2.106.1':
+  '@supabase/realtime-js@2.106.2':
     dependencies:
       '@supabase/phoenix': 0.4.2
       tslib: 2.8.1
 
-  '@supabase/storage-js@2.106.1':
+  '@supabase/storage-js@2.106.2':
     dependencies:
       iceberg-js: 0.8.1
       tslib: 2.8.1
 
-  '@supabase/supabase-js@2.106.1':
+  '@supabase/supabase-js@2.106.2':
     dependencies:
-      '@supabase/auth-js': 2.106.1
-      '@supabase/functions-js': 2.106.1
-      '@supabase/postgrest-js': 2.106.1
-      '@supabase/realtime-js': 2.106.1
-      '@supabase/storage-js': 2.106.1
+      '@supabase/auth-js': 2.106.2
+      '@supabase/functions-js': 2.106.2
+      '@supabase/postgrest-js': 2.106.2
+      '@supabase/realtime-js': 2.106.2
+      '@supabase/storage-js': 2.106.2
 
   '@tailwindcss/node@4.3.0':
     dependencies:


### PR DESCRIPTION
## 概要

**Phase 1 着手前の小規模リファクタ。** Supabase が 2026 年末で Legacy API keys（`anon` JWT / `service_role` JWT）のサポートを終了するため、商用デプロイ前に新方式 (`sb_publishable_*` / `sb_secret_*`) へ寄せて将来負債を回避する。

Supabase 公式 docs に `You cannot send a publishable or secret key in the Authorization: Bearer ... header` と明記されているため、`@supabase/supabase-js` も最新安定版へ更新（実際は新キー形式は `apikey` ヘッダーに渡すだけで透過対応で、changelog でも特別なバージョン要件は無いが、最新安定版に揃えるのが安全）。

## 主な変更

| ファイル | 変更 |
|---|---|
| `apps/web/package.json` | `@supabase/supabase-js` を `^2.46.1` → `^2.106.2`（最新安定版, 2026-05-25） |
| `apps/web/server/lib/env.ts` | `SUPABASE_SECRET_KEY`（新）を追加。両方 optional にし、refine で「いずれか必須」、transform で「`SUPABASE_SECRET_KEY` 優先、無ければ `SUPABASE_SERVICE_ROLE_KEY` にフォールバック」を確定 |
| `apps/web/server/lib/supabaseAdmin.ts` | `createClient` に `env.SUPABASE_SECRET_KEY` を渡す（解決済み値） |
| `apps/web/src/lib/supabase.ts` | `VITE_SUPABASE_ANON_KEY` → `VITE_SUPABASE_PUBLISHABLE_KEY` に完全切替 |
| `apps/web/src/vite-env.d.ts` | 同上の型定義更新 |
| `.env.example` | 新方式 env 名へ。旧名は deprecated コメント付き |
| `apps/web/README.md` | env 例とセットアップ手順を新方式に。Supabase CLI 出力の Publishable / Secret key を控える旨を追記 |
| `docs/operations.md` § 2.2 | Settings → API の取得値を新方式名に更新。旧 `service_role` JWT との後方互換も明記 |
| `docs/design/implementation-notes.md` | 「Supabase キー新方式移行（Phase 1 直前）」項目を追加。設計書 v1.2 § 6 改訂を予約 |

## 後方互換性ポリシー（重要）

| 層 | 旧 → 新 | 後方互換 | 理由 |
|---|---|---|---|
| **BE** | `SUPABASE_SERVICE_ROLE_KEY` → `SUPABASE_SECRET_KEY` | **両方サポート**（新優先・旧フォールバック） | runtime 読み込みで判定コストが低く、既存テスト 51 件をそのまま緑にできる |
| **FE** | `VITE_SUPABASE_ANON_KEY` → `VITE_SUPABASE_PUBLISHABLE_KEY` | **新名のみ**（完全切替） | Vite は build-time に焼き込むため両立メリットが薄く、env 名の二重管理が運用負担になる |

## 商用デプロイ手順への影響（Vercel Env 更新が必要）

Vercel Environment Variables を以下のとおり更新してください：

| 旧 env 名 | 新 env 名 | 必要な対応 |
|---|---|---|
| `VITE_SUPABASE_ANON_KEY` | **`VITE_SUPABASE_PUBLISHABLE_KEY`** | **リネーム必須**（値は Supabase Dashboard の `Publishable key` = `sb_publishable_*`）。本 PR マージ後の最初のデプロイで適用 |
| `SUPABASE_SERVICE_ROLE_KEY` | `SUPABASE_SECRET_KEY` | **当面そのまま動く**（後方互換あり）。落ち着いてから順次 `SUPABASE_SECRET_KEY` = `sb_secret_*` に切替推奨 |

`.github/workflows/release-deploy.yml` の GitHub Actions Secrets には Supabase キーは含まれていない（`PROD_DATABASE_URL` / `PROD_DIRECT_URL` のみ）ため、Secrets 側の更新は不要。

## JWT 検証ミドルウェアへの影響

`apps/web/server/middleware/auth.ts` は **変更不要**。

Supabase 公式 docs（[Signing Keys](https://supabase.com/docs/guides/auth/signing-keys)）に `Publishable and secret API keys no longer are based on the JWT signing key and can be independently managed.` と明記されており、新方式 API キーは JWT 署名キーから分離して独立管理される。

そのため、ユーザー access_token は引き続き：
- **issuer**: `${env.SUPABASE_URL}/auth/v1`
- **audience**: `authenticated`（`SUPABASE_JWT_AUD` の default）
- **JWKS**: `${env.SUPABASE_URL}/auth/v1/.well-known/jwks.json`
- **algorithm**: RS256

で発行される。`jose` + JWKS による現行検証ロジックはそのまま動作する。

## supabase-js のバージョン選定根拠

公式 changelog（`master/CHANGELOG.md`, 2.74.0〜2.106.2）を確認したところ、`publishable` / `secret` / `sb_publishable` / `sb_secret` への明示的な対応コミットは無い。これは「新キーは `apikey` ヘッダーに渡す文字列が変わるだけ」で、SDK 側に特別対応が不要だから（公式 docs の `except if the value exactly equals the apikey header` 条項により、SDK が apikey と Authorization の両ヘッダーに同じ値を送る既存挙動と互換）。

それでも商用前に**最新安定版 2.106.2** に揃えるのが、

- セキュリティパッチ（auth系の小さな fix が複数）の取り込み
- 公式の renaming docs PR（[#2280](https://github.com/supabase/supabase-js/pull/2280)）が反映された後のバージョンで揃える

の二点で望ましい。

## 検証

```bash
pnpm db:generate
pnpm type-check     # ✅
pnpm lint           # ✅
pnpm test           # ✅ Test Files 14 passed (14), Tests 51 passed (51)
pnpm build          # ✅ built in 2.79s
```

既存 51 件のテストは無変更で全部 pass。env 後方互換により `process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key-1234567890'` を設定している既存テスト（auth/dashboard/invitations/plans/projects/share）はそのまま動く。

## 設計書 v1.1 への影響

破壊的変更なし。`docs/design/06-infrastructure.md` の env 表は次回改訂（v1.2）で書き換える方針として `docs/design/implementation-notes.md` に追記済み。

## Sub-Phase 位置付け

- Phase 0 完了直後（PR #13 マージ後）
- Phase 1 着手前の小規模リファクタ
- 機能追加・破壊的変更なし、純粋にキー方式の移行のみ
