### PR TITLE
fix(ui): Input に React.forwardRef を追加して新規登録フォームの「Required」エラーを修正

### DIFF
--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -2,20 +2,23 @@ import * as React from "react";
 
 import { cn } from "./utils";
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
-  return (
-    <input
-      type={type}
-      data-slot="input"
-      className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base bg-input-background transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
-
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        data-slot="input"
+        className={cn(
+          "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base bg-input-background transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
 export { Input };


### PR DESCRIPTION
## 概要

新規登録画面（`/login?screen=signup`）でメールアドレスを入力して「認証メールを送る」を押すと、入力したにもかかわらず `Required` が表示され画面遷移しないバグを修正します。

## 根本原因

`apps/web/src/components/ui/input.tsx` の `Input` コンポーネントが `React.forwardRef` でラップされていなかったため、react-hook-form の `register()` が返す `ref` が DOM の `<input>` に届いていませんでした。

React 18 では `forwardRef` を使わない関数コンポーネントへの `ref` プロップは React によって破棄されます。その結果、フォーム送信時に react-hook-form が入力値を読み取れず `email` が `undefined` になり、zod のデフォルト必須エラー `Required` が返っていました（フォームで定義した日本語メッセージ「正しいメールアドレスを入力してください」にすら到達しない状態）。

```
form.register('email') → { name, onChange, onBlur, ref }
                                                    ↓
<Input {...form.register('email')} />
  → ref が forwardRef なしで受け取られ破棄される
  → 送信時に email = undefined
  → zod が "Required" を返す → 画面遷移しない
```

## 修正内容

`apps/web/src/components/ui/input.tsx` を `React.forwardRef` でラップし、`ref` を内部 `<input ref={ref}>` へ転送しました。スタイル・属性は一切変更していません（shadcn/ui の標準実装パターンに合わせた修正）。

## 影響範囲

同じ `<Input>` を使う以下のフォームも同時に修正されます：
- `SignupForm`（新規登録）✅ 今回のバグ
- `LoginForm`（ログイン）
- `CreateAccountForm`（アカウント作成）
- `PasswordResetRequest`（パスワードリセット）

## テスト手順

1. `supabase start` を起動し `.env.local` の `VITE_SUPABASE_*` が設定されていることを確認
2. `pnpm dev` → `/login?screen=signup` でメールアドレスを入力して「認証メールを送る」を押下
3. `Required` が表示されず、送信完了画面へ遷移することを確認
4. 不正な形式を入力した場合は「正しいメールアドレスを入力してください」が表示されることを確認
5. 認証メールは `http://127.0.0.1:54324`（Inbucket）で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)