### PR TITLE
docs(setup): ローカル起動手順の整備と env 配線・マイグレーション修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,81 @@ trakon-app/
 
 ---
 
-## セットアップ
+## ローカルセットアップ
 
-> Phase 0 実装着手とともに整備します。
+Supabase ローカルスタック（Postgres / Auth / Studio / メール確認）にフル接続して、FE + API を一度に立ち上げる手順。FE/API は同一オリジン（Vite が `/api` を Hono にプロキシ）なので追加設定は不要。
 
-設計上の方針：
+### 前提
+
+| ツール | 要件 | 確認 |
+|---|---|---|
+| Node.js | 20〜22（`.nvmrc` 準拠） | `node -v` |
+| pnpm | 10 系 | `pnpm -v` |
+| Docker | **起動していること**（Supabase ローカルが利用） | `docker info` |
+| Supabase CLI | `pnpm dlx supabase`（都度実行）または `brew install supabase/tap/supabase`（常設） | `pnpm dlx supabase --version` |
+
+### 手順
+
+```bash
+# 1. 依存インストール + Prisma クライアント生成
+pnpm install
+pnpm db:generate
+
+# 2. Supabase ローカルスタックを起動（初回は Docker イメージ取得で数分）
+pnpm dlx supabase start
+#   → 出力される Project URL / Publishable key / Secret key / DB URL を控える
+
+# 3. 環境変数ファイルを作成し、上記の値を反映
+cp .env.example apps/web/.env.local
+#   apps/web/.env.local を編集:
+#     SUPABASE_URL / SUPABASE_SECRET_KEY            (sb_secret_*)
+#     VITE_SUPABASE_URL / VITE_SUPABASE_PUBLISHABLE_KEY (sb_publishable_*)
+#     DATABASE_URL / DIRECT_URL                     (postgresql://postgres:postgres@127.0.0.1:54322/postgres?schema=public)
+
+# 4. マイグレーションをローカル DB へ適用
+pnpm db:deploy
+
+# 5. 開発サーバ起動（Vite 5173 + Hono 3001 を同時起動）
+pnpm dev
+```
+
+ブラウザで **http://localhost:5173** を開く。
+
+### アクセス先
+
+| 用途 | URL |
+|---|---|
+| アプリ（SPA） | http://localhost:5173 |
+| API ヘルスチェック | http://localhost:5173/api/v1/healthz |
+| Supabase Studio（DB GUI） | http://127.0.0.1:54323 |
+| 受信メール確認（Magic-link 等） | http://127.0.0.1:54324 |
+
+### Magic-link でログインを試す
+
+1. http://localhost:5173/login?screen=signup でメールアドレスを入力して送信
+2. http://127.0.0.1:54324 （メール確認 UI）に届いたメールのリンクを開く
+3. プロフィール入力後 `/dashboard` へ
+
+> 詳細な認証フロー・OAuth 設定は [apps/web/README.md](apps/web/README.md) を参照。
+
+### 環境変数の読み込み（仕組み）
+
+実値は **`apps/web/.env.local`**（gitignore）に集約する。Vite（FE）はこのファイルを自動ロードする。Hono dev サーバと Prisma は自動ロードしないため、`dotenv-cli` 経由で同ファイルを注入している（`dev:server` / `db:*` スクリプトに配線済み）。
+
+### よく使うコマンド
+
+| コマンド | 内容 |
+|---|---|
+| `pnpm dev` | FE + API を同時起動 |
+| `pnpm db:deploy` | 既存マイグレーションをローカル DB へ非対話で適用（初回セットアップ向け） |
+| `pnpm db:migrate` | 新規マイグレーション作成（スキーマ変更を伴う開発時） |
+| `pnpm db:studio` | Prisma Studio を起動 |
+| `pnpm dlx supabase stop` | Supabase ローカルスタックを停止 |
+| `Ctrl + C` | 開発サーバ停止 |
+
+> 補足: `pnpm db:migrate`（`prisma migrate dev`）は、`schema.prisma` の `@unique` と生 SQL の部分ユニークインデックスの差分により非対話環境で確認プロンプトを返すことがある。初回適用・ローカル再構築では `pnpm db:deploy` を使う。
+
+設計上の方針（背景）：
 - ローカル開発 DB：[docs/design/06-infrastructure.md](docs/design/06-infrastructure.md)（§6.3.4、Supabase CLI でフルローカル）
 - 環境変数：[docs/design/06-infrastructure.md](docs/design/06-infrastructure.md)（§6.5.3 / §6.7）
 - マイグレーション運用：[docs/design/06-infrastructure.md](docs/design/06-infrastructure.md)（§6.9）

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -40,8 +40,11 @@ cp .env.example apps/web/.env.local
 ### 4. マイグレーション適用
 
 ```bash
-pnpm db:migrate                # prisma migrate dev
+pnpm db:deploy                 # 既存マイグレーションをローカル DB へ非対話で適用
 ```
+
+> 環境変数は `apps/web/.env.local` から `dotenv-cli` 経由で自動注入される（`db:*` / `dev:server` スクリプトに配線済み）。
+> 新規マイグレーションを作成する開発時のみ `pnpm db:migrate`（`prisma migrate dev`）を使う。
 
 ### 5. 開発サーバ起動
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "concurrently -n web,api -c blue,magenta \"pnpm dev:web\" \"pnpm dev:server\"",
     "dev:web": "vite",
-    "dev:server": "tsx watch server/dev.ts",
+    "dev:server": "dotenv -e .env.local -- tsx watch server/dev.ts",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext .ts,.tsx --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
     "test": "pnpm -r --parallel test",
     "db:generate": "pnpm --filter @trakon/db generate",
     "db:migrate": "pnpm --filter @trakon/db migrate",
+    "db:deploy": "pnpm --filter @trakon/db migrate:local",
     "db:studio": "pnpm --filter @trakon/db studio",
     "format": "prettier --write \"apps/**/*.{ts,tsx,js,jsx,json,css}\" \"packages/**/*.{ts,tsx,js,jsx,json}\" \"*.{json,md}\""
   },
   "devDependencies": {
     "@types/node": "^20.14.10",
+    "dotenv-cli": "^11.0.0",
     "prettier": "^3.3.3",
     "typescript": "^5.5.4"
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,9 +10,10 @@
   },
   "scripts": {
     "generate": "prisma generate",
-    "migrate": "prisma migrate dev",
+    "migrate": "dotenv -e ../../apps/web/.env.local -- prisma migrate dev",
+    "migrate:local": "dotenv -e ../../apps/web/.env.local -- prisma migrate deploy",
     "migrate:deploy": "prisma migrate deploy",
-    "studio": "prisma studio",
+    "studio": "dotenv -e ../../apps/web/.env.local -- prisma studio",
     "lint": "echo '(db) no lint configured yet'",
     "type-check": "tsc --noEmit",
     "test": "echo '(db) no tests yet'"

--- a/packages/db/prisma/migrations/20260525000001_init_projects/migration.sql
+++ b/packages/db/prisma/migrations/20260525000001_init_projects/migration.sql
@@ -114,8 +114,10 @@ CREATE INDEX "idx_pi_project_sort" ON "project_items"("project_id", "sort_order"
 CREATE UNIQUE INDEX "uq_inv_token_hash" ON "invitations"("token_hash");
 CREATE INDEX "idx_inv_project_id" ON "invitations"("project_id");
 -- 有効な招待のみを高速検索するための部分インデックス (設計書 §2.4.8)
+-- 注: expires_at > now() は now() が非 IMMUTABLE のため部分インデックス述語に置けない
+--     (有効期限の判定はクエリ側で行う)。
 CREATE INDEX "idx_inv_email_active" ON "invitations"("email")
-  WHERE "accepted_at" IS NULL AND "revoked_at" IS NULL AND "expires_at" > now();
+  WHERE "accepted_at" IS NULL AND "revoked_at" IS NULL;
 
 -- -----------------------------------------------------------------------------
 -- Foreign keys

--- a/packages/db/prisma/migrations/20260527000001_init_share_links/migration.sql
+++ b/packages/db/prisma/migrations/20260527000001_init_share_links/migration.sql
@@ -38,8 +38,10 @@ COMMENT ON TABLE "share_links" IS '非会員 URL 共有 (token_hash = SHA-256, s
 CREATE UNIQUE INDEX "uq_sl_token_hash" ON "share_links"("token_hash");
 CREATE INDEX "idx_sl_project_id" ON "share_links"("project_id");
 -- 有効な共有のみを高速検索 (リンク受信時の検証用)
+-- 注: expires_at > now() は now() が非 IMMUTABLE のため部分インデックス述語に置けない
+--     (有効期限の判定はクエリ側で行う)。
 CREATE INDEX "idx_sl_token_hash_active" ON "share_links"("token_hash")
-  WHERE "revoked_at" IS NULL AND "expires_at" > now();
+  WHERE "revoked_at" IS NULL;
 
 -- -----------------------------------------------------------------------------
 -- Foreign keys

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@types/node':
         specifier: ^20.14.10
         version: 20.19.41
+      dotenv-cli:
+        specifier: ^11.0.0
+        version: 11.0.0
       prettier:
         specifier: ^3.3.3
         version: 3.8.3
@@ -2291,6 +2294,22 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  dotenv-cli@11.0.0:
+    resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
+    hasBin: true
+
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
+    engines: {node: '>=12'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -3138,6 +3157,9 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
@@ -6165,6 +6187,21 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dotenv-cli@11.0.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      dotenv: 17.4.2
+      dotenv-expand: 12.0.3
+      minimist: 1.2.8
+
+  dotenv-expand@12.0.3:
+    dependencies:
+      dotenv: 16.6.1
+
+  dotenv@16.6.1: {}
+
+  dotenv@17.4.2: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -7131,6 +7168,8 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.14
+
+  minimist@1.2.8: {}
 
   minipass@3.3.6:
     dependencies:


### PR DESCRIPTION
## 概要

Supabase ローカルスタックにフル接続して、Web フロント (Vite) と API サーバ (Hono) を**ローカルで起動・動作確認**できるようにする。あわせて、起動を阻んでいた「整っていない仕組み」を整備した。

ルート README の「セットアップ」節がスタブ（「Phase 0 実装着手とともに整備します」）のままで、実際に起動しようとすると下記の 2 つの不備で失敗する状態だった。

## 変更内容

### 1. ローカル起動手順の整備（README）
- ルート `README.md` の「セットアップ」節を、前提 / 手順（`supabase start` → `.env.local` → `pnpm db:deploy` → `pnpm dev`）/ アクセス先一覧 / Magic-link の試し方 / よく使うコマンド一覧 を含む実手順に置換。
- `apps/web/README.md` の手順を配線変更に合わせて整合（手順4を `pnpm db:deploy` に）。

### 2. 環境変数読み込みの配線（仕組みの整備）
- 実値を集約する `apps/web/.env.local` を、**Hono dev サーバ (`tsx`) と Prisma が自動ロードしていなかった**（リポジトリに dotenv / `--env-file` の利用箇所が無く、この環境では Node の `--env-file` も version-manager shim 経由で機能しない）。
- `dotenv-cli` を devDependency として導入し、`dev:server` と `db:*` スクリプトに配線。Vite (FE) は従来どおり自動ロード。

### 3. `pnpm db:deploy` の追加
- `prisma migrate dev` は `schema.prisma` の `@unique` と生 SQL の部分ユニークインデックスの差分により、**非対話環境では確認プロンプトで exit 1** になる。初回適用・ローカル再構築向けに、`migrate deploy` ベースの非対話スクリプト `db:deploy` を追加。

### 4. マイグレーションの実バグ修正（fix）
- `idx_inv_email_active`（`init_projects`）と `idx_sl_token_hash_active`（`init_share_links`）の**部分インデックス述語に `expires_at > now()`** が含まれていた。`now()` は非 IMMUTABLE のため Postgres がインデックス述語で拒否し（`P3006: functions in index predicate must be marked IMMUTABLE`）、**これまでどの Postgres でも一度も適用できない状態**だった。
- 時刻依存条件のみ述語から除去（有効期限の判定はクエリ側で実施）。残りの `... IS NULL` 述語は IMMUTABLE で有効。

> ⚠️ このマイグレーション 2 件はリモート dev/prod DB には未適用のはずですが、スキーマに関わる変更のためレビュー時にご確認ください。

## 動作確認（ローカル）

- `pnpm dlx supabase start`（Postgres/Auth/Studio/Mailpit）→ 全サービス Healthy
- `pnpm db:deploy` → 4 マイグレーションが正常適用、exit 0
- `pnpm dev` → Vite (5173) + Hono (3001) 起動
- `http://localhost:5173/api/v1/healthz` → 200 `{"status":"ok",...}`（Vite プロキシ経由で Hono 到達）
- `http://localhost:5173` → SPA 配信（`<title>TRAKON</title>`）
- 公開エンドポイント（`/api/v1/share/:token`）→ Prisma→Postgres まで疎通しクリーンな 404

## 補足
- `apps/web/.env.local` は gitignore 済みで本 PR には含まれません。
- `migrate:deploy`（CI/リリース用、env は直接注入）は dotenv を付けず従来どおり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)