### PR TITLE
fix(db): uuidv7() に SET search_path を追加して Supabase ローカルで動作させる

### DIFF
--- a/packages/db/prisma/migrations/20260601000001_fix_uuidv7_search_path/migration.sql
+++ b/packages/db/prisma/migrations/20260601000001_fix_uuidv7_search_path/migration.sql
@@ -1,0 +1,27 @@
+-- =============================================================================
+-- Migration: 20260601000001_fix_uuidv7_search_path
+-- uuidv7() の search_path を修正して Supabase ローカル環境で動作させる
+-- =============================================================================
+-- 問題:
+--   Supabase は pgcrypto を extensions スキーマにインストールする。
+--   init_auth で定義した uuidv7() は SET search_path を指定していないため、
+--   関数実行時に gen_random_bytes が解決できず
+--   「function gen_random_bytes(integer) does not exist」エラーになる。
+--
+-- 修正:
+--   uuidv7() に SET search_path = public, extensions を付与して再定義する。
+--   これにより public / extensions どちらに pgcrypto があっても動作する。
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION uuidv7() RETURNS uuid AS $$
+DECLARE
+  unix_ts_ms bytea;
+  buffer bytea;
+BEGIN
+  unix_ts_ms := substring(int8send((extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
+  buffer := unix_ts_ms || gen_random_bytes(10);
+  buffer := set_byte(buffer, 6, (b'01110000'::bit(8) | get_byte(buffer, 6)::bit(8) & b'00001111'::bit(8))::int);
+  buffer := set_byte(buffer, 8, (b'10000000'::bit(8) | get_byte(buffer, 8)::bit(8) & b'00111111'::bit(8))::int);
+  RETURN encode(buffer, 'hex')::uuid;
+END
+$$ LANGUAGE plpgsql VOLATILE SET search_path = public, extensions;


### PR DESCRIPTION
## 概要

プロフィール登録時（`POST /api/v1/auth/me/complete-signup`）に users への INSERT が失敗する問題を修正します。

## エラー

```
function gen_random_bytes(integer) does not exist
  at tx.user.create() in server/services/auth.ts:173
  PostgresError { code: "42883" }
```

## 根本原因

`uuidv7()` 関数（`init_auth` マイグレーションで定義）が `gen_random_bytes()` を呼び出しますが、**Supabase ローカルは `pgcrypto` を `extensions` スキーマにインストールします**。`uuidv7()` の定義時に `SET search_path` を指定していないため、関数の実行コンテキストで `extensions` スキーマが検索されず `gen_random_bytes` が見つかりません。

```sql
-- init_auth の定義（問題あり）
CREATE OR REPLACE FUNCTION uuidv7() RETURNS uuid AS $$
  ...
  buffer := unix_ts_ms || gen_random_bytes(10);  -- extensions.gen_random_bytes が見つからない
  ...
$$ LANGUAGE plpgsql VOLATILE;  -- SET search_path なし
```

## 修正

新しいマイグレーション `20260601000001_fix_uuidv7_search_path` で `uuidv7()` を `SET search_path = public, extensions` 付きで再定義します。

```sql
CREATE OR REPLACE FUNCTION uuidv7() RETURNS uuid AS $$
  ...
$$ LANGUAGE plpgsql VOLATILE SET search_path = public, extensions;
--                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
--                              public (標準 PostgreSQL) と
--                              extensions (Supabase) の両方をカバー
```

## なぜ既存マイグレーションを変更せず新規マイグレーションにするか

`init_auth` は既に各環境に適用済みのため、変更するとチェックサム不一致で `migrate deploy` が失敗します。新規マイグレーションにより既存環境・新規環境ともに安全に修正できます。

## テスト手順

1. `pnpm --filter @trakon/db migrate:local`（ローカルに適用）
2. `pnpm dev` 起動
3. 新規登録 → メール確認（Inbucket） → プロフィール登録フォーム送信
4. `complete-signup` が 500 ではなく 201 を返してダッシュボードに遷移すること
5. ログに `gen_random_bytes` エラーが出ないこと

（ローカルでの適用・動作確認済み: `All migrations have been successfully applied.`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)