### PR TITLE
fix(auth): complete-signup 後に sync キャッシュを無効化してダッシュボードへ遷移する

### DIFF
--- a/apps/web/src/features/auth/SC01LoginPage.tsx
+++ b/apps/web/src/features/auth/SC01LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -301,6 +302,7 @@ type CreateAccountInput = z.infer<typeof createAccountSchema>;
 
 function CreateAccountForm() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { session, isLoading } = useAuthSession();
   const [serverError, setServerError] = useState<string | null>(null);
   const form = useForm<CreateAccountInput>({ resolver: zodResolver(createAccountSchema) });
@@ -327,6 +329,10 @@ function CreateAccountForm() {
         displayName: values.displayName,
         password: values.password,
       });
+      // キャッシュの sync 結果（requiresProfileCompletion: true）を無効化する。
+      // これをしないと RequireAuth が古いキャッシュを見て
+      // /login?screen=create-account に戻してしまう。
+      await queryClient.invalidateQueries({ queryKey: ['auth', 'sync'] });
       navigate('/dashboard', { replace: true });
     } catch (err) {
       if (err instanceof ApiClientError && err.code === 'SAME_EMAIL_DIFFERENT_PROVIDER') {


### PR DESCRIPTION
## 概要

プロフィール登録（complete-signup）が 201 で成功してもダッシュボードに遷移しない問題を修正します。

## 原因

```
complete-signup 201 成功
  → navigate('/dashboard')
  → RequireAuth が useCurrentUser() を参照
  → React Query キャッシュに古い sync 結果が残っている
      { requiresProfileCompletion: true }  ← /auth/callback 時に取得したもの
  → RequireAuth が /login?screen=create-account にリダイレクト
  → ユーザーはプロフィール登録画面に戻される（無限ループ）
```

`completeSignup` 成功後に `navigate` するとき、React Query のキャッシュに `/auth/callback` 時点の sync 結果（`requiresProfileCompletion: true`）が `staleTime: 60_000` でまだ有効なまま残っています。`RequireAuth` はこれを見て `/login?screen=create-account` に戻してしまいます。

## 修正

`navigate` 前に `queryClient.invalidateQueries({ queryKey: ['auth', 'sync'] })` を呼んでキャッシュを無効化します。

```ts
await authApi.completeSignup({ ... });
// ↓ 追加: 古い requiresProfileCompletion: true を捨てる
await queryClient.invalidateQueries({ queryKey: ['auth', 'sync'] });
navigate('/dashboard', { replace: true });
```

`/dashboard` マウント時に sync が再取得され `requiresProfileCompletion: false` が返るため、`RequireAuth` が正常にダッシュボードを表示します。

## 変更ファイル

- `apps/web/src/features/auth/SC01LoginPage.tsx`
  - `useQueryClient` を import
  - `onSubmit` 内で `invalidateQueries` を呼ぶ

## テスト手順

1. 新規登録 → メール確認（Inbucket）
2. プロフィール登録フォームを入力して送信
3. **ダッシュボードに遷移すること**（`/login?screen=create-account` に戻らないこと）
4. ログに `complete-signup 201` が出てその後 `sync 200` が続くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)