### PR TITLE
feat(web): プロトタイプ準拠に画面・機能を刷新

### DIFF
--- a/apps/web/server/routes/v1/plans.test.ts
+++ b/apps/web/server/routes/v1/plans.test.ts
@@ -29,4 +29,12 @@ describe('plans routes', () => {
     });
     expect(res.status).toBe(401);
   });
+
+  it('requires authentication for GET project-wide plans', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/projects/abc/plans');
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('AUTH_MISSING');
+  });
 });

--- a/apps/web/server/routes/v1/projects.ts
+++ b/apps/web/server/routes/v1/projects.ts
@@ -26,6 +26,8 @@ import {
   listItems,
   updateItem,
 } from '../../services/items.js';
+import { listProjectPlans } from '../../services/plans.js';
+import { listProjectPlansQuerySchema } from '../../schemas/projects.js';
 import { ApiException } from '../../lib/errors.js';
 import { membersRoute } from './members.js';
 import { plansRoute } from './plans.js';
@@ -127,6 +129,20 @@ export const projectsRoute = new Hono()
       return c.body(null, 204);
     },
   )
+
+  // --------------------- /projects/:projectId/plans (横断: 制作物列スケジュール用) ---------------------
+  .get('/:projectId/plans', requireProjectMember(), async (c) => {
+    const project = c.get('project');
+    const query = listProjectPlansQuerySchema.parse({
+      from: c.req.query('from'),
+      to: c.req.query('to'),
+    });
+    const { items, total } = await listProjectPlans({
+      projectId: project.projectId,
+      query,
+    });
+    return c.json({ data: items, meta: { total } });
+  })
 
   // ----------------------------- /projects/:projectId/members -----------------------------
   .route('/:projectId/members', membersRoute)

--- a/apps/web/server/schemas/projects.ts
+++ b/apps/web/server/schemas/projects.ts
@@ -64,6 +64,13 @@ export const listProjectsQuerySchema = z.object({
 });
 export type ListProjectsQuery = z.infer<typeof listProjectsQuerySchema>;
 
+/** プロジェクト横断プラン取得 (制作物列スケジュール用) のクエリ。 */
+export const listProjectPlansQuerySchema = z.object({
+  from: isoDate.optional(),
+  to: isoDate.optional(),
+});
+export type ListProjectPlansQuery = z.infer<typeof listProjectPlansQuerySchema>;
+
 export const createItemBodySchema = z.object({
   name: z.string().trim().min(1).max(255),
   sortOrder: z.number().int().min(0).max(10_000).optional(),

--- a/apps/web/server/services/plans.ts
+++ b/apps/web/server/services/plans.ts
@@ -182,6 +182,33 @@ export async function listPlans(input: {
   return { items: rows.map((r) => toPlanDTO(r, [])), total };
 }
 
+/**
+ * プロジェクト配下の全制作物 (item) を横断してプランを取得する。
+ * 制作物列スケジュール (SC-06, プロトタイプ準拠) で、全制作物を 1 つの縦型カレンダーに
+ * 並べるために使用する。`from`/`to` は scheduledDate のレンジで絞り込む。
+ */
+export async function listProjectPlans(input: {
+  projectId: string;
+  query: { from?: string; to?: string };
+}): Promise<{ items: PlanDTO[]; total: number }> {
+  const where: Prisma.PlanWhereInput = {
+    deletedAt: null,
+    item: { projectId: input.projectId, deletedAt: null },
+    ...((input.query.from || input.query.to) && {
+      scheduledDate: {
+        ...(input.query.from && { gte: new Date(`${input.query.from}T00:00:00Z`) }),
+        ...(input.query.to && { lte: new Date(`${input.query.to}T00:00:00Z`) }),
+      },
+    }),
+  };
+  const rows = await prisma.plan.findMany({
+    where,
+    orderBy: [{ scheduledDate: 'asc' }, { createdAt: 'asc' }],
+    include: PLAN_INCLUDE,
+  });
+  return { items: rows.map((r) => toPlanDTO(r, [])), total: rows.length };
+}
+
 export async function getPlan(input: { itemId: string; planId: string }): Promise<PlanWithEventsDTO> {
   const row = await prisma.plan.findFirst({
     where: { id: input.planId, itemId: input.itemId, deletedAt: null },

--- a/apps/web/src/app/SidebarLayout.tsx
+++ b/apps/web/src/app/SidebarLayout.tsx
@@ -1,22 +1,47 @@
+import { useState } from 'react';
 import { Link, NavLink, Outlet, useNavigate } from 'react-router-dom';
-import { LayoutDashboard, FolderKanban, LogOut } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { LayoutDashboard, Plus } from 'lucide-react';
 
-import { Button } from '@/components/ui/button';
 import { Toaster } from '@/components/ui/sonner';
 import { cn } from '@/components/ui/utils';
 import { supabase } from '@/lib/supabase';
 import { useCurrentUser } from '@/features/auth/useCurrentUser';
+import { ProfileModal } from '@/features/auth/ProfileModal';
+import { projectsApi, projectsQueryKey } from '@/features/projects/api';
+
+const DOT_PALETTE = [
+  'bg-violet-500',
+  'bg-sky-500',
+  'bg-emerald-500',
+  'bg-amber-500',
+  'bg-rose-500',
+  'bg-cyan-500',
+  'bg-fuchsia-500',
+  'bg-lime-500',
+];
+
+function dotColor(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
+  return DOT_PALETTE[hash % DOT_PALETTE.length]!;
+}
 
 /**
- * ログイン後画面の共通レイアウト。
- * - 左サイドバー: ダッシュボード / プロジェクト
- * - 上部ヘッダー: ロゴ / ユーザー displayName / サインアウト
- * - メイン: <Outlet />
+ * ログイン後画面の共通レイアウト (プロトタイプ SidebarLayout 準拠)。
+ * - 左サイドバー: TRAKON ロゴ / ダッシュボード / プロジェクト一覧 (色ドット + 追加)
+ * - フッター: ユーザープロフィールボタン → ProfileModal
  */
 export function SidebarLayout() {
   const navigate = useNavigate();
   const { data } = useCurrentUser();
   const user = data && !data.requiresProfileCompletion ? data.user : null;
+  const [profileOpen, setProfileOpen] = useState(false);
+
+  const projectsQuery = useQuery({
+    queryKey: projectsQueryKey.all,
+    queryFn: () => projectsApi.list(),
+  });
 
   const signOut = async () => {
     await supabase.auth.signOut();
@@ -24,41 +49,86 @@ export function SidebarLayout() {
   };
 
   return (
-    <div className="grid min-h-screen grid-rows-[auto_1fr] bg-background text-foreground">
-      <header className="flex h-14 items-center justify-between border-b border-border px-6">
-        <Link to="/dashboard" className="text-base font-semibold tracking-tight">
+    <div className="flex min-h-screen bg-background text-foreground">
+      <aside className="flex w-60 shrink-0 flex-col border-r border-border">
+        <Link to="/dashboard" className="px-5 py-5 text-xl font-bold tracking-tight">
           TRAKON
         </Link>
-        <div className="flex items-center gap-3 text-sm">
-          {user && (
-            <span className="text-muted-foreground">
-              {user.displayName}{' '}
-              <span className="text-xs">({user.email})</span>
-            </span>
-          )}
-          <Button variant="ghost" size="sm" onClick={signOut}>
-            <LogOut className="size-4" />
-            サインアウト
-          </Button>
+
+        <nav className="px-3">
+          <SideLink to="/dashboard" icon={<LayoutDashboard className="size-4" />}>
+            ダッシュボード
+          </SideLink>
+        </nav>
+
+        <div className="mt-4 flex items-center justify-between px-5 py-1">
+          <span className="text-xs font-medium text-muted-foreground">プロジェクト</span>
+          <Link
+            to="/projects/new"
+            aria-label="プロジェクトを作成"
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <Plus className="size-4" />
+          </Link>
         </div>
-      </header>
 
-      <div className="grid grid-cols-[14rem_1fr]">
-        <aside className="border-r border-border">
-          <nav className="flex flex-col gap-1 p-3 text-sm">
-            <SideLink to="/dashboard" icon={<LayoutDashboard className="size-4" />}>
-              ダッシュボード
-            </SideLink>
-            <SideLink to="/projects" icon={<FolderKanban className="size-4" />}>
-              プロジェクト
-            </SideLink>
+        <div className="flex-1 overflow-y-auto px-3">
+          <nav className="flex flex-col gap-0.5">
+            {(projectsQuery.data ?? []).map((p) => (
+              <NavLink
+                key={p.id}
+                to={`/projects/${p.id}`}
+                className={({ isActive }) =>
+                  cn(
+                    'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+                    isActive
+                      ? 'bg-accent text-accent-foreground'
+                      : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground',
+                  )
+                }
+              >
+                <span className={cn('size-2 shrink-0 rounded-full', dotColor(p.id))} />
+                <span className="truncate">{p.name}</span>
+              </NavLink>
+            ))}
+            <NavLink
+              to="/projects"
+              className="mt-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              すべて見る →
+            </NavLink>
           </nav>
-        </aside>
+        </div>
 
-        <main className="overflow-auto">
-          <Outlet />
-        </main>
-      </div>
+        {user && (
+          <button
+            type="button"
+            onClick={() => setProfileOpen(true)}
+            className="flex items-center gap-2 border-t border-border px-4 py-3 text-left hover:bg-accent/40"
+          >
+            <span className="flex size-8 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+              {(user.displayName || user.email).charAt(0).toUpperCase()}
+            </span>
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-medium">{user.displayName}</span>
+              <span className="block truncate text-[11px] text-muted-foreground">{user.email}</span>
+            </span>
+          </button>
+        )}
+      </aside>
+
+      <main className="flex-1 overflow-auto">
+        <Outlet />
+      </main>
+
+      {user && (
+        <ProfileModal
+          user={user}
+          open={profileOpen}
+          onClose={() => setProfileOpen(false)}
+          onSignOut={signOut}
+        />
+      )}
 
       <Toaster richColors position="top-right" />
     </div>
@@ -79,7 +149,7 @@ function SideLink({
       to={to}
       className={({ isActive }) =>
         cn(
-          'flex items-center gap-2 rounded-md px-3 py-2 transition-colors',
+          'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
           isActive
             ? 'bg-accent text-accent-foreground'
             : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground',

--- a/apps/web/src/features/auth/ProfileModal.tsx
+++ b/apps/web/src/features/auth/ProfileModal.tsx
@@ -1,0 +1,79 @@
+import { LogOut } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import type { CurrentUser } from './api';
+
+const AUTH_METHOD_LABEL: Record<CurrentUser['primaryAuthMethod'], string> = {
+  password: 'メール + パスワード',
+  google: 'Google',
+  microsoft: 'Microsoft',
+};
+
+/**
+ * プロフィール表示モーダル (プロトタイプ ProfileModal の表示部)。
+ * 氏名/組織/パスワードの編集は更新 API 未実装のため将来対応 (Phase 1)。
+ */
+export function ProfileModal({
+  user,
+  open,
+  onClose,
+  onSignOut,
+}: {
+  user: CurrentUser;
+  open: boolean;
+  onClose: () => void;
+  onSignOut: () => void;
+}) {
+  const initial = (user.displayName || user.fullName || user.email).charAt(0).toUpperCase();
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>アカウント</DialogTitle>
+          <DialogDescription>プロフィール情報を確認できます。</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-3">
+          <div className="flex size-12 items-center justify-center rounded-full bg-primary text-base font-semibold text-primary-foreground">
+            {initial}
+          </div>
+          <div className="min-w-0">
+            <p className="truncate font-medium">{user.displayName}</p>
+            <p className="truncate text-sm text-muted-foreground">{user.email}</p>
+          </div>
+        </div>
+
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-sm">
+          <dt className="text-muted-foreground">氏名</dt>
+          <dd>{user.fullName}</dd>
+          <dt className="text-muted-foreground">表示名</dt>
+          <dd>{user.displayName}</dd>
+          <dt className="text-muted-foreground">認証方法</dt>
+          <dd>{AUTH_METHOD_LABEL[user.primaryAuthMethod]}</dd>
+        </dl>
+
+        <p className="text-[11px] text-muted-foreground">
+          氏名・パスワードの変更は今後のリリースで対応予定です。
+        </p>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>
+            閉じる
+          </Button>
+          <Button variant="outline" onClick={onSignOut}>
+            <LogOut className="size-4" />
+            サインアウト
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/auth/SC01LoginPage.tsx
+++ b/apps/web/src/features/auth/SC01LoginPage.tsx
@@ -87,10 +87,17 @@ type LoginInput = z.infer<typeof loginSchema>;
 function LoginForm({ goTo }: { goTo: (next: Screen, extra?: Record<string, string>) => void }) {
   const navigate = useNavigate();
   const [serverError, setServerError] = useState<string | null>(null);
+  const [remember, setRemember] = useState(true);
   const form = useForm<LoginInput>({ resolver: zodResolver(loginSchema) });
 
   const onSubmit = async (values: LoginInput) => {
     setServerError(null);
+    // ログイン状態の保存希望を記録 (Supabase は既定で localStorage 永続)
+    try {
+      localStorage.setItem('trakon.rememberMe', remember ? '1' : '0');
+    } catch {
+      /* localStorage 不可環境は無視 */
+    }
     const { error } = await supabase.auth.signInWithPassword(values);
     if (error) {
       setServerError(GENERIC_AUTH_ERROR);
@@ -118,6 +125,15 @@ function LoginForm({ goTo }: { goTo: (next: Screen, extra?: Record<string, strin
               {...form.register('password')}
             />
           </Field>
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
+            <input
+              type="checkbox"
+              className="size-4 accent-primary"
+              checked={remember}
+              onChange={(e) => setRemember(e.target.checked)}
+            />
+            ログイン状態を保存する
+          </label>
           {serverError && <p className="text-sm text-destructive">{serverError}</p>}
           <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
             {form.formState.isSubmitting && <Loader2 className="size-4 animate-spin" />}
@@ -202,7 +218,18 @@ function SignupForm({
         <div className="mt-6">
           <OAuthButtons />
         </div>
-        <div className="mt-6 text-center text-sm">
+        <p className="mt-5 text-center text-[11px] leading-relaxed text-muted-foreground">
+          続けることで、
+          <a href="#" className="underline underline-offset-2">
+            利用規約
+          </a>
+          {' '}および{' '}
+          <a href="#" className="underline underline-offset-2">
+            プライバシーポリシー
+          </a>
+          に同意したものとみなされます。
+        </p>
+        <div className="mt-4 text-center text-sm">
           <button
             type="button"
             className="text-foreground underline-offset-4 hover:underline"
@@ -386,6 +413,7 @@ function CreateAccountForm() {
               autoComplete="new-password"
               {...form.register('password')}
             />
+            <PasswordStrength value={form.watch('password') ?? ''} />
           </Field>
           <Field
             id="passwordConfirm"
@@ -497,6 +525,41 @@ function Field({
       {children}
       {hint && !error && <p className="text-xs text-muted-foreground">{hint}</p>}
       {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// パスワード強度インジケータ (プロトタイプ準拠)
+// -----------------------------------------------------------------------------
+function PasswordStrength({ value }: { value: string }) {
+  if (!value) return null;
+  let score = 0;
+  if (value.length >= 8) score++;
+  if (/[A-Za-z]/.test(value)) score++;
+  if (/\d/.test(value)) score++;
+  if (/[^\w\s]/.test(value)) score++;
+
+  const meta =
+    score <= 1
+      ? { label: '弱い', color: 'bg-red-500' }
+      : score === 2
+        ? { label: '普通', color: 'bg-amber-500' }
+        : score === 3
+          ? { label: 'やや強い', color: 'bg-lime-500' }
+          : { label: '強い', color: 'bg-emerald-500' };
+
+  return (
+    <div className="mt-1.5 space-y-1" aria-live="polite">
+      <div className="flex gap-1">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className={`h-1 flex-1 rounded-full ${i < score ? meta.color : 'bg-muted'}`}
+          />
+        ))}
+      </div>
+      <p className="text-[11px] text-muted-foreground">強度：{meta.label}</p>
     </div>
   );
 }

--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -71,6 +71,7 @@ export function BallDetailModal({
     mutationFn: () => plansApi.remove(projectId, itemId, planId),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+      qc.invalidateQueries({ queryKey: plansQueryKey.projectList(projectId) });
       toast.success('予定を削除しました');
       setDeleting(false);
       onClose();
@@ -119,6 +120,10 @@ export function BallDetailModal({
                   <BallHolderBanner plan={plan} />
 
                   <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+                    <dt className="text-muted-foreground">開始日</dt>
+                    <dd>{format(new Date(plan.scheduledDate), 'yyyy/M/d')}</dd>
+                    <dt className="text-muted-foreground">終了日</dt>
+                    <dd>{plan.dueDate ? format(new Date(plan.dueDate), 'yyyy/M/d') : '—'}</dd>
                     <dt className="text-muted-foreground">FROM</dt>
                     <dd>
                       {plan.fromMember

--- a/apps/web/src/features/plans/CreatePlanModal.tsx
+++ b/apps/web/src/features/plans/CreatePlanModal.tsx
@@ -125,6 +125,7 @@ export function CreatePlanModal({
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+      qc.invalidateQueries({ queryKey: plansQueryKey.projectList(projectId) });
       toast.success('予定を作成しました');
       onClose();
     },
@@ -145,6 +146,7 @@ export function CreatePlanModal({
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+      qc.invalidateQueries({ queryKey: plansQueryKey.projectList(projectId) });
       toast.success('予定を更新しました');
       onClose();
     },
@@ -155,8 +157,9 @@ export function CreatePlanModal({
   const submitting = createMut.isPending || updateMut.isPending;
   const onSubmit = (v: FormValues) => (mode === 'edit' ? updateMut.mutate(v) : createMut.mutate(v));
 
+  // 後続候補は同じ制作物 (item) 内の active な予定のみ
   const successorCandidates = plans.filter(
-    (p) => p.id !== editingPlan?.id && p.status === 'active',
+    (p) => p.itemId === itemId && p.id !== editingPlan?.id && p.status === 'active',
   );
 
   return (
@@ -173,21 +176,16 @@ export function CreatePlanModal({
 
         <form id="plan-form" onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
           <Field label="予定名" error={form.formState.errors.title?.message}>
-            <Input {...form.register('title')} autoFocus />
+            <Input {...form.register('title')} autoFocus placeholder="例: トップページ構成" />
           </Field>
 
-          <div className="grid grid-cols-2 gap-3">
-            <Field label="カテゴリ" error={form.formState.errors.category?.message}>
-              <SelectField
-                value={form.watch('category')}
-                onChange={(v) => form.setValue('category', v as PlanCategory)}
-                options={PLAN_CATEGORIES.map((c) => ({ value: c.value, label: c.label }))}
-              />
-            </Field>
-            <Field label="開始日" error={form.formState.errors.scheduledDate?.message}>
-              <Input type="date" {...form.register('scheduledDate')} />
-            </Field>
-          </div>
+          <Field label="カテゴリ" error={form.formState.errors.category?.message}>
+            <SelectField
+              value={form.watch('category')}
+              onChange={(v) => form.setValue('category', v as PlanCategory)}
+              options={PLAN_CATEGORIES.map((c) => ({ value: c.value, label: c.label }))}
+            />
+          </Field>
 
           <div className="grid grid-cols-2 gap-3">
             <Field
@@ -213,9 +211,14 @@ export function CreatePlanModal({
             </Field>
           </div>
 
-          <Field label="期日 (任意)" error={form.formState.errors.dueDate?.message}>
-            <Input type="date" {...form.register('dueDate')} />
-          </Field>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="開始日" error={form.formState.errors.scheduledDate?.message}>
+              <Input type="date" {...form.register('scheduledDate')} />
+            </Field>
+            <Field label="終了日 (任意)" error={form.formState.errors.dueDate?.message}>
+              <Input type="date" {...form.register('dueDate')} />
+            </Field>
+          </div>
 
           <Field
             label="後続の予定 (任意)"

--- a/apps/web/src/features/plans/DateChangeConfirmModal.tsx
+++ b/apps/web/src/features/plans/DateChangeConfirmModal.tsx
@@ -1,0 +1,54 @@
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+
+/**
+ * ボールをドラッグして日付を変更した際の確認ダイアログ。
+ * プロトタイプ DateChangeConfirmModal の移植:
+ *  - 「この予定のみ変更」
+ *  - 「後続の予定も一緒にずらす」
+ */
+export function DateChangeConfirmModal({
+  ballName,
+  onClose,
+  onConfirm,
+}: {
+  ballName: string;
+  onClose: () => void;
+  onConfirm: (moveSubsequent: boolean) => void;
+}) {
+  return (
+    <AlertDialog open onOpenChange={(o) => !o && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>日程を変更しますか？</AlertDialogTitle>
+          <AlertDialogDescription>
+            「{ballName}」の日程を変更します。後続の予定の扱いを選んでください。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="flex flex-col gap-2 pt-2">
+          <Button onClick={() => onConfirm(true)}>
+            後続の予定も一緒にずらす
+          </Button>
+          <p className="-mt-1 text-[11px] text-muted-foreground">
+            この予定の後に始まる同じ制作物の予定を、同じ日数分ずらします。
+          </p>
+          <Button variant="outline" onClick={() => onConfirm(false)}>
+            この予定のみ変更
+          </Button>
+          <p className="-mt-1 text-[11px] text-muted-foreground">
+            他の予定の日程は変更しません。
+          </p>
+          <Button variant="ghost" onClick={onClose}>
+            キャンセル
+          </Button>
+        </div>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -1,44 +1,66 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import {
-  addDays,
-  differenceInDays,
-  format,
-  isSameDay,
-  isWeekend,
-  parseISO,
-} from 'date-fns';
+import { addDays, differenceInDays, format, isSameDay, isWeekend, parseISO } from 'date-fns';
 import { isHoliday } from '@holiday-jp/holiday_jp';
-import { ArrowLeft, Plus, CheckCircle2 } from 'lucide-react';
+import { ArrowLeft, CheckCircle2, Plus, ZoomIn, ZoomOut } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { cn } from '@/components/ui/utils';
-import { projectsApi, projectsQueryKey } from '@/features/projects/api';
-import { membersApi, membersQueryKey, type ProjectMember } from '@/features/projects/membersApi';
+import { projectsApi, projectsQueryKey, type ProjectItem } from '@/features/projects/api';
+import { membersApi, membersQueryKey } from '@/features/projects/membersApi';
 import { plansApi, plansQueryKey, type Plan } from './api';
 import { CATEGORY_STYLE } from './categoryColor';
 import { PlanModalsHost } from './PlanModalsHost';
+import { DateChangeConfirmModal } from './DateChangeConfirmModal';
+import { useReschedulePlan, type ReschedulePatch } from './usePlanReschedule';
+import {
+  assignLanes,
+  ballTier,
+  dayIndex,
+  isActiveNow,
+  isOverdue,
+  itemColor,
+  LANE_WIDTH,
+  MIN_COLUMN_WIDTH,
+  planRange,
+  ROW_HEIGHT_DEFAULT,
+  ROW_HEIGHT_MAX,
+  ROW_HEIGHT_MIN,
+  ROW_HEIGHT_STEP,
+} from './scheduleLayout';
+
+const DATE_AXIS_WIDTH = 76;
 
 /**
- * SC-06 縦型スケジュール (/projects/:projectId/items/:itemId)
- *  - 縦軸: プロジェクト期間内の日付
- *  - 横軸: プロジェクトメンバー (受諾済み + 招待中)
- *  - 予定チップは FROM メンバー列に配置、TO はバッジで明示
- *  - セルクリック → SC-07 作成モーダル / チップクリック → SC-08 詳細モーダル
+ * SC-06 制作物列スケジュール (/projects/:projectId/items/:itemId)
+ * プロトタイプ DeliverableSchedulePage 準拠:
+ *  - 縦軸: プロジェクト期間の日付 (連続カレンダー / 行高ズーム可)
+ *  - 横軸: 制作物 (deliverable) 列。重なるボールはレーン自動割当
+ *  - ボールは scheduledDate〜dueDate のスパンに配置、FROM→TO を可視化
+ *  - ドラッグで日付移動 (確認ダイアログ)、上下端ドラッグで期間リサイズ
  */
 export function ItemSchedulePage() {
   const { projectId, itemId } = useParams<{ projectId: string; itemId: string }>();
-  if (!projectId || !itemId) {
-    return <NotFound />;
-  }
+  if (!projectId || !itemId) return <NotFound />;
   return <Inner projectId={projectId} itemId={itemId} />;
 }
 
 function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
   const [, setParams] = useSearchParams();
+  const [rowHeight, setRowHeight] = useState(ROW_HEIGHT_DEFAULT);
+  // 表示する制作物: 'all' か特定 itemId。初期は URL の itemId にフォーカス。
+  const [viewItemId, setViewItemId] = useState<string>(itemId);
+  useEffect(() => setViewItemId(itemId), [itemId]);
 
   const projectQuery = useQuery({
     queryKey: projectsQueryKey.detail(projectId),
@@ -53,12 +75,18 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
     queryFn: () => membersApi.list(projectId),
   });
   const plansQuery = useQuery({
-    queryKey: plansQueryKey.list(projectId, itemId),
-    queryFn: () => plansApi.list(projectId, itemId),
+    queryKey: plansQueryKey.projectList(projectId),
+    queryFn: () => plansApi.listByProject(projectId),
   });
 
+  const reschedule = useReschedulePlan(projectId);
+  const [pendingMove, setPendingMove] = useState<{ plan: Plan; dayDelta: number } | null>(null);
+
   const project = projectQuery.data;
-  const item = itemsQuery.data?.find((i) => i.id === itemId);
+  const items = useMemo(
+    () => (itemsQuery.data ?? []).slice().sort((a, b) => a.sortOrder - b.sortOrder),
+    [itemsQuery.data],
+  );
   const members = useMemo(
     () => (membersQuery.data ?? []).slice().sort((a, b) => a.sortOrder - b.sortOrder),
     [membersQuery.data],
@@ -73,43 +101,35 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
     return Array.from({ length: count }, (_, i) => addDays(start, i));
   }, [project]);
 
-  // memberId -> column index
-  const memberIndex = useMemo(() => {
-    const map = new Map<string, number>();
-    members.forEach((m, i) => map.set(m.id, i));
-    return map;
-  }, [members]);
+  const visibleItems = useMemo(
+    () => (viewItemId === 'all' ? items : items.filter((i) => i.id === viewItemId)),
+    [items, viewItemId],
+  );
 
-  // 日付セルごとに「FROM メンバー列に乗せる plans」を割り当て
-  const plansByCell = useMemo(() => {
-    // key = `${YYYY-MM-DD}|${memberId}`
+  const plansByItem = useMemo(() => {
     const map = new Map<string, Plan[]>();
     for (const p of plans) {
-      if (!p.fromMember) continue;
-      const key = `${p.scheduledDate}|${p.fromMember.id}`;
-      const arr = map.get(key) ?? [];
+      const arr = map.get(p.itemId) ?? [];
       arr.push(p);
-      map.set(key, arr);
+      map.set(p.itemId, arr);
     }
     return map;
   }, [plans]);
 
   const loading =
-    projectQuery.isLoading ||
-    itemsQuery.isLoading ||
-    membersQuery.isLoading ||
-    plansQuery.isLoading;
+    projectQuery.isLoading || itemsQuery.isLoading || membersQuery.isLoading || plansQuery.isLoading;
   const loadFailed = projectQuery.error || itemsQuery.error || membersQuery.error;
 
+  const focusedItem = items.find((i) => i.id === itemId);
   if (loading) return <PageSkeleton />;
-  if (!project || !item || loadFailed) return <NotFound />;
+  if (!project || !focusedItem || loadFailed) return <NotFound />;
 
-  const openCreateModal = (date: Date, fromMemberId?: string) => {
+  const openCreateModal = (date: Date, targetItemId: string) => {
     setParams(
       (sp) => {
         sp.set('modal', 'create-plan');
         sp.set('date', format(date, 'yyyy-MM-dd'));
-        if (fromMemberId) sp.set('fromMemberId', fromMemberId);
+        sp.set('itemId', targetItemId);
         sp.delete('planId');
         return sp;
       },
@@ -122,34 +142,91 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
         sp.set('modal', 'ball-detail');
         sp.set('planId', planId);
         sp.delete('date');
-        sp.delete('fromMemberId');
+        sp.delete('itemId');
         return sp;
       },
       { replace: true },
     );
   };
 
+  const commitMove = (plan: Plan, dayDelta: number) => {
+    if (dayDelta === 0) return;
+    setPendingMove({ plan, dayDelta });
+  };
+
+  const confirmMove = (moveSubsequent: boolean) => {
+    if (!pendingMove) return;
+    const { plan, dayDelta } = pendingMove;
+    const { end } = planRange(plan);
+    const patches: ReschedulePatch[] = [shiftPatch(plan, dayDelta)];
+    if (moveSubsequent) {
+      const originalEndMs = parseISO(end).getTime();
+      for (const p of plansByItem.get(plan.itemId) ?? []) {
+        if (p.id === plan.id) continue;
+        if (p.status !== 'active') continue;
+        if (parseISO(planRange(p).start).getTime() >= originalEndMs) {
+          patches.push(shiftPatch(p, dayDelta));
+        }
+      }
+    }
+    reschedule.mutate(patches);
+    setPendingMove(null);
+  };
+
+  const commitResize = (plan: Plan, edge: 'top' | 'bottom', dayDelta: number) => {
+    if (dayDelta === 0) return;
+    const { start, end } = planRange(plan);
+    if (edge === 'top') {
+      const newStart = shiftIso(start, dayDelta);
+      if (newStart > end) return;
+      reschedule.mutate([
+        { itemId: plan.itemId, planId: plan.id, patch: { scheduledDate: newStart } },
+      ]);
+    } else {
+      const newEnd = shiftIso(end, dayDelta);
+      if (newEnd < start) return;
+      reschedule.mutate([
+        { itemId: plan.itemId, planId: plan.id, patch: { dueDate: newEnd } },
+      ]);
+    }
+  };
+
+  const headerTargetItem = viewItemId === 'all' ? itemId : viewItemId;
+
   return (
     <div className="flex h-full flex-col">
-      <header className="flex items-center justify-between border-b border-border px-8 py-4">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-8 py-4">
         <div>
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <Link to={`/projects/${projectId}/edit`} className="hover:text-foreground">
               {project.name}
             </Link>
             <span>/</span>
-            <span>{item.name}</span>
+            <span>スケジュール</span>
           </div>
-          <h1 className="text-lg font-semibold tracking-tight">{item.name}</h1>
+          <h1 className="text-lg font-semibold tracking-tight">{project.name}</h1>
         </div>
         <div className="flex items-center gap-2">
+          <Select value={viewItemId} onValueChange={setViewItemId}>
+            <SelectTrigger className="h-9 w-44 text-xs">
+              <SelectValue placeholder="制作物" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">すべての制作物</SelectItem>
+              {items.map((i) => (
+                <SelectItem key={i.id} value={i.id}>
+                  {i.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <Button variant="ghost" size="sm" asChild>
             <Link to={`/projects/${projectId}/edit`}>
               <ArrowLeft className="size-4" />
-              プロジェクト設定へ
+              プロジェクト設定
             </Link>
           </Button>
-          <Button size="sm" onClick={() => openCreateModal(new Date())}>
+          <Button size="sm" onClick={() => openCreateModal(new Date(), headerTargetItem)}>
             <Plus className="size-4" />
             予定を追加
           </Button>
@@ -157,104 +234,242 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
       </header>
 
       {members.length === 0 ? (
-        <div className="m-8 rounded-md border border-dashed border-border p-12 text-center text-sm text-muted-foreground">
-          まずは参加者を追加してください。
-          <div className="mt-3">
-            <Button size="sm" variant="outline" asChild>
-              <Link to={`/projects/${projectId}/members?tab=manage`}>参加者管理を開く</Link>
-            </Button>
-          </div>
-        </div>
+        <EmptyHint projectId={projectId} />
       ) : days.length === 0 ? (
         <p className="m-8 text-sm text-muted-foreground">プロジェクト期間が設定されていません。</p>
+      ) : visibleItems.length === 0 ? (
+        <p className="m-8 text-sm text-muted-foreground">制作物がありません。</p>
       ) : (
-        <ScheduleGrid
+        <ScheduleBoard
           days={days}
-          members={members}
-          plansByCell={plansByCell}
-          onCellClick={openCreateModal}
-          onPlanClick={openDetailModal}
-          memberIndex={memberIndex}
+          items={visibleItems}
+          plansByItem={plansByItem}
+          rowHeight={rowHeight}
+          onOpenCreate={openCreateModal}
+          onOpenDetail={openDetailModal}
+          onMove={commitMove}
+          onResize={commitResize}
         />
       )}
 
-      <PlanModalsHost
-        projectId={projectId}
-        itemId={itemId}
-        members={members}
-        plans={plans}
-      />
+      {members.length > 0 && days.length > 0 && (
+        <ZoomControl rowHeight={rowHeight} onChange={setRowHeight} />
+      )}
+
+      {pendingMove && (
+        <DateChangeConfirmModal
+          ballName={pendingMove.plan.title}
+          onClose={() => setPendingMove(null)}
+          onConfirm={confirmMove}
+        />
+      )}
+
+      <PlanModalsHost projectId={projectId} members={members} plans={plans} fallbackItemId={itemId} />
     </div>
   );
 }
 
 // -----------------------------------------------------------------------------
-// Schedule grid
+// Board
 // -----------------------------------------------------------------------------
-function ScheduleGrid({
+
+type DragState = {
+  plan: Plan;
+  mode: 'move' | 'resize-top' | 'resize-bottom';
+  startClientY: number;
+  dayDelta: number;
+  moved: boolean;
+};
+
+function ScheduleBoard({
   days,
-  members,
-  plansByCell,
-  onCellClick,
-  onPlanClick,
-  memberIndex,
+  items,
+  plansByItem,
+  rowHeight,
+  onOpenCreate,
+  onOpenDetail,
+  onMove,
+  onResize,
 }: {
   days: Date[];
-  members: ProjectMember[];
-  plansByCell: Map<string, Plan[]>;
-  onCellClick: (date: Date, fromMemberId?: string) => void;
-  onPlanClick: (planId: string) => void;
-  memberIndex: Map<string, number>;
+  items: ProjectItem[];
+  plansByItem: Map<string, Plan[]>;
+  rowHeight: number;
+  onOpenCreate: (date: Date, itemId: string) => void;
+  onOpenDetail: (planId: string) => void;
+  onMove: (plan: Plan, dayDelta: number) => void;
+  onResize: (plan: Plan, edge: 'top' | 'bottom', dayDelta: number) => void;
 }) {
-  const gridStyle = {
-    gridTemplateColumns: `100px repeat(${members.length}, minmax(160px, 1fr))`,
-  };
+  const today = new Date();
+  const [drag, setDrag] = useState<DragState | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  dragRef.current = drag;
+
+  useEffect(() => {
+    if (!drag) return;
+    const onPointerMove = (e: PointerEvent) => {
+      const d = dragRef.current;
+      if (!d) return;
+      const deltaPx = e.clientY - d.startClientY;
+      const dayDelta = Math.round(deltaPx / rowHeight);
+      const moved = Math.abs(deltaPx) > 4;
+      if (dayDelta !== d.dayDelta || moved !== d.moved) {
+        setDrag({ ...d, dayDelta, moved });
+      }
+    };
+    const onPointerUp = () => {
+      const d = dragRef.current;
+      setDrag(null);
+      if (!d) return;
+      if (d.mode === 'move') {
+        if (!d.moved) onOpenDetail(d.plan.id);
+        else onMove(d.plan, d.dayDelta);
+      } else {
+        onResize(d.plan, d.mode === 'resize-top' ? 'top' : 'bottom', d.dayDelta);
+      }
+    };
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+    return () => {
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerUp);
+    };
+  }, [drag, rowHeight, onMove, onResize, onOpenDetail]);
+
+  const totalHeight = days.length * rowHeight;
+
+  const dayTones = useMemo(
+    () =>
+      days.map((d) => {
+        const weekend = isWeekend(d);
+        const holiday = isHoliday(d);
+        const today2 = isSameDay(d, today);
+        const tone = today2
+          ? 'bg-amber-50'
+          : holiday
+            ? 'bg-rose-50/60'
+            : weekend
+              ? 'bg-slate-50'
+              : 'bg-background';
+        return { weekend, holiday, today: today2, tone, first: d.getDate() === 1 };
+      }),
+    // today はマウント時点で固定で良い
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [days, rowHeight],
+  );
 
   return (
     <div className="flex-1 overflow-auto">
-      <div className="grid" style={gridStyle}>
-        {/* ヘッダー行 */}
-        <div className="sticky top-0 z-20 border-b border-r border-border bg-background" />
-        {members.map((m) => (
-          <div
-            key={m.id}
-            className="sticky top-0 z-20 border-b border-r border-border bg-background px-3 py-2 text-xs"
-          >
-            <div className="font-medium text-foreground">{m.name}</div>
-            <div className="truncate text-[10px] text-muted-foreground">
-              {m.organizationName || '—'}
-            </div>
+      <div className="flex w-max select-none">
+        {/* 日付軸 (sticky left) */}
+        <div
+          className="sticky left-0 z-30 shrink-0 border-r border-border bg-background"
+          style={{ width: DATE_AXIS_WIDTH }}
+        >
+          <div className="sticky top-0 z-10 h-12 border-b border-border bg-background" />
+          <div className="relative" style={{ height: totalHeight }}>
+            {days.map((d, i) => {
+              const t = dayTones[i]!;
+              return (
+                <div
+                  key={i}
+                  className={cn(
+                    'absolute left-0 right-0 flex flex-col items-center justify-center border-b border-border text-xs',
+                    t.tone,
+                    t.first && 'border-t-2 border-t-foreground/20',
+                    t.today && 'font-semibold text-amber-700',
+                    t.holiday && 'text-rose-600',
+                  )}
+                  style={{ top: i * rowHeight, height: rowHeight }}
+                >
+                  <span>{format(d, 'M/d')}</span>
+                  {rowHeight >= 30 && (
+                    <span
+                      className={cn(
+                        'text-[10px]',
+                        t.weekend ? 'text-slate-500' : 'text-muted-foreground',
+                        t.holiday && 'text-rose-500',
+                      )}
+                    >
+                      {format(d, 'EEEEE')}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
           </div>
-        ))}
+        </div>
 
-        {/* 日付行 */}
-        {days.map((d) => {
-          const dateStr = format(d, 'yyyy-MM-dd');
-          const weekend = isWeekend(d);
-          const holiday = isHoliday(d);
-          const today = isSameDay(d, new Date());
-          const cellTone = today
-            ? 'bg-amber-50'
-            : holiday
-              ? 'bg-rose-50/60'
-              : weekend
-                ? 'bg-slate-50'
-                : 'bg-background';
+        {/* 制作物列 */}
+        {items.map((item) => {
+          const itemPlans = (plansByItem.get(item.id) ?? [])
+            .slice()
+            .sort((a, b) => a.scheduledDate.localeCompare(b.scheduledDate));
+          const { laneOf, laneCount } = assignLanes(itemPlans);
+          const colWidth = Math.max(MIN_COLUMN_WIDTH, laneCount * LANE_WIDTH);
+          const color = itemColor(item.id);
           return (
-            <DayRow
-              key={dateStr}
-              date={d}
-              dateStr={dateStr}
-              members={members}
-              plansByCell={plansByCell}
-              cellTone={cellTone}
-              today={today}
-              holiday={holiday}
-              weekend={weekend}
-              onCellClick={onCellClick}
-              onPlanClick={onPlanClick}
-              memberIndex={memberIndex}
-            />
+            <div
+              key={item.id}
+              className="shrink-0 border-r border-border"
+              style={{ width: colWidth }}
+            >
+              {/* 列ヘッダー (sticky top) */}
+              <div className="sticky top-0 z-20 flex h-12 items-center gap-2 border-b border-border bg-background px-3">
+                <span className={cn('size-2.5 shrink-0 rounded-full', color.dot)} />
+                <span className="truncate text-sm font-medium">{item.name}</span>
+                <Badge variant="secondary" className="ml-auto shrink-0 text-[10px]">
+                  {itemPlans.length}件
+                </Badge>
+              </div>
+
+              {/* 本体 */}
+              <div className="relative" style={{ height: totalHeight }}>
+                {/* 日付セル (クリックで作成) */}
+                {days.map((d, i) => {
+                  const t = dayTones[i]!;
+                  return (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => onOpenCreate(d, item.id)}
+                      className={cn(
+                        'absolute left-0 right-0 border-b border-border/70 transition-colors hover:bg-accent/30',
+                        t.tone,
+                        t.first && 'border-t-2 border-t-foreground/20',
+                      )}
+                      style={{ top: i * rowHeight, height: rowHeight }}
+                      aria-label={`${format(d, 'M/d')} に予定を作成`}
+                    />
+                  );
+                })}
+
+                {/* ボール */}
+                {itemPlans.map((plan) => (
+                  <BallChip
+                    key={plan.id}
+                    plan={plan}
+                    days={days}
+                    rowHeight={rowHeight}
+                    lane={laneOf.get(plan.id) ?? 0}
+                    today={today}
+                    drag={drag?.plan.id === plan.id ? drag : null}
+                    onActivate={() => onOpenDetail(plan.id)}
+                    onPointerDownBall={(e, mode) => {
+                      e.stopPropagation();
+                      if (plan.status !== 'active' && mode !== 'move') return;
+                      setDrag({
+                        plan,
+                        mode,
+                        startClientY: e.clientY,
+                        dayDelta: 0,
+                        moved: false,
+                      });
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
           );
         })}
       </div>
@@ -262,131 +477,216 @@ function ScheduleGrid({
   );
 }
 
-function DayRow({
-  date,
-  dateStr,
-  members,
-  plansByCell,
-  cellTone,
-  today,
-  holiday,
-  weekend,
-  onCellClick,
-  onPlanClick,
-  memberIndex: _memberIndex,
-}: {
-  date: Date;
-  dateStr: string;
-  members: ProjectMember[];
-  plansByCell: Map<string, Plan[]>;
-  cellTone: string;
-  today: boolean;
-  holiday: boolean;
-  weekend: boolean;
-  onCellClick: (date: Date, fromMemberId?: string) => void;
-  onPlanClick: (planId: string) => void;
-  memberIndex: Map<string, number>;
-}) {
-  const weekday = format(date, 'EEEEE'); // 短い曜日
-  const dayLabel = format(date, 'M/d');
-  return (
-    <>
-      <div
-        className={cn(
-          'sticky left-0 z-10 flex flex-col items-center justify-center border-b border-r border-border px-2 py-3 text-xs',
-          cellTone,
-          today && 'font-semibold text-amber-700',
-          holiday && 'text-rose-600',
-        )}
-      >
-        <span>{dayLabel}</span>
-        <span
-          className={cn(
-            'text-[10px]',
-            weekend ? 'text-slate-500' : 'text-muted-foreground',
-            holiday && 'text-rose-500',
-          )}
-        >
-          {weekday}
-        </span>
-      </div>
-      {members.map((m) => {
-        const key = `${dateStr}|${m.id}`;
-        const cellPlans = plansByCell.get(key) ?? [];
-        return (
-          <button
-            key={key}
-            type="button"
-            onClick={() => onCellClick(date, m.id)}
-            className={cn(
-              'group min-h-[64px] border-b border-r border-border p-1 text-left transition-colors',
-              cellTone,
-              'hover:bg-accent/40',
-            )}
-          >
-            <div className="flex flex-col gap-1">
-              {cellPlans.map((p) => (
-                <PlanChip
-                  key={p.id}
-                  plan={p}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onPlanClick(p.id);
-                  }}
-                />
-              ))}
-            </div>
-          </button>
-        );
-      })}
-    </>
-  );
-}
+// -----------------------------------------------------------------------------
+// Ball chip
+// -----------------------------------------------------------------------------
 
-function PlanChip({
+function BallChip({
   plan,
-  onClick,
+  days,
+  rowHeight,
+  lane,
+  today,
+  drag,
+  onActivate,
+  onPointerDownBall,
 }: {
   plan: Plan;
-  onClick: (e: React.MouseEvent) => void;
+  days: Date[];
+  rowHeight: number;
+  lane: number;
+  today: Date;
+  drag: DragState | null;
+  onActivate: () => void;
+  onPointerDownBall: (e: React.PointerEvent, mode: DragState['mode']) => void;
 }) {
+  const { start, end } = planRange(plan);
+  let startIdx = dayIndex(days, start);
+  let endIdx = dayIndex(days, end);
+
+  // ドラッグ中のライブプレビュー
+  if (drag) {
+    if (drag.mode === 'move') {
+      startIdx += drag.dayDelta;
+      endIdx += drag.dayDelta;
+    } else if (drag.mode === 'resize-top') {
+      startIdx = Math.min(endIdx, startIdx + drag.dayDelta);
+    } else if (drag.mode === 'resize-bottom') {
+      endIdx = Math.max(startIdx, endIdx + drag.dayDelta);
+    }
+  }
+
+  const top = startIdx * rowHeight + 1;
+  const height = (endIdx - startIdx + 1) * rowHeight - 3;
+  const tier = ballTier(height);
   const style = CATEGORY_STYLE[plan.category];
   const completed = plan.status === 'completed';
+  const overdue = isOverdue(plan, today);
+  const active = isActiveNow(plan, today);
+  const editable = plan.status === 'active';
+
+  const cardClass = completed
+    ? 'border-slate-200 bg-slate-100/80 text-slate-500 opacity-60'
+    : overdue
+      ? 'border-red-400 bg-red-50 text-red-700'
+      : cn(style.bg, style.border, style.text);
+
   return (
     <div
       role="button"
       tabIndex={0}
-      onClick={onClick}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          onClick(e as unknown as React.MouseEvent);
+          onActivate(); // キーボードでは詳細を開く (移動はマウスのみ)
         }
       }}
+      onPointerDown={(e) => onPointerDownBall(e, 'move')}
       className={cn(
-        'cursor-pointer rounded-md border px-2 py-1 text-xs shadow-sm transition-colors',
-        completed
-          ? 'border-slate-200 bg-slate-100/80 text-slate-500 line-through'
-          : `${style.bg} ${style.border} ${style.text} hover:brightness-95`,
+        'absolute overflow-hidden rounded-md border px-2 py-1 text-xs shadow-sm',
+        cardClass,
+        active && !completed && 'ring-2 ring-primary/40',
+        drag?.mode === 'move' && 'opacity-70',
+        editable ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
       )}
+      style={{
+        top,
+        height,
+        left: lane * LANE_WIDTH + 6,
+        width: LANE_WIDTH - 12,
+      }}
     >
+      {/* リサイズハンドル (上) */}
+      {editable && tier !== 'mini' && (
+        <div
+          onPointerDown={(e) => onPointerDownBall(e, 'resize-top')}
+          className="absolute inset-x-0 top-0 h-1.5 cursor-ns-resize"
+          aria-hidden
+        />
+      )}
+
       <div className="flex items-center justify-between gap-1">
         <span className="line-clamp-1 font-medium">{plan.title}</span>
         {completed && <CheckCircle2 className="size-3 shrink-0 text-emerald-500" />}
       </div>
-      <div className="mt-0.5 flex items-center gap-1 text-[10px] opacity-90">
-        <Badge variant="secondary" className="px-1 py-0 text-[10px]">
-          {style.label}
-        </Badge>
-        {plan.toMember && (
-          <span className="line-clamp-1">→ {plan.toMember.name}</span>
-        )}
-      </div>
+
+      {tier !== 'mini' && (
+        <div className="mt-0.5 flex items-center gap-1 text-[10px] opacity-90">
+          <span className="rounded bg-black/5 px-1">{style.label}</span>
+          <span className="line-clamp-1">
+            {format(parseISO(start), 'M/d')}
+            {start !== end && `〜${format(parseISO(end), 'M/d')}`}
+          </span>
+        </div>
+      )}
+
+      {tier === 'normal' && (
+        <div className="mt-1 border-t border-current/10 pt-1 text-[10px] leading-tight">
+          <div className="flex items-center gap-1">
+            <span className="opacity-60">FROM</span>
+            <span className="line-clamp-1 font-medium">{plan.fromMember?.name ?? '—'}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="opacity-60">TO</span>
+            <span className="line-clamp-1 font-medium">{plan.toMember?.name ?? '—'}</span>
+            {plan.ballHolder && (
+              <Badge variant="secondary" className="ml-auto px-1 py-0 text-[9px]">
+                {plan.ballHolder.name}
+              </Badge>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* リサイズハンドル (下) */}
+      {editable && tier !== 'mini' && (
+        <div
+          onPointerDown={(e) => onPointerDownBall(e, 'resize-bottom')}
+          className="absolute inset-x-0 bottom-0 h-1.5 cursor-ns-resize"
+          aria-hidden
+        />
+      )}
     </div>
   );
 }
 
 // -----------------------------------------------------------------------------
+// Zoom control
+// -----------------------------------------------------------------------------
+
+function ZoomControl({
+  rowHeight,
+  onChange,
+}: {
+  rowHeight: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="fixed bottom-6 right-6 z-40 flex items-center gap-3 rounded-lg border border-border bg-background p-3 shadow-lg">
+      <button
+        type="button"
+        aria-label="縮小"
+        className="text-muted-foreground hover:text-foreground"
+        onClick={() => onChange(Math.max(ROW_HEIGHT_MIN, rowHeight - ROW_HEIGHT_STEP))}
+      >
+        <ZoomOut className="size-4" />
+      </button>
+      <input
+        type="range"
+        min={ROW_HEIGHT_MIN}
+        max={ROW_HEIGHT_MAX}
+        step={ROW_HEIGHT_STEP}
+        value={rowHeight}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-28 accent-primary"
+        aria-label="行の高さ"
+      />
+      <button
+        type="button"
+        aria-label="拡大"
+        className="text-muted-foreground hover:text-foreground"
+        onClick={() => onChange(Math.min(ROW_HEIGHT_MAX, rowHeight + ROW_HEIGHT_STEP))}
+      >
+        <ZoomIn className="size-4" />
+      </button>
+      <span className="ml-1 min-w-[2.5rem] text-xs text-muted-foreground">{rowHeight}px</span>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// helpers / misc
+// -----------------------------------------------------------------------------
+
+function shiftIso(iso: string, days: number): string {
+  return format(addDays(parseISO(iso), days), 'yyyy-MM-dd');
+}
+
+function shiftPatch(plan: Plan, dayDelta: number): ReschedulePatch {
+  const { start, end } = planRange(plan);
+  return {
+    itemId: plan.itemId,
+    planId: plan.id,
+    patch: {
+      scheduledDate: shiftIso(start, dayDelta),
+      dueDate: plan.dueDate ? shiftIso(end, dayDelta) : null,
+    },
+  };
+}
+
+function EmptyHint({ projectId }: { projectId: string }) {
+  return (
+    <div className="m-8 rounded-md border border-dashed border-border p-12 text-center text-sm text-muted-foreground">
+      まずは参加者を追加してください。
+      <div className="mt-3">
+        <Button size="sm" variant="outline" asChild>
+          <Link to={`/projects/${projectId}/members?tab=manage`}>参加者管理を開く</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 function PageSkeleton() {
   return (
     <div className="space-y-3 p-8">

--- a/apps/web/src/features/plans/MemberKanbanTab.tsx
+++ b/apps/web/src/features/plans/MemberKanbanTab.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from 'react';
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   DndContext,
   PointerSensor,
@@ -30,12 +31,16 @@ import { projectsApi, projectsQueryKey } from '@/features/projects/api';
 import type { ProjectMember } from '@/features/projects/membersApi';
 import { plansApi, plansQueryKey, type Plan } from './api';
 import { CATEGORY_STYLE } from './categoryColor';
+import { PlanModalsHost } from './PlanModalsHost';
+
+const ALL = '__all__';
 
 /**
- * SC-17 メンバーかんばん
- *  - 上部の制作物セレクタで対象 item を選び、その plans をメンバー別にかんばん表示
- *  - メンバー列間で DnD すると、ドロップ先メンバーへ TOSS (toMemberId 指定)
- *  - 完了は各カードの「完了する」ボタンで (DnD ではない、シンプル化)
+ * SC-17 メンバーかんばん (プロトタイプ MemberKanbanPage 準拠)
+ *  - 制作チーム / クライアント のスイムレーンに分割
+ *  - 制作物セレクタ (すべて / 個別) で対象を絞り込み (既定: すべて)
+ *  - メンバー列間で DnD すると、ドロップ先メンバーへ TOSS
+ *  - カードクリックでボール詳細モーダル / 各カードに「完了する」
  */
 export function MemberKanbanTab({
   projectId,
@@ -53,12 +58,7 @@ export function MemberKanbanTab({
     queryFn: () => projectsApi.listItems(projectId),
   });
 
-  // 制作物未指定なら最初の制作物を自動選択
-  useEffect(() => {
-    if (!selectedItemId && itemsQuery.data && itemsQuery.data.length > 0) {
-      onChangeItem(itemsQuery.data[0]!.id);
-    }
-  }, [selectedItemId, itemsQuery.data, onChangeItem]);
+  const itemFilter = selectedItemId ?? ALL;
 
   return (
     <Card>
@@ -67,14 +67,12 @@ export function MemberKanbanTab({
           <CardTitle className="text-base">メンバーかんばん</CardTitle>
           {itemsQuery.data && itemsQuery.data.length > 0 && (
             <div className="w-64">
-              <Select
-                value={selectedItemId ?? itemsQuery.data[0]?.id ?? ''}
-                onValueChange={onChangeItem}
-              >
+              <Select value={itemFilter} onValueChange={onChangeItem}>
                 <SelectTrigger>
                   <SelectValue placeholder="制作物を選択" />
                 </SelectTrigger>
                 <SelectContent>
+                  <SelectItem value={ALL}>すべての制作物</SelectItem>
                   {itemsQuery.data.map((it) => (
                     <SelectItem key={it.id} value={it.id}>
                       {it.name}
@@ -87,15 +85,14 @@ export function MemberKanbanTab({
         </div>
       </CardHeader>
       <CardContent>
-        {itemsQuery.isLoading || !selectedItemId ? (
-          <Skeleton className="h-64 w-full rounded-md" />
-        ) : (
-          <KanbanBoard
-            projectId={projectId}
-            itemId={selectedItemId}
-            members={members}
-          />
-        )}
+        <KanbanBoard
+          projectId={projectId}
+          itemFilter={itemFilter === ALL ? null : itemFilter}
+          members={members}
+          itemNameById={
+            new Map((itemsQuery.data ?? []).map((it) => [it.id, it.name]))
+          }
+        />
       </CardContent>
     </Card>
   );
@@ -104,51 +101,50 @@ export function MemberKanbanTab({
 // -----------------------------------------------------------------------------
 function KanbanBoard({
   projectId,
-  itemId,
+  itemFilter,
   members,
+  itemNameById,
 }: {
   projectId: string;
-  itemId: string;
+  itemFilter: string | null;
   members: ProjectMember[];
+  itemNameById: Map<string, string>;
 }) {
   const qc = useQueryClient();
+  const [, setParams] = useSearchParams();
+  const listKey = plansQueryKey.projectList(projectId);
+
   const plansQuery = useQuery({
-    queryKey: plansQueryKey.list(projectId, itemId),
-    queryFn: () => plansApi.list(projectId, itemId),
+    queryKey: listKey,
+    queryFn: () => plansApi.listByProject(projectId),
   });
 
+  const invalidateAll = (itemId: string) => {
+    qc.invalidateQueries({ queryKey: listKey });
+    qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+  };
+
   const tossMut = useMutation({
-    mutationFn: ({ planId, toMemberId }: { planId: string; toMemberId: string }) =>
-      plansApi.toss(projectId, itemId, planId, { toMemberId }),
-    onMutate: async ({ planId, toMemberId }) => {
-      await qc.cancelQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
-      const prev = qc.getQueryData<Plan[]>(plansQueryKey.list(projectId, itemId));
+    mutationFn: ({ plan, toMemberId }: { plan: Plan; toMemberId: string }) =>
+      plansApi.toss(projectId, plan.itemId, plan.id, { toMemberId }),
+    onMutate: async ({ plan, toMemberId }) => {
+      await qc.cancelQueries({ queryKey: listKey });
+      const prev = qc.getQueryData<Plan[]>(listKey);
       if (prev) {
         const toMember = members.find((m) => m.id === toMemberId);
+        const ref = toMember
+          ? {
+              id: toMember.id,
+              name: toMember.name,
+              organizationName: toMember.organizationName,
+              memberType: toMember.memberType,
+            }
+          : null;
         qc.setQueryData<Plan[]>(
-          plansQueryKey.list(projectId, itemId),
+          listKey,
           prev.map((p) =>
-            p.id === planId
-              ? {
-                  ...p,
-                  toMember: toMember
-                    ? {
-                        id: toMember.id,
-                        name: toMember.name,
-                        organizationName: toMember.organizationName,
-                        memberType: toMember.memberType,
-                      }
-                    : p.toMember,
-                  ballHolder: toMember
-                    ? {
-                        id: toMember.id,
-                        name: toMember.name,
-                        organizationName: toMember.organizationName,
-                        memberType: toMember.memberType,
-                      }
-                    : p.ballHolder,
-                  ballState: 'tossed',
-                }
+            p.id === plan.id && ref
+              ? { ...p, toMember: ref, ballHolder: ref, ballState: 'tossed' }
               : p,
           ),
         );
@@ -156,21 +152,17 @@ function KanbanBoard({
       return { prev };
     },
     onError: (err, _vars, ctx) => {
-      if (ctx?.prev) {
-        qc.setQueryData(plansQueryKey.list(projectId, itemId), ctx.prev);
-      }
+      if (ctx?.prev) qc.setQueryData(listKey, ctx.prev);
       toast.error(err instanceof ApiClientError ? err.message : 'TOSS に失敗しました');
     },
     onSuccess: () => toast.success('TOSS しました'),
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
-    },
+    onSettled: (_d, _e, vars) => invalidateAll(vars.plan.itemId),
   });
 
   const completeMut = useMutation({
-    mutationFn: (planId: string) => plansApi.complete(projectId, itemId, planId),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+    mutationFn: (plan: Plan) => plansApi.complete(projectId, plan.itemId, plan.id),
+    onSuccess: (_d, plan) => {
+      invalidateAll(plan.itemId);
       toast.success('完了しました');
     },
     onError: (e) =>
@@ -181,46 +173,84 @@ function KanbanBoard({
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
   );
 
+  const plans = useMemo(() => {
+    const all = plansQuery.data ?? [];
+    return itemFilter ? all.filter((p) => p.itemId === itemFilter) : all;
+  }, [plansQuery.data, itemFilter]);
+
+  const plansByHolder = useMemo(() => {
+    const map = new Map<string, Plan[]>();
+    for (const p of plans) {
+      if (p.status !== 'active' || !p.ballHolder) continue;
+      const arr = map.get(p.ballHolder.id) ?? [];
+      arr.push(p);
+      map.set(p.ballHolder.id, arr);
+    }
+    return map;
+  }, [plans]);
+
+  const production = members.filter((m) => m.memberType === 'production');
+  const clients = members.filter((m) => m.memberType === 'client');
+
   const onDragEnd = (e: DragEndEvent) => {
     const planId = String(e.active.id);
     const overMemberId = e.over?.id ? String(e.over.id) : null;
     if (!overMemberId) return;
-    const plan = plansQuery.data?.find((p) => p.id === planId);
+    const plan = plans.find((p) => p.id === planId);
     if (!plan) return;
-    if (plan.ballHolder?.id === overMemberId) return; // 自列に戻すだけは無視
-    tossMut.mutate({ planId, toMemberId: overMemberId });
+    if (plan.ballHolder?.id === overMemberId) return; // 同じ列なら無視
+    tossMut.mutate({ plan, toMemberId: overMemberId });
   };
+
+  const openDetail = (planId: string) =>
+    setParams(
+      (sp) => {
+        sp.set('modal', 'ball-detail');
+        sp.set('planId', planId);
+        return sp;
+      },
+      { replace: true },
+    );
 
   if (plansQuery.isLoading) return <Skeleton className="h-64 w-full rounded-md" />;
   if (plansQuery.error)
-    return (
-      <p className="text-sm text-destructive">予定の取得に失敗しました</p>
-    );
+    return <p className="text-sm text-destructive">予定の取得に失敗しました</p>;
 
-  const plans = plansQuery.data ?? [];
-  // active な予定のみ表示。完了済みは隠す（完了済みは SC-06 やダッシュボードで参照）
-  const plansByHolder = new Map<string, Plan[]>();
-  for (const p of plans) {
-    if (p.status !== 'active' || !p.ballHolder) continue;
-    const arr = plansByHolder.get(p.ballHolder.id) ?? [];
-    arr.push(p);
-    plansByHolder.set(p.ballHolder.id, arr);
-  }
+  const renderLane = (title: string, laneMembers: ProjectMember[]) => {
+    if (laneMembers.length === 0) return null;
+    return (
+      <div className="space-y-2">
+        <h3 className="text-xs font-medium text-muted-foreground">{title}</h3>
+        <div className="flex gap-3 overflow-x-auto pb-2">
+          {laneMembers.map((m) => (
+            <MemberColumn
+              key={m.id}
+              member={m}
+              plans={plansByHolder.get(m.id) ?? []}
+              tossing={tossMut.isPending}
+              completing={completeMut.isPending}
+              itemNameById={itemNameById}
+              onComplete={(plan) => completeMut.mutate(plan)}
+              onOpenDetail={openDetail}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  };
 
   return (
     <DndContext sensors={sensors} onDragEnd={onDragEnd}>
-      <div className="flex gap-3 overflow-x-auto pb-2">
-        {members.map((m) => (
-          <MemberColumn
-            key={m.id}
-            member={m}
-            plans={plansByHolder.get(m.id) ?? []}
-            tossing={tossMut.isPending}
-            completing={completeMut.isPending}
-            onComplete={(planId) => completeMut.mutate(planId)}
-          />
-        ))}
+      <div className="space-y-5">
+        {renderLane('制作チーム', production)}
+        {renderLane('クライアント', clients)}
       </div>
+      <PlanModalsHost
+        projectId={projectId}
+        members={members}
+        plans={plansQuery.data ?? []}
+        fallbackItemId={itemFilter ?? (plansQuery.data?.[0]?.itemId ?? '')}
+      />
     </DndContext>
   );
 }
@@ -231,13 +261,17 @@ function MemberColumn({
   plans,
   tossing,
   completing,
+  itemNameById,
   onComplete,
+  onOpenDetail,
 }: {
   member: ProjectMember;
   plans: Plan[];
   tossing: boolean;
   completing: boolean;
-  onComplete: (planId: string) => void;
+  itemNameById: Map<string, string>;
+  onComplete: (plan: Plan) => void;
+  onOpenDetail: (planId: string) => void;
 }) {
   const { isOver, setNodeRef } = useDroppable({ id: member.id });
   return (
@@ -251,9 +285,7 @@ function MemberColumn({
     >
       <div className="mb-2 sticky top-0 z-10 rounded-md bg-card px-2 py-1.5">
         <p className="text-sm font-medium leading-tight">{member.name}</p>
-        <p className="text-[10px] text-muted-foreground">
-          {member.organizationName || '—'}
-        </p>
+        <p className="text-[10px] text-muted-foreground">{member.organizationName || '—'}</p>
         <div className="mt-1 flex items-center gap-1 text-[10px] text-muted-foreground">
           <Badge variant="secondary" className="px-1 py-0 text-[10px]">
             担当 {plans.length} 件
@@ -263,7 +295,7 @@ function MemberColumn({
       <div className="flex flex-col gap-2">
         {plans.length === 0 ? (
           <div className="rounded-md border border-dashed border-border bg-background p-3 text-center text-[11px] text-muted-foreground">
-            ボールはありません
+            担当中の予定はありません
           </div>
         ) : (
           plans.map((p) => (
@@ -271,7 +303,9 @@ function MemberColumn({
               key={p.id}
               plan={p}
               completing={completing}
+              itemName={itemNameById.get(p.itemId)}
               onComplete={onComplete}
+              onOpenDetail={onOpenDetail}
             />
           ))
         )}
@@ -283,11 +317,15 @@ function MemberColumn({
 function DraggablePlanCard({
   plan,
   completing,
+  itemName,
   onComplete,
+  onOpenDetail,
 }: {
   plan: Plan;
   completing: boolean;
-  onComplete: (planId: string) => void;
+  itemName?: string;
+  onComplete: (plan: Plan) => void;
+  onOpenDetail: (planId: string) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: plan.id,
@@ -296,16 +334,22 @@ function DraggablePlanCard({
     ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` }
     : undefined;
   const cat = CATEGORY_STYLE[plan.category];
+  const overdue =
+    plan.ballState === 'ready' &&
+    !!plan.dueDate &&
+    new Date(plan.dueDate) < new Date(new Date().toDateString());
+
   return (
     <div
       ref={setNodeRef}
       style={style}
       className={cn(
         'rounded-md border bg-card shadow-sm',
-        cat.border,
+        overdue ? 'border-red-400' : cat.border,
         isDragging && 'opacity-60',
       )}
     >
+      {/* ドラッグハンドル (ヘッダー) */}
       <div
         className={cn(
           'flex items-center gap-1 rounded-t-md px-2 py-1 text-[10px]',
@@ -316,6 +360,7 @@ function DraggablePlanCard({
         {...attributes}
         role="button"
         tabIndex={0}
+        aria-label="ドラッグして TOSS"
       >
         <GripVertical className="size-3 opacity-60" />
         <span>{cat.label}</span>
@@ -323,28 +368,41 @@ function DraggablePlanCard({
           {plan.ballState === 'tossed' ? 'TOSS済' : '準備中'}
         </Badge>
       </div>
-      <div className="px-2 py-1.5 text-xs">
-        <p className="line-clamp-2 font-medium">{plan.title}</p>
+      {/* 本体 (クリックで詳細) */}
+      <button
+        type="button"
+        onClick={() => onOpenDetail(plan.id)}
+        className="block w-full px-2 py-1.5 text-left text-xs hover:bg-accent/30"
+      >
+        <p className={cn('line-clamp-2 font-medium', overdue && 'text-red-700')}>
+          {plan.title}
+        </p>
+        {itemName && (
+          <p className="mt-0.5 line-clamp-1 text-[10px] text-muted-foreground">{itemName}</p>
+        )}
         <p className="mt-0.5 text-[10px] text-muted-foreground">
           {format(new Date(plan.scheduledDate), 'M/d')}
           {plan.dueDate ? ` 〜 期日 ${format(new Date(plan.dueDate), 'M/d')}` : ''}
         </p>
-        <div className="mt-1.5 flex justify-end">
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-7 gap-1 text-[11px]"
-            onClick={() => onComplete(plan.id)}
-            disabled={completing}
-          >
-            {completing ? (
-              <Loader2 className="size-3 animate-spin" />
-            ) : (
-              <CheckCircle2 className="size-3" />
-            )}
-            完了する
-          </Button>
-        </div>
+        {plan.toMember && (
+          <p className="mt-0.5 text-[10px] text-muted-foreground">Next: {plan.toMember.name}</p>
+        )}
+      </button>
+      <div className="flex justify-end px-2 pb-1.5">
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 gap-1 text-[11px]"
+          onClick={() => onComplete(plan)}
+          disabled={completing}
+        >
+          {completing ? (
+            <Loader2 className="size-3 animate-spin" />
+          ) : (
+            <CheckCircle2 className="size-3" />
+          )}
+          完了する
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/src/features/plans/PlanModalsHost.tsx
+++ b/apps/web/src/features/plans/PlanModalsHost.tsx
@@ -7,33 +7,43 @@ import type { Plan } from './api';
 
 /**
  * URL の `?modal=...` を見て SC-07 / SC-08 を出し分けるホスト。
- * 各モーダルは閉じる時に URL の modal 系パラメータを掃除する。
+ *
+ * 制作物列スケジュールでは plans が複数 item を跨ぐため、対象 itemId を解決する:
+ *  - create-plan: クエリ `itemId` (列 = 制作物)。無ければ fallbackItemId。
+ *  - edit-plan / ball-detail: 対象 plan の itemId。
  */
 export function PlanModalsHost({
   projectId,
-  itemId,
   members,
   plans,
+  fallbackItemId,
 }: {
   projectId: string;
-  itemId: string;
   members: ProjectMember[];
   plans: Plan[];
+  fallbackItemId: string;
 }) {
   const [params, setParams] = useSearchParams();
   const modal = params.get('modal');
+  const planId = params.get('planId') ?? undefined;
 
   const closeModal = () => {
     setParams(
       (sp) => {
-        for (const k of ['modal', 'date', 'fromMemberId', 'planId']) sp.delete(k);
+        for (const k of ['modal', 'date', 'fromMemberId', 'itemId', 'planId']) sp.delete(k);
         return sp;
       },
       { replace: true },
     );
   };
 
+  const planItemId = planId ? plans.find((p) => p.id === planId)?.itemId : undefined;
+
   if (modal === 'create-plan' || modal === 'edit-plan') {
+    const itemId =
+      modal === 'edit-plan'
+        ? (planItemId ?? fallbackItemId)
+        : (params.get('itemId') ?? fallbackItemId);
     return (
       <CreatePlanModal
         projectId={projectId}
@@ -43,18 +53,18 @@ export function PlanModalsHost({
         mode={modal === 'edit-plan' ? 'edit' : 'create'}
         defaultDate={params.get('date') ?? undefined}
         defaultFromMemberId={params.get('fromMemberId') ?? undefined}
-        planId={params.get('planId') ?? undefined}
+        planId={planId}
         onClose={closeModal}
       />
     );
   }
 
-  if (modal === 'ball-detail' && params.get('planId')) {
+  if (modal === 'ball-detail' && planId) {
     return (
       <BallDetailModal
         projectId={projectId}
-        itemId={itemId}
-        planId={params.get('planId')!}
+        itemId={planItemId ?? fallbackItemId}
+        planId={planId}
         members={members}
         onClose={closeModal}
         onEdit={() => {

--- a/apps/web/src/features/plans/api.ts
+++ b/apps/web/src/features/plans/api.ts
@@ -103,6 +103,14 @@ export const plansApi = {
     const q = sp.toString() ? `?${sp.toString()}` : '';
     return apiRequest<Plan[]>(`${basePath(projectId, itemId)}${q}`);
   },
+  /** プロジェクト配下の全制作物を横断したプラン取得 (制作物列スケジュール用)。 */
+  listByProject: (projectId: string, query?: { from?: string; to?: string }) => {
+    const sp = new URLSearchParams();
+    if (query?.from) sp.set('from', query.from);
+    if (query?.to) sp.set('to', query.to);
+    const q = sp.toString() ? `?${sp.toString()}` : '';
+    return apiRequest<Plan[]>(`/projects/${projectId}/plans${q}`);
+  },
   get: (projectId: string, itemId: string, planId: string) =>
     apiRequest<PlanDetail>(`${basePath(projectId, itemId)}/${planId}`),
   create: (projectId: string, itemId: string, body: CreatePlanInput) =>
@@ -138,4 +146,5 @@ export const plansQueryKey = {
     ['projects', projectId, 'items', itemId, 'plans'] as const,
   detail: (projectId: string, itemId: string, planId: string) =>
     ['projects', projectId, 'items', itemId, 'plans', planId] as const,
+  projectList: (projectId: string) => ['projects', projectId, 'plans'] as const,
 };

--- a/apps/web/src/features/plans/scheduleLayout.ts
+++ b/apps/web/src/features/plans/scheduleLayout.ts
@@ -1,0 +1,120 @@
+import { differenceInCalendarDays, parseISO } from 'date-fns';
+
+import type { Plan } from './api';
+
+/**
+ * 制作物列スケジュール (プロトタイプ DeliverableSchedulePage 準拠) の
+ * 描画ロジックをまとめた純粋関数群。
+ */
+
+export const LANE_WIDTH = 240; // 1 レーン (サブ列) の幅 px
+export const MIN_COLUMN_WIDTH = 280; // 制作物列の最小幅 px
+export const ROW_HEIGHT_MIN = 20;
+export const ROW_HEIGHT_MAX = 80;
+export const ROW_HEIGHT_DEFAULT = 40;
+export const ROW_HEIGHT_STEP = 5;
+
+/** プラン期間の開始/終了日 (dueDate 未設定なら scheduledDate と同日)。 */
+export function planRange(plan: Plan): { start: string; end: string } {
+  return { start: plan.scheduledDate, end: plan.dueDate ?? plan.scheduledDate };
+}
+
+/**
+ * 重なり合うボールを横方向のサブレーンに割り当てる。
+ * プロトタイプ assignLanes の移植: 期間が重なるボールは別レーンへ。
+ * 入力は scheduledDate 昇順である前提 (BE がソート済み)。
+ */
+export function assignLanes(plans: Plan[]): {
+  laneOf: Map<string, number>;
+  laneCount: number;
+} {
+  const lanes: { end: number }[] = []; // lanes[i].end = そのレーンの最終占有 epoch(ms)
+  const laneOf = new Map<string, number>();
+
+  for (const plan of plans) {
+    const { start, end } = planRange(plan);
+    const startMs = parseISO(start).getTime();
+    const endMs = parseISO(end).getTime();
+
+    let assigned = -1;
+    for (let i = 0; i < lanes.length; i++) {
+      const lane = lanes[i];
+      // 重ならない (このレーンの最後の終了が今回の開始より前) なら再利用
+      if (lane && lane.end < startMs) {
+        assigned = i;
+        break;
+      }
+    }
+    if (assigned === -1) {
+      lanes.push({ end: endMs });
+      assigned = lanes.length - 1;
+    } else {
+      const lane = lanes[assigned];
+      if (lane) lane.end = endMs;
+    }
+    laneOf.set(plan.id, assigned);
+  }
+
+  return { laneOf, laneCount: Math.max(1, lanes.length) };
+}
+
+/** days 配列中での日付の行インデックス (範囲外は端にクランプ)。 */
+export function dayIndex(days: Date[], isoDate: string): number {
+  const first = days[0];
+  if (!first) return 0;
+  const idx = differenceInCalendarDays(parseISO(isoDate), first);
+  if (idx < 0) return 0;
+  if (idx > days.length - 1) return days.length - 1;
+  return idx;
+}
+
+export type BallTier = 'mini' | 'compact' | 'normal';
+
+/** ボール高さから表示段階を決める (プロトタイプ閾値 80 / 120)。 */
+export function ballTier(heightPx: number): BallTier {
+  if (heightPx < 80) return 'mini';
+  if (heightPx < 120) return 'compact';
+  return 'normal';
+}
+
+/** ボールが期限超過か (ballState=ready かつ 終了日 < 今日)。 */
+export function isOverdue(plan: Plan, today: Date): boolean {
+  if (plan.ballState !== 'ready') return false;
+  const { end } = planRange(plan);
+  return parseISO(end).getTime() < startOfDay(today).getTime();
+}
+
+/** 本日がボール期間内か (active な進行中ボール)。 */
+export function isActiveNow(plan: Plan, today: Date): boolean {
+  if (plan.status !== 'active') return false;
+  const { start, end } = planRange(plan);
+  const t = startOfDay(today).getTime();
+  return parseISO(start).getTime() <= t && t <= parseISO(end).getTime();
+}
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+/**
+ * 制作物 id から決定的に色クラスを割り当てる (BE に色フィールドが無いため)。
+ * ヘッダーのドット / 列アクセントに使用。
+ */
+const ITEM_PALETTE = [
+  { dot: 'bg-violet-500', accent: 'border-t-violet-400' },
+  { dot: 'bg-sky-500', accent: 'border-t-sky-400' },
+  { dot: 'bg-emerald-500', accent: 'border-t-emerald-400' },
+  { dot: 'bg-amber-500', accent: 'border-t-amber-400' },
+  { dot: 'bg-rose-500', accent: 'border-t-rose-400' },
+  { dot: 'bg-cyan-500', accent: 'border-t-cyan-400' },
+  { dot: 'bg-fuchsia-500', accent: 'border-t-fuchsia-400' },
+  { dot: 'bg-lime-500', accent: 'border-t-lime-400' },
+] as const;
+
+export function itemColor(itemId: string): (typeof ITEM_PALETTE)[number] {
+  let hash = 0;
+  for (let i = 0; i < itemId.length; i++) {
+    hash = (hash * 31 + itemId.charCodeAt(i)) >>> 0;
+  }
+  return ITEM_PALETTE[hash % ITEM_PALETTE.length]!;
+}

--- a/apps/web/src/features/plans/useOptimisticBallAction.ts
+++ b/apps/web/src/features/plans/useOptimisticBallAction.ts
@@ -81,6 +81,7 @@ export function useTossPlan(input: { projectId: string; itemId: string; planId: 
     onSettled: () => {
       qc.invalidateQueries({ queryKey: listKey });
       qc.invalidateQueries({ queryKey: detailKey });
+      qc.invalidateQueries({ queryKey: plansQueryKey.projectList(input.projectId) });
     },
   });
 }
@@ -120,6 +121,7 @@ export function useCompletePlan(input: { projectId: string; itemId: string; plan
     onSettled: () => {
       qc.invalidateQueries({ queryKey: listKey });
       qc.invalidateQueries({ queryKey: detailKey });
+      qc.invalidateQueries({ queryKey: plansQueryKey.projectList(input.projectId) });
     },
   });
 }

--- a/apps/web/src/features/plans/usePlanReschedule.ts
+++ b/apps/web/src/features/plans/usePlanReschedule.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { ApiClientError } from '@/lib/api';
+import { plansApi, plansQueryKey, type UpdatePlanInput } from './api';
+
+export type ReschedulePatch = {
+  itemId: string;
+  planId: string;
+  patch: UpdatePlanInput;
+};
+
+/**
+ * ドラッグ移動 / リサイズによる日付変更を反映するフック。
+ * 「後続もずらす」では複数プランを順次 PATCH する (BE に一括カスケード API が無いため)。
+ * 完了後に横断プラン一覧 (projectList) を無効化して再取得する。
+ */
+export function useReschedulePlan(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation<void, ApiClientError, ReschedulePatch[]>({
+    mutationFn: async (patches) => {
+      for (const p of patches) {
+        await plansApi.update(projectId, p.itemId, p.planId, p.patch);
+      }
+    },
+    onSuccess: () => toast.success('日程を更新しました'),
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '日程の更新に失敗しました'),
+    onSettled: (_data, _err, patches) => {
+      qc.invalidateQueries({ queryKey: plansQueryKey.projectList(projectId) });
+      // 念のため per-item 一覧も無効化 (詳細モーダル等が参照)
+      const itemIds = new Set(patches?.map((p) => p.itemId));
+      for (const itemId of itemIds) {
+        qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+      }
+    },
+  });
+}

--- a/apps/web/src/features/projects/MembersPage.tsx
+++ b/apps/web/src/features/projects/MembersPage.tsx
@@ -116,7 +116,8 @@ export function MembersPage() {
           selectedItemId={selectedItemId}
           onChangeItem={(itemId) => {
             const sp = new URLSearchParams(params);
-            sp.set('itemId', itemId);
+            if (itemId === '__all__') sp.delete('itemId');
+            else sp.set('itemId', itemId);
             setParams(sp, { replace: true });
           }}
         />


### PR DESCRIPTION
## 概要

Figma 由来プロトタイプ (`prototype/`) と実装 (`apps/web/`) を比較し、機能・画面要件の大きな差分を解消する。リポジトリの文書階層では「基本設計書 > プロトタイプ」だが、**プロトタイプを正（見た目優先）** とする方針で Web アプリを作り替えた。特にコア画面のスケジュールを **参加者列 → 制作物列** に変更（最大の差分）。

## 変更内容

### バックエンド
- **プロジェクト横断プラン取得** `GET /projects/:projectId/plans?from=&to=` を新設（制作物列スケジュール／全制作物かんばんで使用）。`listProjectPlans` サービス＋ Zod スキーマ＋認可ガード（既存 `requireProjectMember`）。

### スケジュール（SC-06・コア刷新）
- 横軸を **制作物列** に変更（`sortOrder` 順・id から決定的色割当）
- 縦軸は連続カレンダー（行高ズーム 20–80px）
- 重なるボールの **レーン自動割当**
- **ドラッグで日付移動**（既存ボールは「この予定のみ／後続も一緒にずらす」確認ダイアログ）
- 上下端ドラッグで **期間リサイズ**
- **FROM→TO** 表示、overdue（赤）・本日・土日祝の装飾、3 段階表示（mini/compact/normal）

### メンバーかんばん（SC-17）
- **制作チーム／クライアントのスイムレーン** 分割
- **カードクリックで詳細モーダル**、制作物名表示、ドラッグ=TOSS
- 制作物セレクタに「すべて」を追加

### 認証（SC-01）
- 「ログイン状態を保存する」チェック、利用規約/プライバシー同意文言、**パスワード強度インジケータ**

### レイアウト
- プロトタイプ風サイドバー（プロジェクト一覧＋色ドット＋追加ボタン、フッターに **ProfileModal**）
- 作成/詳細モーダルの項目順・文言をプロトタイプに整形

## 縮退（対応 API 未実装のため）
- かんばんの **差し戻し**（Phase 1）→ 非表示
- ProfileModal の **氏名/パスワード編集** → 表示のみ
- 日付の **後続カスケード** → 一括 API が無くクライアント順次 PATCH で実現

## 検証
- ✅ `pnpm -C apps/web type-check`
- ✅ `pnpm -C apps/web lint`（warning 0）
- ✅ `pnpm -C apps/web test`（52 件）
- ✅ `pnpm -C apps/web build`
- ⚠️ ブラウザ実機確認は未実施（ローカル dev スタック衝突回避のため）。隔離ポートでの起動確認を推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)