### PR TITLE
feat(web): レビュー反映 — 差し戻し/プロフィール編集/右Sheet/操作改善

### DIFF
--- a/apps/web/server/routes/v1/auth.test.ts
+++ b/apps/web/server/routes/v1/auth.test.ts
@@ -23,4 +23,14 @@ describe('auth routes', () => {
     const body = (await res.json()) as { error: { code: string } };
     expect(body.error.code).toBe('AUTH_INVALID');
   });
+
+  it('requires authentication for PATCH /me', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/auth/me', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ displayName: 'x' }),
+    });
+    expect(res.status).toBe(401);
+  });
 });

--- a/apps/web/server/routes/v1/auth.ts
+++ b/apps/web/server/routes/v1/auth.ts
@@ -1,12 +1,13 @@
 import { Hono } from 'hono';
 
 import { requireAuth } from '../../middleware/auth.js';
-import { completeSignupBodySchema } from '../../schemas/auth.js';
+import { completeSignupBodySchema, updateProfileBodySchema } from '../../schemas/auth.js';
 import {
   completeSignup,
   getCurrentUser,
   recordLogin,
   syncUser,
+  updateProfile,
 } from '../../services/auth.js';
 import { ApiException } from '../../lib/errors.js';
 
@@ -51,6 +52,19 @@ export const authRoute = new Hono()
         email: result.email,
       },
     });
+  })
+
+  /** プロフィール / 認証情報の更新 (氏名・表示名・パスワード) */
+  .patch('/me', async (c) => {
+    const authUser = c.get('authUser');
+    const body = updateProfileBodySchema.parse(await c.req.json());
+    const user = await updateProfile({
+      authUserId: authUser.authUserId,
+      fullName: body.fullName,
+      displayName: body.displayName,
+      newPassword: body.newPassword,
+    });
+    return c.json({ data: user });
   })
 
   /** Magic-link サインアップ詳細入力受け取り (users INSERT + パスワード設定) */

--- a/apps/web/server/routes/v1/plans.test.ts
+++ b/apps/web/server/routes/v1/plans.test.ts
@@ -37,4 +37,12 @@ describe('plans routes', () => {
     const body = (await res.json()) as { error: { code: string } };
     expect(body.error.code).toBe('AUTH_MISSING');
   });
+
+  it('requires authentication for POST /toss-undo', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/projects/abc/items/def/plans/xyz/toss-undo', {
+      method: 'POST',
+    });
+    expect(res.status).toBe(401);
+  });
 });

--- a/apps/web/server/routes/v1/plans.ts
+++ b/apps/web/server/routes/v1/plans.ts
@@ -21,7 +21,7 @@ import {
   setPlanSuccessor,
   updatePlan,
 } from '../../services/plans.js';
-import { completePlan, tossPlan } from '../../services/ballActions.js';
+import { completePlan, tossPlan, undoTossPlan } from '../../services/ballActions.js';
 
 /**
  * `/projects/:projectId/items/:itemId/plans` 配下のエンドポイント。
@@ -109,6 +109,22 @@ export const plansRoute = new Hono()
       projectId: project.projectId,
       planId,
       body,
+      currentUserId: c.get('currentUserId'),
+      currentMemberId: project.memberId,
+      isDirector: project.isDirector,
+    });
+    return c.json({ data: result });
+  })
+
+  .post('/:planId/toss-undo', async (c) => {
+    const itemId = c.get('itemId');
+    const project = c.get('project');
+    const planId = c.req.param('planId');
+    if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
+    const result = await undoTossPlan({
+      itemId,
+      projectId: project.projectId,
+      planId,
       currentUserId: c.get('currentUserId'),
       currentMemberId: project.memberId,
       isDirector: project.isDirector,

--- a/apps/web/server/schemas/auth.ts
+++ b/apps/web/server/schemas/auth.ts
@@ -13,3 +13,23 @@ export const completeSignupBodySchema = z.object({
 });
 
 export type CompleteSignupBody = z.infer<typeof completeSignupBodySchema>;
+
+/** プロフィール / 認証情報の更新 (氏名・表示名・パスワード、いずれも任意) */
+export const updateProfileBodySchema = z
+  .object({
+    fullName: z.string().trim().min(1).max(100).optional(),
+    displayName: z.string().trim().min(1).max(50).optional(),
+    newPassword: z
+      .string()
+      .min(8, 'Password must be at least 8 characters.')
+      .max(128)
+      .refine((v) => /[A-Za-z]/.test(v) && /\d/.test(v) && /[^\w\s]/.test(v), {
+        message: 'Password must include letters, digits, and a symbol.',
+      })
+      .optional(),
+  })
+  .refine((v) => v.fullName !== undefined || v.displayName !== undefined || v.newPassword !== undefined, {
+    message: 'At least one field must be provided.',
+  });
+
+export type UpdateProfileBody = z.infer<typeof updateProfileBodySchema>;

--- a/apps/web/server/services/auth.ts
+++ b/apps/web/server/services/auth.ts
@@ -194,6 +194,56 @@ export async function completeSignup(input: {
   return toDTO(user);
 }
 
+/**
+ * プロフィール / 認証情報を更新する。
+ * - newPassword: Supabase Auth 側を admin 更新 (completeSignup と同方針)
+ * - fullName / displayName: public.users を更新
+ * いずれも任意。1 件以上の指定はスキーマで担保。
+ */
+export async function updateProfile(input: {
+  authUserId: string;
+  fullName?: string;
+  displayName?: string;
+  newPassword?: string;
+}): Promise<CurrentUserDTO> {
+  const existing = await prisma.user.findUnique({ where: { authUserId: input.authUserId } });
+  if (!existing) {
+    throw new ApiException('PROFILE_NOT_COMPLETED', 404, 'User profile not found.');
+  }
+
+  if (input.newPassword) {
+    const supabase = getSupabaseAdmin();
+    const { error } = await supabase.auth.admin.updateUserById(input.authUserId, {
+      password: input.newPassword,
+    });
+    if (error) {
+      throw new ApiException('SUPABASE_UPDATE_FAILED', 500, error.message);
+    }
+  }
+
+  const updated = await prisma.$transaction(async (tx) => {
+    const u = await tx.user.update({
+      where: { id: existing.id },
+      data: {
+        ...(input.fullName !== undefined && { fullName: input.fullName }),
+        ...(input.displayName !== undefined && { displayName: input.displayName }),
+      },
+    });
+    await tx.auditLog.create({
+      data: {
+        actorUserId: u.id,
+        action: 'update_profile',
+        resourceType: 'user',
+        resourceId: u.id,
+        result: 'success',
+      },
+    });
+    return u;
+  });
+
+  return toDTO(updated);
+}
+
 export async function getCurrentUser(authUserId: string): Promise<CurrentUserDTO | null> {
   const user = await prisma.user.findUnique({ where: { authUserId } });
   return user ? toDTO(user) : null;

--- a/apps/web/server/services/ballActions.ts
+++ b/apps/web/server/services/ballActions.ts
@@ -38,22 +38,26 @@ async function loadPlanWithIncludes(
   return row;
 }
 
-function ballAlreadyTossed(plan: PlanWithIncludes): boolean {
-  return plan.ballEvents.some((e) => e.eventType === 'tossed');
+/**
+ * 最新イベント 1 件で現在の ball state を判定する。
+ * toss_undone (差し戻し) は直前の tossed を打ち消し ready に戻す。
+ * ball_events は occurredAt DESC で取得しているので [0] が最新。
+ */
+function currentBallState(plan: PlanWithIncludes): 'ready' | 'tossed' | 'completed' {
+  const latest = plan.ballEvents[0];
+  if (!latest || latest.eventType === 'toss_undone') return 'ready';
+  if (latest.eventType === 'tossed') return 'tossed';
+  return 'completed';
 }
 
 function ballHolderMemberId(plan: PlanWithIncludes): string | null {
-  if (plan.ballEvents.length === 0) return plan.fromMemberId;
-  // ball_events は occurredAt DESC で取得しているので [0] が最新
-  const latest = plan.ballEvents[0];
-  if (latest?.eventType === 'tossed') return plan.toMemberId;
-  return plan.toMemberId; // completed も to
+  return currentBallState(plan) === 'ready' ? plan.fromMemberId : plan.toMemberId;
 }
 
 async function recordAudit(input: {
   tx: Prisma.TransactionClient;
   actorUserId: string;
-  action: 'toss' | 'complete' | 'auto_toss';
+  action: 'toss' | 'complete' | 'auto_toss' | 'untoss';
   planId: string;
 }): Promise<void> {
   await input.tx.auditLog.create({
@@ -85,7 +89,7 @@ export async function tossPlan(input: {
     if (plan.status !== 'active') {
       throw new ApiException('PLAN_NOT_ACTIVE', 422, 'Plan is not active.');
     }
-    if (ballAlreadyTossed(plan)) {
+    if (currentBallState(plan) !== 'ready') {
       throw new ApiException('ALREADY_TOSSED', 409, 'Ball has already been tossed.');
     }
 
@@ -203,7 +207,7 @@ export async function completePlan(input: {
         where: { id: plan.successorPlanId, itemId: input.itemId, deletedAt: null },
         include: PLAN_INCLUDE,
       });
-      if (successor && successor.status === 'active' && !ballAlreadyTossed(successor)) {
+      if (successor && successor.status === 'active' && currentBallState(successor) === 'ready') {
         await tx.ballEvent.create({
           data: {
             planId: successor.id,
@@ -231,4 +235,58 @@ export async function completePlan(input: {
     plan: toPlanDTO(result.completed, []),
     autoTossed: result.autoTossed ? toPlanDTO(result.autoTossed, []) : null,
   };
+}
+
+// -----------------------------------------------------------------------------
+// Undo TOSS (差し戻し)
+// -----------------------------------------------------------------------------
+export async function undoTossPlan(input: {
+  itemId: string;
+  projectId: string;
+  planId: string;
+  currentUserId: string;
+  currentMemberId: string;
+  isDirector: boolean;
+}): Promise<{ plan: PlanDTO }> {
+  const result = await prisma.$transaction(async (tx) => {
+    const plan = await loadPlanWithIncludes(tx, input.planId, input.itemId);
+
+    if (plan.status !== 'active') {
+      throw new ApiException('PLAN_NOT_ACTIVE', 422, 'Plan is not active.');
+    }
+    if (currentBallState(plan) !== 'tossed') {
+      throw new ApiException('NOT_TOSSED', 409, 'Ball is not in a tossed state.');
+    }
+
+    // 認可: 現在の Ball Holder (= toMember, 差し戻す本人) または ディレクター
+    const holder = ballHolderMemberId(plan);
+    if (!input.isDirector && holder !== input.currentMemberId) {
+      throw new ApiException(
+        'FORBIDDEN',
+        403,
+        'Only the current ball holder or director can undo a toss.',
+      );
+    }
+
+    // append-only のため、行削除ではなく toss_undone を追記して ready に戻す
+    await tx.ballEvent.create({
+      data: {
+        planId: plan.id,
+        eventType: 'toss_undone',
+        source: 'human',
+        actorMemberId: input.currentMemberId,
+        actorUserId: input.currentUserId,
+      },
+    });
+    await recordAudit({
+      tx,
+      actorUserId: input.currentUserId,
+      action: 'untoss',
+      planId: plan.id,
+    });
+
+    return loadPlanWithIncludes(tx, plan.id, input.itemId);
+  });
+
+  return { plan: toPlanDTO(result, []) };
 }

--- a/apps/web/server/services/plans.ts
+++ b/apps/web/server/services/plans.ts
@@ -19,7 +19,7 @@ export type MemberRef = {
 
 export type BallEventDTO = {
   id: string;
-  eventType: 'tossed' | 'completed';
+  eventType: 'tossed' | 'completed' | 'toss_undone';
   source: 'human' | 'auto_chain';
   actor: MemberRef | null;
   occurredAt: string;
@@ -85,7 +85,7 @@ type PlanRow = Prisma.PlanGetPayload<{
 function toEventDTO(ev: PlanRow['ballEvents'][number]): BallEventDTO {
   return {
     id: ev.id,
-    eventType: ev.eventType as 'tossed' | 'completed',
+    eventType: ev.eventType as 'tossed' | 'completed' | 'toss_undone',
     source: ev.source as 'human' | 'auto_chain',
     actor: toMemberRef(ev.actorMember),
     occurredAt: ev.occurredAt.toISOString(),
@@ -99,7 +99,7 @@ export function toPlanDTO(row: PlanRow, members: PlanRow['fromMember'][]): PlanD
   const eventsDesc = row.ballEvents; // already DESC
   const latest = pickLatestBallEvent(
     eventsDesc.map((e) => ({
-      eventType: e.eventType as 'tossed' | 'completed',
+      eventType: e.eventType as 'tossed' | 'completed' | 'toss_undone',
       source: e.source as 'human' | 'auto_chain',
       occurredAt: e.occurredAt,
     })),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Route, Routes, Navigate as Nav, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 
 import { AuthCallbackPage } from './app/AuthCallbackPage';
 import { DashboardPage } from './app/DashboardPage';
@@ -11,6 +12,7 @@ import { MembersPage } from './features/projects/MembersPage';
 import { ProjectCreatePage } from './features/projects/ProjectCreatePage';
 import { ProjectEditPage } from './features/projects/ProjectEditPage';
 import { ProjectListPage } from './features/projects/ProjectListPage';
+import { projectsApi, projectsQueryKey } from './features/projects/api';
 import { ShareLinksPage } from './features/shareLinks/ShareLinksPage';
 import { SharePage } from './features/shareLinks/SharePage';
 
@@ -39,8 +41,8 @@ export function App() {
           path="/projects/:projectId/items/:itemId"
           element={<ItemSchedulePage />}
         />
-        {/* /projects/:projectId は当面 edit に飛ばす (詳細ダッシュボードは Phase 1) */}
-        <Route path="/projects/:projectId" element={<ProjectRedirectToEdit />} />
+        {/* /projects/:projectId は先頭の制作物スケジュール (縦型カレンダー) へ */}
+        <Route path="/projects/:projectId" element={<ProjectRedirectToSchedule />} />
       </Route>
 
       <Route path="/" element={<Navigate to="/dashboard" replace />} />
@@ -49,7 +51,28 @@ export function App() {
   );
 }
 
-function ProjectRedirectToEdit() {
+/**
+ * プロジェクト直下 → 先頭の制作物スケジュールへリダイレクト。
+ * 制作物が無ければプロジェクト編集へフォールバック。
+ */
+function ProjectRedirectToSchedule() {
   const { projectId } = useParams<{ projectId: string }>();
-  return <Nav to={`/projects/${projectId}/edit`} replace />;
+  const itemsQuery = useQuery({
+    queryKey: projectsQueryKey.items(projectId ?? ''),
+    queryFn: () => projectsApi.listItems(projectId!),
+    enabled: !!projectId,
+  });
+
+  if (!projectId) return <Nav to="/projects" replace />;
+  if (itemsQuery.isLoading) {
+    return <div className="p-8 text-sm text-muted-foreground">読み込み中…</div>;
+  }
+  const items = (itemsQuery.data ?? []).slice().sort((a, b) => a.sortOrder - b.sortOrder);
+  const first = items[0];
+  return (
+    <Nav
+      to={first ? `/projects/${projectId}/items/${first.id}` : `/projects/${projectId}/edit`}
+      replace
+    />
+  );
 }

--- a/apps/web/src/components/ui/date-field.tsx
+++ b/apps/web/src/components/ui/date-field.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { CalendarDays } from 'lucide-react';
+
+import { Input } from './input';
+import { cn } from './utils';
+
+/**
+ * 日付入力フィールド。ネイティブ `<input type="date">` に
+ * カレンダーアイコンボタンを重ね、押下で `showPicker()` を呼んでピッカーを起動する。
+ * RHF の register をそのまま spread できるよう ref を転送する。
+ */
+export const DateField = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+  ({ className, ...props }, ref) => {
+    const innerRef = React.useRef<HTMLInputElement | null>(null);
+
+    const setRefs = (el: HTMLInputElement | null) => {
+      innerRef.current = el;
+      if (typeof ref === 'function') ref(el);
+      else if (ref) (ref as React.MutableRefObject<HTMLInputElement | null>).current = el;
+    };
+
+    const openPicker = () => {
+      const el = innerRef.current;
+      if (!el) return;
+      if (typeof el.showPicker === 'function') {
+        try {
+          el.showPicker();
+          return;
+        } catch {
+          /* showPicker 不可時は focus にフォールバック */
+        }
+      }
+      el.focus();
+    };
+
+    return (
+      <div className="relative">
+        <Input
+          ref={setRefs}
+          type="date"
+          className={cn('pr-9 [&::-webkit-calendar-picker-indicator]:opacity-0', className)}
+          {...props}
+        />
+        <button
+          type="button"
+          onClick={openPicker}
+          aria-label="カレンダーを開く"
+          className="absolute inset-y-0 right-0 flex items-center pr-2.5 text-muted-foreground hover:text-foreground"
+        >
+          <CalendarDays className="size-4" />
+        </button>
+      </div>
+    );
+  },
+);
+DateField.displayName = 'DateField';

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
+
+import { cn } from './utils';
+
+/**
+ * 右からスライドインする非ブロッキングなパネル (Sheet)。
+ * `@radix-ui/react-dialog` を `modal={false}` で利用し、オーバーレイを描画しない。
+ * → 背面のカレンダー等を操作したまま予定の作成/詳細を扱える。
+ * 外側クリックでは閉じず、× ボタン / Esc / 明示的な close で閉じる。
+ */
+function Sheet({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="sheet" modal={false} {...props} />;
+}
+
+function SheetClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPrimitive.Portal data-slot="sheet-portal">
+      <DialogPrimitive.Content
+        data-slot="sheet-content"
+        // 背面操作を許可: 外側クリック/フォーカス移動では閉じない
+        onInteractOutside={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        className={cn(
+          'bg-background fixed inset-y-0 right-0 z-50 flex h-full w-full max-w-[420px] flex-col gap-4 border-l p-6 shadow-xl',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right duration-200',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden">
+          <XIcon className="size-4" />
+          <span className="sr-only">閉じる</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn('flex flex-col gap-1.5 pr-8', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn('mt-auto flex flex-col gap-2', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="sheet-title"
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="sheet-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/apps/web/src/features/auth/ProfileModal.tsx
+++ b/apps/web/src/features/auth/ProfileModal.tsx
@@ -1,6 +1,14 @@
-import { LogOut } from 'lucide-react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Loader2, LogOut } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   Dialog,
   DialogContent,
@@ -9,7 +17,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import type { CurrentUser } from './api';
+import { ApiClientError } from '@/lib/api';
+import { authApi, type CurrentUser } from './api';
 
 const AUTH_METHOD_LABEL: Record<CurrentUser['primaryAuthMethod'], string> = {
   password: 'メール + パスワード',
@@ -17,9 +26,12 @@ const AUTH_METHOD_LABEL: Record<CurrentUser['primaryAuthMethod'], string> = {
   microsoft: 'Microsoft',
 };
 
+type Mode = 'view' | 'profile' | 'password';
+
 /**
- * プロフィール表示モーダル (プロトタイプ ProfileModal の表示部)。
- * 氏名/組織/パスワードの編集は更新 API 未実装のため将来対応 (Phase 1)。
+ * プロフィール / 認証情報モーダル (プロトタイプ ProfileModal 準拠)。
+ * - 表示 / 氏名・表示名の編集 / パスワード変更 を切替
+ * - 更新は PATCH /auth/me、成功時 ['auth','sync'] を invalidate
  */
 export function ProfileModal({
   user,
@@ -32,48 +44,211 @@ export function ProfileModal({
   onClose: () => void;
   onSignOut: () => void;
 }) {
-  const initial = (user.displayName || user.fullName || user.email).charAt(0).toUpperCase();
+  const [mode, setMode] = useState<Mode>('view');
+  const close = () => {
+    setMode('view');
+    onClose();
+  };
+
   return (
-    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+    <Dialog open={open} onOpenChange={(o) => !o && close()}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>アカウント</DialogTitle>
-          <DialogDescription>プロフィール情報を確認できます。</DialogDescription>
+          <DialogDescription>
+            {mode === 'password'
+              ? 'パスワードを変更します。'
+              : mode === 'profile'
+                ? 'お名前と表示名を変更します。'
+                : 'プロフィール情報を確認・編集できます。'}
+          </DialogDescription>
         </DialogHeader>
 
-        <div className="flex items-center gap-3">
-          <div className="flex size-12 items-center justify-center rounded-full bg-primary text-base font-semibold text-primary-foreground">
-            {initial}
-          </div>
-          <div className="min-w-0">
-            <p className="truncate font-medium">{user.displayName}</p>
-            <p className="truncate text-sm text-muted-foreground">{user.email}</p>
-          </div>
-        </div>
-
-        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-sm">
-          <dt className="text-muted-foreground">氏名</dt>
-          <dd>{user.fullName}</dd>
-          <dt className="text-muted-foreground">表示名</dt>
-          <dd>{user.displayName}</dd>
-          <dt className="text-muted-foreground">認証方法</dt>
-          <dd>{AUTH_METHOD_LABEL[user.primaryAuthMethod]}</dd>
-        </dl>
-
-        <p className="text-[11px] text-muted-foreground">
-          氏名・パスワードの変更は今後のリリースで対応予定です。
-        </p>
-
-        <DialogFooter>
-          <Button variant="ghost" onClick={onClose}>
-            閉じる
-          </Button>
-          <Button variant="outline" onClick={onSignOut}>
-            <LogOut className="size-4" />
-            サインアウト
-          </Button>
-        </DialogFooter>
+        {mode === 'view' && (
+          <ViewMode
+            user={user}
+            onEdit={() => setMode('profile')}
+            onChangePassword={() => setMode('password')}
+            onSignOut={onSignOut}
+            onClose={close}
+          />
+        )}
+        {mode === 'profile' && <ProfileForm user={user} onDone={() => setMode('view')} />}
+        {mode === 'password' && <PasswordForm onDone={() => setMode('view')} />}
       </DialogContent>
     </Dialog>
+  );
+}
+
+function ViewMode({
+  user,
+  onEdit,
+  onChangePassword,
+  onSignOut,
+  onClose,
+}: {
+  user: CurrentUser;
+  onEdit: () => void;
+  onChangePassword: () => void;
+  onSignOut: () => void;
+  onClose: () => void;
+}) {
+  const initial = (user.displayName || user.fullName || user.email).charAt(0).toUpperCase();
+  return (
+    <>
+      <div className="flex items-center gap-3">
+        <div className="flex size-12 items-center justify-center rounded-full bg-primary text-base font-semibold text-primary-foreground">
+          {initial}
+        </div>
+        <div className="min-w-0">
+          <p className="truncate font-medium">{user.displayName}</p>
+          <p className="truncate text-sm text-muted-foreground">{user.email}</p>
+        </div>
+      </div>
+
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-sm">
+        <dt className="text-muted-foreground">氏名</dt>
+        <dd>{user.fullName}</dd>
+        <dt className="text-muted-foreground">表示名</dt>
+        <dd>{user.displayName}</dd>
+        <dt className="text-muted-foreground">認証方法</dt>
+        <dd>{AUTH_METHOD_LABEL[user.primaryAuthMethod]}</dd>
+      </dl>
+
+      <div className="flex flex-wrap gap-2">
+        <Button variant="outline" size="sm" onClick={onEdit}>
+          プロフィールを編集
+        </Button>
+        {user.primaryAuthMethod === 'password' && (
+          <Button variant="outline" size="sm" onClick={onChangePassword}>
+            パスワードを変更
+          </Button>
+        )}
+      </div>
+
+      <DialogFooter>
+        <Button variant="ghost" onClick={onClose}>
+          閉じる
+        </Button>
+        <Button variant="outline" onClick={onSignOut}>
+          <LogOut className="size-4" />
+          サインアウト
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+const profileSchema = z.object({
+  fullName: z.string().trim().min(1, '氏名は必須').max(100),
+  displayName: z.string().trim().min(1, '表示名は必須').max(50),
+});
+type ProfileValues = z.infer<typeof profileSchema>;
+
+function ProfileForm({ user, onDone }: { user: CurrentUser; onDone: () => void }) {
+  const qc = useQueryClient();
+  const form = useForm<ProfileValues>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: { fullName: user.fullName, displayName: user.displayName },
+  });
+
+  const mut = useMutation({
+    mutationFn: (v: ProfileValues) => authApi.updateProfile(v),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['auth', 'sync'] });
+      toast.success('プロフィールを更新しました');
+      onDone();
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '更新に失敗しました'),
+  });
+
+  return (
+    <form onSubmit={form.handleSubmit((v) => mut.mutate(v))} className="space-y-3">
+      <FormField label="氏名" error={form.formState.errors.fullName?.message}>
+        <Input {...form.register('fullName')} autoFocus />
+      </FormField>
+      <FormField label="表示名" error={form.formState.errors.displayName?.message}>
+        <Input {...form.register('displayName')} />
+      </FormField>
+      <DialogFooter>
+        <Button type="button" variant="ghost" onClick={onDone} disabled={mut.isPending}>
+          キャンセル
+        </Button>
+        <Button type="submit" disabled={mut.isPending}>
+          {mut.isPending && <Loader2 className="size-4 animate-spin" />}
+          保存
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+const passwordSchema = z
+  .object({
+    newPassword: z
+      .string()
+      .min(8, 'パスワードは8文字以上')
+      .max(128)
+      .refine((v) => /[A-Za-z]/.test(v) && /\d/.test(v) && /[^\w\s]/.test(v), {
+        message: '英字・数字・記号をそれぞれ1文字以上含めてください',
+      }),
+    confirm: z.string(),
+  })
+  .refine((v) => v.newPassword === v.confirm, {
+    path: ['confirm'],
+    message: 'パスワードが一致しません',
+  });
+type PasswordValues = z.infer<typeof passwordSchema>;
+
+function PasswordForm({ onDone }: { onDone: () => void }) {
+  const form = useForm<PasswordValues>({ resolver: zodResolver(passwordSchema) });
+
+  const mut = useMutation({
+    mutationFn: (v: PasswordValues) => authApi.updateProfile({ newPassword: v.newPassword }),
+    onSuccess: () => {
+      toast.success('パスワードを変更しました');
+      onDone();
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '変更に失敗しました'),
+  });
+
+  return (
+    <form onSubmit={form.handleSubmit((v) => mut.mutate(v))} className="space-y-3">
+      <FormField label="新しいパスワード" error={form.formState.errors.newPassword?.message}>
+        <Input type="password" autoComplete="new-password" {...form.register('newPassword')} />
+      </FormField>
+      <FormField label="新しいパスワード（確認）" error={form.formState.errors.confirm?.message}>
+        <Input type="password" autoComplete="new-password" {...form.register('confirm')} />
+      </FormField>
+      <DialogFooter>
+        <Button type="button" variant="ghost" onClick={onDone} disabled={mut.isPending}>
+          キャンセル
+        </Button>
+        <Button type="submit" disabled={mut.isPending}>
+          {mut.isPending && <Loader2 className="size-4 animate-spin" />}
+          パスワードを変更
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+function FormField({
+  label,
+  error,
+  children,
+}: {
+  label: string;
+  error?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label>{label}</Label>
+      {children}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
   );
 }

--- a/apps/web/src/features/auth/api.ts
+++ b/apps/web/src/features/auth/api.ts
@@ -19,9 +19,17 @@ export type CompleteSignupInput = {
   password: string;
 };
 
+export type UpdateProfileInput = {
+  fullName?: string;
+  displayName?: string;
+  newPassword?: string;
+};
+
 export const authApi = {
   syncMe: () => apiRequest<SyncResponse>('/auth/me/sync', { method: 'POST' }),
   getMe: () => apiRequest<CurrentUser>('/auth/me'),
   completeSignup: (body: CompleteSignupInput) =>
     apiRequest<CurrentUser>('/auth/me/complete-signup', { method: 'POST', body }),
+  updateProfile: (body: UpdateProfileInput) =>
+    apiRequest<CurrentUser>('/auth/me', { method: 'PATCH', body }),
 };

--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -1,19 +1,19 @@
 import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
-import { CheckCircle2, Loader2, Pencil, Send, Trash2, Zap } from 'lucide-react';
+import { CheckCircle2, Loader2, Pencil, Send, Trash2, Undo2, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -67,6 +67,18 @@ export function BallDetailModal({
   const tossMut = useTossPlan({ projectId, itemId, planId });
   const completeMut = useCompletePlan({ projectId, itemId, planId });
 
+  const undoMut = useMutation({
+    mutationFn: () => plansApi.undoToss(projectId, itemId, planId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+      qc.invalidateQueries({ queryKey: plansQueryKey.projectList(projectId) });
+      qc.invalidateQueries({ queryKey: plansQueryKey.detail(projectId, itemId, planId) });
+      toast.success('差し戻しました');
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '差し戻しに失敗しました'),
+  });
+
   const deleteMut = useMutation({
     mutationFn: () => plansApi.remove(projectId, itemId, planId),
     onSuccess: () => {
@@ -81,14 +93,14 @@ export function BallDetailModal({
   });
 
   return (
-    <Dialog open onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="max-w-lg">
+    <Sheet open onOpenChange={(o) => !o && onClose()}>
+      <SheetContent>
         {detailQuery.isLoading && <DetailSkeleton />}
         {detailQuery.error && (
-          <DialogHeader>
-            <DialogTitle>取得に失敗しました</DialogTitle>
-            <DialogDescription>時間をおいて再度お試しください。</DialogDescription>
-          </DialogHeader>
+          <SheetHeader>
+            <SheetTitle>取得に失敗しました</SheetTitle>
+            <SheetDescription>時間をおいて再度お試しください。</SheetDescription>
+          </SheetHeader>
         )}
         {detailQuery.data &&
           (() => {
@@ -103,20 +115,20 @@ export function BallDetailModal({
 
             return (
               <>
-                <DialogHeader>
-                  <DialogTitle className="flex items-center gap-2">
+                <SheetHeader>
+                  <SheetTitle className="flex items-center gap-2">
                     <Badge variant="secondary" className={`${style.bg} ${style.text}`}>
                       {style.label}
                     </Badge>
                     {plan.title}
-                  </DialogTitle>
-                  <DialogDescription>
+                  </SheetTitle>
+                  <SheetDescription>
                     {format(new Date(plan.scheduledDate), 'yyyy/M/d')}
                     {plan.dueDate && ` 〜 期日 ${format(new Date(plan.dueDate), 'yyyy/M/d')}`}
-                  </DialogDescription>
-                </DialogHeader>
+                  </SheetDescription>
+                </SheetHeader>
 
-                <div className="space-y-3 text-sm">
+                <div className="flex-1 space-y-3 overflow-y-auto text-sm">
                   <BallHolderBanner plan={plan} />
 
                   <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
@@ -147,7 +159,7 @@ export function BallDetailModal({
                   </Section>
                 </div>
 
-                <DialogFooter className="flex w-full justify-between gap-2 sm:justify-between">
+                <SheetFooter className="flex-row items-center justify-between">
                   <div className="flex gap-1">
                     {plan.status === 'active' && (
                       <Button
@@ -182,27 +194,38 @@ export function BallDetailModal({
                       </Button>
                     )}
                     {plan.ballState === 'tossed' && canAct && (
-                      <Button
-                        onClick={handleComplete}
-                        disabled={completeMut.isPending}
-                      >
-                        {completeMut.isPending ? (
-                          <Loader2 className="size-4 animate-spin" />
-                        ) : (
-                          <CheckCircle2 className="size-4" />
-                        )}
-                        完了する
-                      </Button>
+                      <>
+                        <Button
+                          variant="outline"
+                          onClick={() => undoMut.mutate()}
+                          disabled={undoMut.isPending}
+                        >
+                          {undoMut.isPending ? (
+                            <Loader2 className="size-4 animate-spin" />
+                          ) : (
+                            <Undo2 className="size-4" />
+                          )}
+                          差し戻す
+                        </Button>
+                        <Button onClick={handleComplete} disabled={completeMut.isPending}>
+                          {completeMut.isPending ? (
+                            <Loader2 className="size-4 animate-spin" />
+                          ) : (
+                            <CheckCircle2 className="size-4" />
+                          )}
+                          完了する
+                        </Button>
+                      </>
                     )}
                     <Button variant="outline" onClick={onClose}>
                       閉じる
                     </Button>
                   </div>
-                </DialogFooter>
+                </SheetFooter>
               </>
             );
           })()}
-      </DialogContent>
+      </SheetContent>
 
       <AlertDialog open={deleting} onOpenChange={(o) => !o && setDeleting(false)}>
         <AlertDialogContent>
@@ -226,7 +249,7 @@ export function BallDetailModal({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Dialog>
+    </Sheet>
   );
 }
 

--- a/apps/web/src/features/plans/CreatePlanModal.tsx
+++ b/apps/web/src/features/plans/CreatePlanModal.tsx
@@ -8,14 +8,15 @@ import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
 import { Input } from '@/components/ui/input';
+import { DateField } from '@/components/ui/date-field';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -65,6 +66,7 @@ export function CreatePlanModal({
   plans,
   mode,
   defaultDate,
+  defaultDueDate,
   defaultFromMemberId,
   planId,
   onClose,
@@ -75,6 +77,7 @@ export function CreatePlanModal({
   plans: Plan[];
   mode: 'create' | 'edit';
   defaultDate?: string;
+  defaultDueDate?: string;
   defaultFromMemberId?: string;
   planId?: string;
   onClose: () => void;
@@ -88,7 +91,7 @@ export function CreatePlanModal({
       title: '',
       category: 'other',
       scheduledDate: defaultDate ?? new Date().toISOString().slice(0, 10),
-      dueDate: '',
+      dueDate: defaultDueDate ?? '',
       fromMemberId: defaultFromMemberId ?? '',
       toMemberId: '',
       successorPlanId: '',
@@ -163,18 +166,22 @@ export function CreatePlanModal({
   );
 
   return (
-    <Dialog open onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle>{mode === 'edit' ? '予定を編集' : '予定を追加'}</DialogTitle>
-          <DialogDescription>
+    <Sheet open onOpenChange={(o) => !o && onClose()}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>{mode === 'edit' ? '予定を編集' : '予定を追加'}</SheetTitle>
+          <SheetDescription>
             {mode === 'edit'
-              ? '日付やメモなどの基本情報を変更します（TOSS 後は FROM/TO の変更不可）'
+              ? '日付やメモなどの基本情報を変更します（TOSS 後は FROM/TO の変更不可）。カレンダー上でカードをドラッグして期間を変更することもできます。'
               : 'カレンダー上に予定（ボール）を作成します'}
-          </DialogDescription>
-        </DialogHeader>
+          </SheetDescription>
+        </SheetHeader>
 
-        <form id="plan-form" onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
+        <form
+          id="plan-form"
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="flex-1 space-y-3 overflow-y-auto pr-1"
+        >
           <Field label="予定名" error={form.formState.errors.title?.message}>
             <Input {...form.register('title')} autoFocus placeholder="例: トップページ構成" />
           </Field>
@@ -213,10 +220,10 @@ export function CreatePlanModal({
 
           <div className="grid grid-cols-2 gap-3">
             <Field label="開始日" error={form.formState.errors.scheduledDate?.message}>
-              <Input type="date" {...form.register('scheduledDate')} />
+              <DateField {...form.register('scheduledDate')} />
             </Field>
             <Field label="終了日 (任意)" error={form.formState.errors.dueDate?.message}>
-              <Input type="date" {...form.register('dueDate')} />
+              <DateField {...form.register('dueDate')} />
             </Field>
           </div>
 
@@ -241,7 +248,7 @@ export function CreatePlanModal({
           </Field>
         </form>
 
-        <DialogFooter>
+        <SheetFooter className="sm:flex-row sm:justify-end">
           <Button type="button" variant="ghost" onClick={onClose} disabled={submitting}>
             キャンセル
           </Button>
@@ -249,9 +256,9 @@ export function CreatePlanModal({
             {submitting && <Loader2 className="size-4 animate-spin" />}
             {mode === 'edit' ? '保存' : '追加'}
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
   );
 }
 

--- a/apps/web/src/features/plans/DateChangeConfirmModal.tsx
+++ b/apps/web/src/features/plans/DateChangeConfirmModal.tsx
@@ -33,10 +33,10 @@ export function DateChangeConfirmModal({
         </AlertDialogHeader>
         <div className="flex flex-col gap-2 pt-2">
           <Button onClick={() => onConfirm(true)}>
-            後続の予定も一緒にずらす
+            次の予定（後続チェーン）も一緒にずらす
           </Button>
           <p className="-mt-1 text-[11px] text-muted-foreground">
-            この予定の後に始まる同じ制作物の予定を、同じ日数分ずらします。
+            「次の予定」で連なる後続の予定を、同じ日数分ずらします。
           </p>
           <Button variant="outline" onClick={() => onConfirm(false)}>
             この予定のみ変更

--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -3,7 +3,7 @@ import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { addDays, differenceInDays, format, isSameDay, isWeekend, parseISO } from 'date-fns';
 import { isHoliday } from '@holiday-jp/holiday_jp';
-import { ArrowLeft, CheckCircle2, Plus, ZoomIn, ZoomOut } from 'lucide-react';
+import { CheckCircle2, KanbanSquare, Plus, Settings, ZoomIn, ZoomOut } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -124,12 +124,17 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
   if (loading) return <PageSkeleton />;
   if (!project || !focusedItem || loadFailed) return <NotFound />;
 
-  const openCreateModal = (date: Date, targetItemId: string) => {
+  const openCreateModal = (date: Date, targetItemId: string, dueDate?: Date) => {
     setParams(
       (sp) => {
         sp.set('modal', 'create-plan');
         sp.set('date', format(date, 'yyyy-MM-dd'));
         sp.set('itemId', targetItemId);
+        if (dueDate && format(dueDate, 'yyyy-MM-dd') !== format(date, 'yyyy-MM-dd')) {
+          sp.set('due', format(dueDate, 'yyyy-MM-dd'));
+        } else {
+          sp.delete('due');
+        }
         sp.delete('planId');
         return sp;
       },
@@ -157,16 +162,16 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
   const confirmMove = (moveSubsequent: boolean) => {
     if (!pendingMove) return;
     const { plan, dayDelta } = pendingMove;
-    const { end } = planRange(plan);
     const patches: ReschedulePatch[] = [shiftPatch(plan, dayDelta)];
     if (moveSubsequent) {
-      const originalEndMs = parseISO(end).getTime();
-      for (const p of plansByItem.get(plan.itemId) ?? []) {
-        if (p.id === plan.id) continue;
-        if (p.status !== 'active') continue;
-        if (parseISO(planRange(p).start).getTime() >= originalEndMs) {
-          patches.push(shiftPatch(p, dayDelta));
-        }
+      // 「次の予定」(successorPlanId) のチェーンをたどって同日数ずらす
+      const byId = new Map(plans.map((p) => [p.id, p]));
+      const seen = new Set<string>([plan.id]);
+      let cur = plan.successorPlanId ? byId.get(plan.successorPlanId) : undefined;
+      while (cur && !seen.has(cur.id)) {
+        seen.add(cur.id);
+        if (cur.status === 'active') patches.push(shiftPatch(cur, dayDelta));
+        cur = cur.successorPlanId ? byId.get(cur.successorPlanId) : undefined;
       }
     }
     reschedule.mutate(patches);
@@ -205,6 +210,10 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
             <span>スケジュール</span>
           </div>
           <h1 className="text-lg font-semibold tracking-tight">{project.name}</h1>
+          <p className="text-xs text-muted-foreground">
+            期間: {format(parseISO(project.startDate), 'yyyy/M/d')} 〜{' '}
+            {format(parseISO(project.endDate), 'yyyy/M/d')}
+          </p>
         </div>
         <div className="flex items-center gap-2">
           <Select value={viewItemId} onValueChange={setViewItemId}>
@@ -221,9 +230,15 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
             </SelectContent>
           </Select>
           <Button variant="ghost" size="sm" asChild>
+            <Link to={`/projects/${projectId}/members`}>
+              <KanbanSquare className="size-4" />
+              メンバーかんばん
+            </Link>
+          </Button>
+          <Button variant="ghost" size="sm" asChild>
             <Link to={`/projects/${projectId}/edit`}>
-              <ArrowLeft className="size-4" />
-              プロジェクト設定
+              <Settings className="size-4" />
+              プロジェクト情報
             </Link>
           </Button>
           <Button size="sm" onClick={() => openCreateModal(new Date(), headerTargetItem)}>
@@ -295,7 +310,7 @@ function ScheduleBoard({
   items: ProjectItem[];
   plansByItem: Map<string, Plan[]>;
   rowHeight: number;
-  onOpenCreate: (date: Date, itemId: string) => void;
+  onOpenCreate: (date: Date, itemId: string, dueDate?: Date) => void;
   onOpenDetail: (planId: string) => void;
   onMove: (plan: Plan, dayDelta: number) => void;
   onResize: (plan: Plan, edge: 'top' | 'bottom', dayDelta: number) => void;
@@ -304,6 +319,30 @@ function ScheduleBoard({
   const [drag, setDrag] = useState<DragState | null>(null);
   const dragRef = useRef<DragState | null>(null);
   dragRef.current = drag;
+
+  // 空セルの縦ドラッグで期間付き新規作成
+  type CreateDrag = { itemId: string; startIdx: number; endIdx: number };
+  const [createDrag, setCreateDrag] = useState<CreateDrag | null>(null);
+  const createDragRef = useRef<CreateDrag | null>(null);
+  createDragRef.current = createDrag;
+
+  useEffect(() => {
+    if (!createDrag) return;
+    const onUp = () => {
+      const cd = createDragRef.current;
+      setCreateDrag(null);
+      if (!cd) return;
+      const s = Math.min(cd.startIdx, cd.endIdx);
+      const e = Math.max(cd.startIdx, cd.endIdx);
+      const startDate = days[s];
+      const endDate = days[e];
+      if (!startDate) return;
+      if (s === e) onOpenCreate(startDate, cd.itemId);
+      else onOpenCreate(startDate, cd.itemId, endDate);
+    };
+    window.addEventListener('pointerup', onUp);
+    return () => window.removeEventListener('pointerup', onUp);
+  }, [createDrag, days, onOpenCreate]);
 
   useEffect(() => {
     if (!drag) return;
@@ -366,7 +405,7 @@ function ScheduleBoard({
           className="sticky left-0 z-30 shrink-0 border-r border-border bg-background"
           style={{ width: DATE_AXIS_WIDTH }}
         >
-          <div className="sticky top-0 z-10 h-12 border-b border-border bg-background" />
+          <div className="sticky top-0 z-10 h-16 border-b border-border bg-background" />
           <div className="relative" style={{ height: totalHeight }}>
             {days.map((d, i) => {
               const t = dayTones[i]!;
@@ -408,35 +447,75 @@ function ScheduleBoard({
           const { laneOf, laneCount } = assignLanes(itemPlans);
           const colWidth = Math.max(MIN_COLUMN_WIDTH, laneCount * LANE_WIDTH);
           const color = itemColor(item.id);
+          // 代表ボール = 最新の active プラン。その現ホルダーを列上部に表示
+          const activePlans = itemPlans.filter((p) => p.status === 'active');
+          const repHolder = activePlans.length
+            ? activePlans[activePlans.length - 1]!.ballHolder
+            : null;
           return (
             <div
               key={item.id}
               className="shrink-0 border-r border-border"
               style={{ width: colWidth }}
             >
-              {/* 列ヘッダー (sticky top) */}
-              <div className="sticky top-0 z-20 flex h-12 items-center gap-2 border-b border-border bg-background px-3">
-                <span className={cn('size-2.5 shrink-0 rounded-full', color.dot)} />
-                <span className="truncate text-sm font-medium">{item.name}</span>
-                <Badge variant="secondary" className="ml-auto shrink-0 text-[10px]">
-                  {itemPlans.length}件
-                </Badge>
+              {/* 列ヘッダー (sticky top): 制作物名 ＋ 現在のボール保持者 */}
+              <div className="sticky top-0 z-20 flex h-16 flex-col justify-center gap-0.5 border-b border-border bg-background px-3">
+                <div className="flex items-center gap-2">
+                  <span className={cn('size-2.5 shrink-0 rounded-full', color.dot)} />
+                  <span className="truncate text-sm font-medium">{item.name}</span>
+                  <Badge variant="secondary" className="ml-auto shrink-0 text-[10px]">
+                    {itemPlans.length}件
+                  </Badge>
+                </div>
+                <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                  <span className="shrink-0">ボール保持:</span>
+                  {repHolder ? (
+                    <span className="truncate font-medium text-foreground">
+                      {repHolder.organizationName
+                        ? `${repHolder.organizationName} ${repHolder.name}`
+                        : repHolder.name}
+                    </span>
+                  ) : (
+                    <span>—</span>
+                  )}
+                </div>
               </div>
 
               {/* 本体 */}
               <div className="relative" style={{ height: totalHeight }}>
-                {/* 日付セル (クリックで作成) */}
+                {/* 日付セル (クリックで単日作成 / 縦ドラッグで期間作成) */}
                 {days.map((d, i) => {
                   const t = dayTones[i]!;
+                  const inRange =
+                    createDrag !== null &&
+                    createDrag.itemId === item.id &&
+                    i >= Math.min(createDrag.startIdx, createDrag.endIdx) &&
+                    i <= Math.max(createDrag.startIdx, createDrag.endIdx);
                   return (
                     <button
                       key={i}
                       type="button"
-                      onClick={() => onOpenCreate(d, item.id)}
+                      onPointerDown={(e) => {
+                        if (e.button === 0) {
+                          setCreateDrag({ itemId: item.id, startIdx: i, endIdx: i });
+                        }
+                      }}
+                      onPointerEnter={() =>
+                        setCreateDrag((cd) =>
+                          cd && cd.itemId === item.id ? { ...cd, endIdx: i } : cd,
+                        )
+                      }
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          onOpenCreate(d, item.id);
+                        }
+                      }}
                       className={cn(
                         'absolute left-0 right-0 border-b border-border/70 transition-colors hover:bg-accent/30',
                         t.tone,
                         t.first && 'border-t-2 border-t-foreground/20',
+                        inRange && 'bg-primary/15',
                       )}
                       style={{ top: i * rowHeight, height: rowHeight }}
                       aria-label={`${format(d, 'M/d')} に予定を作成`}
@@ -521,15 +600,19 @@ function BallChip({
   const tier = ballTier(height);
   const style = CATEGORY_STYLE[plan.category];
   const completed = plan.status === 'completed';
+  const tossed = plan.ballState === 'tossed';
   const overdue = isOverdue(plan, today);
   const active = isActiveNow(plan, today);
   const editable = plan.status === 'active';
 
+  // TOSS 済みは「相手に渡し終えた＝自分の作業は完了」をグレーで表現
   const cardClass = completed
     ? 'border-slate-200 bg-slate-100/80 text-slate-500 opacity-60'
     : overdue
       ? 'border-red-400 bg-red-50 text-red-700'
-      : cn(style.bg, style.border, style.text);
+      : tossed
+        ? 'border-slate-300 bg-slate-100 text-slate-600'
+        : cn(style.bg, style.border, style.text);
 
   return (
     <div

--- a/apps/web/src/features/plans/MemberKanbanTab.tsx
+++ b/apps/web/src/features/plans/MemberKanbanTab.tsx
@@ -334,6 +334,7 @@ function DraggablePlanCard({
     ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` }
     : undefined;
   const cat = CATEGORY_STYLE[plan.category];
+  const tossed = plan.ballState === 'tossed';
   const overdue =
     plan.ballState === 'ready' &&
     !!plan.dueDate &&
@@ -345,7 +346,7 @@ function DraggablePlanCard({
       style={style}
       className={cn(
         'rounded-md border bg-card shadow-sm',
-        overdue ? 'border-red-400' : cat.border,
+        overdue ? 'border-red-400' : tossed ? 'border-slate-300' : cat.border,
         isDragging && 'opacity-60',
       )}
     >
@@ -353,8 +354,7 @@ function DraggablePlanCard({
       <div
         className={cn(
           'flex items-center gap-1 rounded-t-md px-2 py-1 text-[10px]',
-          cat.bg,
-          cat.text,
+          tossed ? 'bg-slate-100 text-slate-600' : cn(cat.bg, cat.text),
         )}
         {...listeners}
         {...attributes}

--- a/apps/web/src/features/plans/PlanModalsHost.tsx
+++ b/apps/web/src/features/plans/PlanModalsHost.tsx
@@ -30,7 +30,7 @@ export function PlanModalsHost({
   const closeModal = () => {
     setParams(
       (sp) => {
-        for (const k of ['modal', 'date', 'fromMemberId', 'itemId', 'planId']) sp.delete(k);
+        for (const k of ['modal', 'date', 'due', 'fromMemberId', 'itemId', 'planId']) sp.delete(k);
         return sp;
       },
       { replace: true },
@@ -52,6 +52,7 @@ export function PlanModalsHost({
         plans={plans}
         mode={modal === 'edit-plan' ? 'edit' : 'create'}
         defaultDate={params.get('date') ?? undefined}
+        defaultDueDate={params.get('due') ?? undefined}
         defaultFromMemberId={params.get('fromMemberId') ?? undefined}
         planId={planId}
         onClose={closeModal}

--- a/apps/web/src/features/plans/api.ts
+++ b/apps/web/src/features/plans/api.ts
@@ -139,6 +139,11 @@ export const plansApi = {
       method: 'POST',
       body: {},
     }),
+  undoToss: (projectId: string, itemId: string, planId: string) =>
+    apiRequest<{ plan: Plan }>(`${basePath(projectId, itemId)}/${planId}/toss-undo`, {
+      method: 'POST',
+      body: {},
+    }),
 };
 
 export const plansQueryKey = {

--- a/apps/web/src/features/projects/ProjectCreatePage.tsx
+++ b/apps/web/src/features/projects/ProjectCreatePage.tsx
@@ -9,6 +9,7 @@ import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { DateField } from '@/components/ui/date-field';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -132,10 +133,10 @@ export function ProjectCreatePage() {
           </Field>
           <div className="grid grid-cols-2 gap-4">
             <Field label="開始日" error={form.formState.errors.startDate?.message}>
-              <Input type="date" {...form.register('startDate')} />
+              <DateField {...form.register('startDate')} />
             </Field>
             <Field label="終了日" error={form.formState.errors.endDate?.message}>
-              <Input type="date" {...form.register('endDate')} />
+              <DateField {...form.register('endDate')} />
             </Field>
           </div>
         </CardContent>

--- a/apps/web/src/features/projects/ProjectEditPage.tsx
+++ b/apps/web/src/features/projects/ProjectEditPage.tsx
@@ -9,6 +9,7 @@ import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { DateField } from '@/components/ui/date-field';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -113,10 +114,10 @@ function ProjectEditInner({ projectId, onBack }: { projectId: string; onBack: ()
             </Field>
             <div className="grid grid-cols-2 gap-4">
               <Field label="開始日" error={form.formState.errors.startDate?.message}>
-                <Input type="date" {...form.register('startDate')} />
+                <DateField {...form.register('startDate')} />
               </Field>
               <Field label="終了日" error={form.formState.errors.endDate?.message}>
-                <Input type="date" {...form.register('endDate')} />
+                <DateField {...form.register('endDate')} />
               </Field>
             </div>
             <div className="flex justify-end">

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -24,7 +24,8 @@
   --destructive: #d4183d;
   --destructive-foreground: #ffffff;
   --border: rgba(0, 0, 0, 0.1);
-  --input: transparent;
+  /* 入力欄の枠線を明確にするため不可視(transparent)から濃いグレーへ */
+  --input: rgba(0, 0, 0, 0.45);
   --input-background: #f3f3f5;
   --ring: oklch(0.708 0 0);
   --radius: 0.625rem;

--- a/packages/db/prisma/migrations/20260601000002_add_toss_undone_event/migration.sql
+++ b/packages/db/prisma/migrations/20260601000002_add_toss_undone_event/migration.sql
@@ -1,0 +1,12 @@
+-- -----------------------------------------------------------------------------
+-- 差し戻し (toss_undone) イベント種別を追加
+-- ball_events は append-only (UPDATE/DELETE 拒否) のため、TOSS の取り消しは
+-- 行削除ではなく 'toss_undone' イベントの追記で表現する。
+-- 最新イベントが 'toss_undone' のとき state = 'ready' (from_member に戻る)。
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE "ball_events" DROP CONSTRAINT "ck_be_event_type";
+
+ALTER TABLE "ball_events"
+  ADD CONSTRAINT "ck_be_event_type"
+  CHECK ("event_type" IN ('tossed', 'completed', 'toss_undone'));

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -187,7 +187,7 @@ model Plan {
 model BallEvent {
   id            String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
   planId        String   @map("plan_id") @db.Uuid
-  /// 'tossed' | 'completed' (CHECK 制約)
+  /// 'tossed' | 'completed' | 'toss_undone' (CHECK 制約)
   eventType     String   @map("event_type")
   /// 'human' | 'auto_chain' (CHECK 制約 + actor_consistency)
   source        String   @default("human")

--- a/packages/shared/src/domain/ballHolder.ts
+++ b/packages/shared/src/domain/ballHolder.ts
@@ -5,8 +5,10 @@
 
 export type PlanState = 'ready' | 'tossed' | 'completed';
 
+export type BallEventType = 'tossed' | 'completed' | 'toss_undone';
+
 export type BallEventLike = {
-  eventType: 'tossed' | 'completed';
+  eventType: BallEventType;
   source: 'human' | 'auto_chain';
   occurredAt: string | Date;
 };
@@ -29,9 +31,13 @@ export type BallHolderResult = {
  *   - イベント未発生: from_member が Ball Holder, state = 'ready'
  *   - 最新 = tossed: to_member が Ball Holder, state = 'tossed'
  *   - 最新 = completed: to_member が Ball Holder (完了者), state = 'completed'
+ *   - 最新 = toss_undone (差し戻し): from_member に戻る, state = 'ready'
+ *
+ * 各イベントは「遷移後の状態」を表すため、最新イベント 1 件で現状態が決まる
+ * (toss_undone は直前の tossed を打ち消し ready に戻す)。
  */
 export function deriveBallHolder(plan: PlanLike, latestEvent?: BallEventLike | null): BallHolderResult {
-  if (!latestEvent) {
+  if (!latestEvent || latestEvent.eventType === 'toss_undone') {
     return { memberId: plan.fromMemberId, state: 'ready' };
   }
   if (latestEvent.eventType === 'tossed') {


### PR DESCRIPTION
PR #22 のレビューでいただいた 9 件の修正依頼を反映します。

## 対応内容（依頼番号と対応）

1. **後続タスクの編集（チェーン連動）** — 予定の日付変更時、`successorPlanId` で連なる後続予定のみを同日数ずらす（「後に始まる全予定」ではなくチェーン基準）。
2. **プロジェクト→縦型カレンダー導線** — `/projects/:id` を先頭制作物のスケジュールへリダイレクト。スケジュールヘッダーに**プロジェクト期間・情報/編集・メンバーかんばん**へのリンクを追加。
3. **右サイドパネル化（非ブロッキング）** — 予定の作成/詳細を右からスライドする `Sheet`（`modal={false}`・オーバーレイ無し）に変更。**開いたままカレンダーを操作可**。空セルの**縦ドラッグで期間付き新規作成**、既存カードの移動/リサイズで期間調整。
4. **入力枠を明確化** — `--input` トークンが透明で枠が見えなかったため濃いグレーへ。
5. **日付ピッカー** — `DateField`（ネイティブ `<input type=date>` ＋カレンダーアイコン → `showPicker()`）を導入し各日付入力へ適用（依存追加なし）。
6. **かんばんへの導線** — スケジュールヘッダーに「メンバーかんばん」リンクを追加。
7. **TOSS の差し戻し＋グレー表示** — `ball_events` に **`toss_undone`** 種別を追加（append-only のため行削除せず追記）。`POST /plans/:id/toss-undo` を新設。ボール詳細に「差し戻す」、TOSS 済みは**グレー表示**。
8. **プロフィール/認証情報の編集** — `PATCH /auth/me`（氏名・表示名・パスワード）。`ProfileModal` を表示→編集/パスワード変更に対応。
9. **制作物列ヘッダーに現ボール保持者を表示** — 代表ボール（最新 active プラン）のホルダーを「所属 表示名」で表示。

## バックエンド変更
- 新 migration `20260601000002_add_toss_undone_event`（CHECK 制約に `toss_undone` を追加）。
- `deriveBallHolder` を最新イベントで `ready/tossed/completed` 判定（`toss_undone`→ready）。
- `undoTossPlan`（認可: 現ホルダー or ディレクター）、`updateProfile`（Supabase admin + Prisma）。

## 検証
- ✅ `type-check` / `lint`（warning 0）/ `test`（54 件）/ `build`
- ⚠️ **要マイグレーション適用**: 差し戻し機能の動作には `pnpm db:deploy` で `toss_undone` migration の適用が必要（共有ローカル DB を本ブランチから変更すると `migrate dev` で drift を招くため、本作業では未適用）。
- ⚠️ ブラウザ実機確認は未実施（dev スタック衝突回避）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)