### PR TITLE
fix(web): 監査ログ制約バグ修正＋デザイン一貫性（ヘッダ/サイドバー統一）

### DIFF
--- a/apps/web/src/app/DashboardPage.tsx
+++ b/apps/web/src/app/DashboardPage.tsx
@@ -8,6 +8,8 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/components/ui/utils';
+import { PageContainer } from '@/components/layout/PageContainer';
+import { PageHeader } from '@/components/layout/PageHeader';
 import { CATEGORY_STYLE } from '@/features/plans/categoryColor';
 import {
   dashboardApi,
@@ -27,15 +29,15 @@ export function DashboardPage() {
   });
 
   return (
-    <div className="mx-auto max-w-5xl space-y-6 px-8 py-10">
-      <header>
-        <h1 className="text-xl font-semibold tracking-tight">ダッシュボード</h1>
-        <p className="text-sm text-muted-foreground">
-          {data
+    <PageContainer width="lg">
+      <PageHeader
+        title="ダッシュボード"
+        description={
+          data
             ? `${format(parseISO(data.today), 'yyyy年 M月d日 (E)', { locale: ja })} 時点で進行中のボール`
-            : '今日のボールを集計中…'}
-        </p>
-      </header>
+            : '今日のボールを集計中…'
+        }
+      />
 
       {isLoading && <Loading />}
       {error && (
@@ -86,7 +88,7 @@ export function DashboardPage() {
           )}
         </>
       )}
-    </div>
+    </PageContainer>
   );
 }
 

--- a/apps/web/src/app/SidebarLayout.tsx
+++ b/apps/web/src/app/SidebarLayout.tsx
@@ -4,6 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import { LayoutDashboard, Plus } from 'lucide-react';
 
 import { Toaster } from '@/components/ui/sonner';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Avatar } from '@/components/ui/avatar';
 import { cn } from '@/components/ui/utils';
 import { supabase } from '@/lib/supabase';
 import { useCurrentUser } from '@/features/auth/useCurrentUser';
@@ -49,19 +51,22 @@ export function SidebarLayout() {
   };
 
   return (
-    <div className="flex min-h-screen bg-background text-foreground">
-      <aside className="flex w-60 shrink-0 flex-col border-r border-border">
-        <Link to="/dashboard" className="px-5 py-5 text-xl font-bold tracking-tight">
+    <div className="flex h-screen overflow-hidden bg-background text-foreground">
+      <aside className="flex h-full w-60 shrink-0 flex-col border-r border-border">
+        <Link
+          to="/dashboard"
+          className="shrink-0 px-5 py-5 text-xl font-bold tracking-tight"
+        >
           TRAKON
         </Link>
 
-        <nav className="px-3">
+        <nav className="shrink-0 px-3">
           <SideLink to="/dashboard" icon={<LayoutDashboard className="size-4" />}>
             ダッシュボード
           </SideLink>
         </nav>
 
-        <div className="mt-4 flex items-center justify-between px-5 py-1">
+        <div className="mt-4 flex shrink-0 items-center justify-between px-5 py-1">
           <span className="text-xs font-medium text-muted-foreground">プロジェクト</span>
           <Link
             to="/projects/new"
@@ -100,24 +105,35 @@ export function SidebarLayout() {
           </nav>
         </div>
 
-        {user && (
-          <button
-            type="button"
-            onClick={() => setProfileOpen(true)}
-            className="flex items-center gap-2 border-t border-border px-4 py-3 text-left hover:bg-accent/40"
-          >
-            <span className="flex size-8 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
-              {(user.displayName || user.email).charAt(0).toUpperCase()}
-            </span>
-            <span className="min-w-0">
-              <span className="block truncate text-sm font-medium">{user.displayName}</span>
-              <span className="block truncate text-[11px] text-muted-foreground">{user.email}</span>
-            </span>
-          </button>
-        )}
+        {/* ユーザー情報フッター: 全ページ共通で常時表示 (読込中は Skeleton) */}
+        <div className="shrink-0 border-t border-border">
+          {user ? (
+            <button
+              type="button"
+              onClick={() => setProfileOpen(true)}
+              className="flex w-full items-center gap-2 px-4 py-3 text-left hover:bg-accent/40"
+            >
+              <Avatar name={user.displayName || user.email} className="size-8 text-xs" />
+              <span className="min-w-0">
+                <span className="block truncate text-sm font-medium">{user.displayName}</span>
+                <span className="block truncate text-[11px] text-muted-foreground">
+                  {user.email}
+                </span>
+              </span>
+            </button>
+          ) : (
+            <div className="flex items-center gap-2 px-4 py-3">
+              <Skeleton className="size-8 rounded-full" />
+              <div className="flex-1 space-y-1">
+                <Skeleton className="h-3.5 w-24" />
+                <Skeleton className="h-3 w-32" />
+              </div>
+            </div>
+          )}
+        </div>
       </aside>
 
-      <main className="flex-1 overflow-auto">
+      <main className="h-full flex-1 overflow-auto">
         <Outlet />
       </main>
 

--- a/apps/web/src/components/layout/PageContainer.tsx
+++ b/apps/web/src/components/layout/PageContainer.tsx
@@ -1,0 +1,30 @@
+import { cn } from '@/components/ui/utils';
+
+const WIDTHS = {
+  md: 'max-w-3xl',
+  lg: 'max-w-5xl',
+  xl: 'max-w-6xl',
+} as const;
+
+/**
+ * 認証ページの共通コンテンツコンテナ。
+ * 最大幅・左右余白・縦リズムを全ページで統一する。
+ * - md: フォーム系 (作成/編集)
+ * - lg: 一覧/ダッシュボード (既定)
+ * - xl: テーブル系 (参加者管理など)
+ */
+export function PageContainer({
+  width = 'lg',
+  className,
+  children,
+}: {
+  width?: keyof typeof WIDTHS;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={cn('mx-auto flex w-full flex-col gap-6 px-6 py-8', WIDTHS[width], className)}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/components/ui/utils';
+
+/**
+ * 全ページ共通のページヘッダ。
+ * タイトル・説明・パンくず・右側アクションをページごとに出し分ける。
+ * - 通常: コンテナ内ヘッダ
+ * - fullWidth: 画面全幅に下線を引くヘッダ (スケジュール等のキャンバス系)
+ */
+export function PageHeader({
+  title,
+  description,
+  breadcrumb,
+  actions,
+  fullWidth = false,
+  className,
+}: {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  breadcrumb?: React.ReactNode;
+  actions?: React.ReactNode;
+  fullWidth?: boolean;
+  className?: string;
+}) {
+  const inner = (
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div className="space-y-1">
+        {breadcrumb && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">{breadcrumb}</div>
+        )}
+        <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+        {description && <p className="text-sm text-muted-foreground">{description}</p>}
+      </div>
+      {actions && <div className="flex flex-wrap items-center gap-2">{actions}</div>}
+    </div>
+  );
+
+  if (fullWidth) {
+    return (
+      <header className={cn('border-b border-border px-8 py-4', className)}>{inner}</header>
+    );
+  }
+  return <header className={className}>{inner}</header>;
+}

--- a/apps/web/src/components/ui/avatar.tsx
+++ b/apps/web/src/components/ui/avatar.tsx
@@ -1,0 +1,26 @@
+import { cn } from './utils';
+
+/**
+ * イニシャル表示の軽量アバター (Radix 依存なし)。
+ * サイズは className（例: `size-8 text-xs`）で指定する。
+ */
+export function Avatar({
+  name,
+  className,
+}: {
+  name: string;
+  className?: string;
+}) {
+  const initial = (name?.trim() || '?').charAt(0).toUpperCase();
+  return (
+    <span
+      className={cn(
+        'flex shrink-0 items-center justify-center rounded-full bg-primary font-semibold text-primary-foreground',
+        className,
+      )}
+      aria-hidden
+    >
+      {initial}
+    </span>
+  );
+}

--- a/apps/web/src/features/auth/ProfileModal.tsx
+++ b/apps/web/src/features/auth/ProfileModal.tsx
@@ -9,6 +9,7 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Avatar } from '@/components/ui/avatar';
 import {
   Dialog,
   DialogContent,
@@ -93,13 +94,13 @@ function ViewMode({
   onSignOut: () => void;
   onClose: () => void;
 }) {
-  const initial = (user.displayName || user.fullName || user.email).charAt(0).toUpperCase();
   return (
     <>
       <div className="flex items-center gap-3">
-        <div className="flex size-12 items-center justify-center rounded-full bg-primary text-base font-semibold text-primary-foreground">
-          {initial}
-        </div>
+        <Avatar
+          name={user.displayName || user.fullName || user.email}
+          className="size-12 text-base"
+        />
         <div className="min-w-0">
           <p className="truncate font-medium">{user.displayName}</p>
           <p className="truncate text-sm text-muted-foreground">{user.email}</p>

--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -20,6 +20,7 @@ import { projectsApi, projectsQueryKey, type ProjectItem } from '@/features/proj
 import { membersApi, membersQueryKey } from '@/features/projects/membersApi';
 import { plansApi, plansQueryKey, type Plan } from './api';
 import { CATEGORY_STYLE } from './categoryColor';
+import { PageHeader } from '@/components/layout/PageHeader';
 import { PlanModalsHost } from './PlanModalsHost';
 import { DateChangeConfirmModal } from './DateChangeConfirmModal';
 import { useReschedulePlan, type ReschedulePatch } from './usePlanReschedule';
@@ -200,53 +201,56 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-8 py-4">
-        <div>
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      <PageHeader
+        fullWidth
+        breadcrumb={
+          <>
             <Link to={`/projects/${projectId}/edit`} className="hover:text-foreground">
               {project.name}
             </Link>
             <span>/</span>
             <span>スケジュール</span>
-          </div>
-          <h1 className="text-lg font-semibold tracking-tight">{project.name}</h1>
-          <p className="text-xs text-muted-foreground">
-            期間: {format(parseISO(project.startDate), 'yyyy/M/d')} 〜{' '}
-            {format(parseISO(project.endDate), 'yyyy/M/d')}
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Select value={viewItemId} onValueChange={setViewItemId}>
-            <SelectTrigger className="h-9 w-44 text-xs">
-              <SelectValue placeholder="制作物" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">すべての制作物</SelectItem>
-              {items.map((i) => (
-                <SelectItem key={i.id} value={i.id}>
-                  {i.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Button variant="ghost" size="sm" asChild>
-            <Link to={`/projects/${projectId}/members`}>
-              <KanbanSquare className="size-4" />
-              メンバーかんばん
-            </Link>
-          </Button>
-          <Button variant="ghost" size="sm" asChild>
-            <Link to={`/projects/${projectId}/edit`}>
-              <Settings className="size-4" />
-              プロジェクト情報
-            </Link>
-          </Button>
-          <Button size="sm" onClick={() => openCreateModal(new Date(), headerTargetItem)}>
-            <Plus className="size-4" />
-            予定を追加
-          </Button>
-        </div>
-      </header>
+          </>
+        }
+        title={project.name}
+        description={`期間: ${format(parseISO(project.startDate), 'yyyy/M/d')} 〜 ${format(
+          parseISO(project.endDate),
+          'yyyy/M/d',
+        )}`}
+        actions={
+          <>
+            <Select value={viewItemId} onValueChange={setViewItemId}>
+              <SelectTrigger className="h-9 w-44 text-xs">
+                <SelectValue placeholder="制作物" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">すべての制作物</SelectItem>
+                {items.map((i) => (
+                  <SelectItem key={i.id} value={i.id}>
+                    {i.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button variant="ghost" size="sm" asChild>
+              <Link to={`/projects/${projectId}/members`}>
+                <KanbanSquare className="size-4" />
+                メンバーかんばん
+              </Link>
+            </Button>
+            <Button variant="ghost" size="sm" asChild>
+              <Link to={`/projects/${projectId}/edit`}>
+                <Settings className="size-4" />
+                プロジェクト情報
+              </Link>
+            </Button>
+            <Button size="sm" onClick={() => openCreateModal(new Date(), headerTargetItem)}>
+              <Plus className="size-4" />
+              予定を追加
+            </Button>
+          </>
+        }
+      />
 
       {members.length === 0 ? (
         <EmptyHint projectId={projectId} />

--- a/apps/web/src/features/projects/MembersPage.tsx
+++ b/apps/web/src/features/projects/MembersPage.tsx
@@ -49,6 +49,8 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { ApiClientError } from '@/lib/api';
+import { PageContainer } from '@/components/layout/PageContainer';
+import { PageHeader } from '@/components/layout/PageHeader';
 import { membersApi, membersQueryKey, type ProjectMember } from './membersApi';
 
 const STATUS_LABEL: Record<ProjectMember['inviteStatus'], { text: string; tone: 'default' | 'secondary' | 'destructive' }> = {
@@ -72,21 +74,19 @@ export function MembersPage() {
   if (!projectId) return <NotFound projectId={undefined} />;
 
   return (
-    <div className="mx-auto max-w-6xl space-y-5 px-8 py-10">
-      <header className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight">参加者</h1>
-          <p className="text-sm text-muted-foreground">
-            プロジェクトのメンバーを管理します
-          </p>
-        </div>
-        <Button variant="ghost" size="sm" asChild>
-          <Link to={`/projects/${projectId}/edit`}>
-            <ArrowLeft className="size-4" />
-            プロジェクト設定に戻る
-          </Link>
-        </Button>
-      </header>
+    <PageContainer width="xl">
+      <PageHeader
+        title="参加者・かんばん"
+        description="プロジェクトのメンバーとボールを管理します"
+        actions={
+          <Button variant="ghost" size="sm" asChild>
+            <Link to={`/projects/${projectId}/edit`}>
+              <ArrowLeft className="size-4" />
+              プロジェクト設定に戻る
+            </Link>
+          </Button>
+        }
+      />
 
       <Tabs
         value={tab}
@@ -124,7 +124,7 @@ export function MembersPage() {
       ) : (
         <ManageTab projectId={projectId} />
       )}
-    </div>
+    </PageContainer>
   );
 }
 

--- a/apps/web/src/features/projects/ProjectCreatePage.tsx
+++ b/apps/web/src/features/projects/ProjectCreatePage.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { DateField } from '@/components/ui/date-field';
+import { PageHeader } from '@/components/layout/PageHeader';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -111,17 +112,20 @@ export function ProjectCreatePage() {
   };
 
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="mx-auto max-w-3xl space-y-6 px-8 py-10">
-      <header className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight">プロジェクトを新規作成</h1>
-          <p className="text-sm text-muted-foreground">基本情報・制作物・参加者をまとめて入力します</p>
-        </div>
-        <Button type="button" variant="ghost" size="sm" onClick={() => setCancelOpen(true)}>
-          <ArrowLeft className="size-4" />
-          一覧に戻る
-        </Button>
-      </header>
+    <form
+      onSubmit={form.handleSubmit(onSubmit)}
+      className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-8"
+    >
+      <PageHeader
+        title="プロジェクトを新規作成"
+        description="基本情報・制作物・参加者をまとめて入力します"
+        actions={
+          <Button type="button" variant="ghost" size="sm" onClick={() => setCancelOpen(true)}>
+            <ArrowLeft className="size-4" />
+            一覧に戻る
+          </Button>
+        }
+      />
 
       <Card>
         <CardHeader>

--- a/apps/web/src/features/projects/ProjectEditPage.tsx
+++ b/apps/web/src/features/projects/ProjectEditPage.tsx
@@ -10,6 +10,8 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { DateField } from '@/components/ui/date-field';
+import { PageContainer } from '@/components/layout/PageContainer';
+import { PageHeader } from '@/components/layout/PageHeader';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -91,17 +93,17 @@ function ProjectEditInner({ projectId, onBack }: { projectId: string; onBack: ()
   const project = projectQuery.data!;
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 px-8 py-10">
-      <header className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight">{project.name}</h1>
-          <p className="text-sm text-muted-foreground">プロジェクト設定</p>
-        </div>
-        <Button variant="ghost" size="sm" onClick={onBack}>
-          <ArrowLeft className="size-4" />
-          一覧に戻る
-        </Button>
-      </header>
+    <PageContainer width="md">
+      <PageHeader
+        title={project.name}
+        description="プロジェクト設定"
+        actions={
+          <Button variant="ghost" size="sm" onClick={onBack}>
+            <ArrowLeft className="size-4" />
+            一覧に戻る
+          </Button>
+        }
+      />
 
       <form onSubmit={form.handleSubmit((v) => updateMut.mutate(v))}>
         <Card>
@@ -165,7 +167,7 @@ function ProjectEditInner({ projectId, onBack }: { projectId: string; onBack: ()
           </Button>
         </CardContent>
       </Card>
-    </div>
+    </PageContainer>
   );
 }
 

--- a/apps/web/src/features/projects/ProjectListPage.tsx
+++ b/apps/web/src/features/projects/ProjectListPage.tsx
@@ -6,6 +6,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
+import { PageContainer } from '@/components/layout/PageContainer';
+import { PageHeader } from '@/components/layout/PageHeader';
 import { projectsApi, projectsQueryKey } from './api';
 
 const dateFmt = new Intl.DateTimeFormat('ja-JP', { dateStyle: 'medium' });
@@ -17,19 +19,19 @@ export function ProjectListPage() {
   });
 
   return (
-    <div className="mx-auto max-w-5xl px-8 py-10">
-      <header className="mb-6 flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight">プロジェクト</h1>
-          <p className="text-sm text-muted-foreground">参加中のプロジェクト一覧</p>
-        </div>
-        <Button asChild>
-          <Link to="/projects/new">
-            <Plus className="size-4" />
-            新規作成
-          </Link>
-        </Button>
-      </header>
+    <PageContainer width="lg">
+      <PageHeader
+        title="プロジェクト"
+        description="参加中のプロジェクト一覧"
+        actions={
+          <Button asChild>
+            <Link to="/projects/new">
+              <Plus className="size-4" />
+              新規作成
+            </Link>
+          </Button>
+        }
+      />
 
       {isLoading && <ListSkeleton />}
 
@@ -94,7 +96,7 @@ export function ProjectListPage() {
           ))}
         </ul>
       )}
-    </div>
+    </PageContainer>
   );
 }
 

--- a/apps/web/src/features/shareLinks/ShareLinksPage.tsx
+++ b/apps/web/src/features/shareLinks/ShareLinksPage.tsx
@@ -11,6 +11,8 @@ import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
+import { PageContainer } from '@/components/layout/PageContainer';
+import { PageHeader } from '@/components/layout/PageHeader';
 import {
   Dialog,
   DialogContent,
@@ -79,21 +81,19 @@ function Inner({ projectId }: { projectId: string }) {
   });
 
   return (
-    <div className="mx-auto max-w-4xl space-y-5 px-8 py-10">
-      <header className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight">共有リンク</h1>
-          <p className="text-sm text-muted-foreground">
-            クライアントなど非会員に閲覧・操作用 URL を発行します
-          </p>
-        </div>
-        <Button variant="ghost" size="sm" asChild>
-          <Link to={`/projects/${projectId}/edit`}>
-            <ArrowLeft className="size-4" />
-            プロジェクト設定
-          </Link>
-        </Button>
-      </header>
+    <PageContainer width="lg">
+      <PageHeader
+        title="共有リンク"
+        description="クライアントなど非会員に閲覧・操作用 URL を発行します"
+        actions={
+          <Button variant="ghost" size="sm" asChild>
+            <Link to={`/projects/${projectId}/edit`}>
+              <ArrowLeft className="size-4" />
+              プロジェクト設定
+            </Link>
+          </Button>
+        }
+      />
 
       <Card>
         <CardHeader>
@@ -196,7 +196,7 @@ function Inner({ projectId }: { projectId: string }) {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </div>
+    </PageContainer>
   );
 }
 

--- a/packages/db/prisma/migrations/20260601000003_extend_audit_actions/migration.sql
+++ b/packages/db/prisma/migrations/20260601000003_extend_audit_actions/migration.sql
@@ -1,0 +1,25 @@
+-- -----------------------------------------------------------------------------
+-- 監査ログの action に 'update_profile' と 'untoss' を追加
+--  - update_profile: PATCH /auth/me (氏名・表示名・パスワード変更)
+--  - untoss:         TOSS 差し戻し (toss_undone)
+-- これらが ck_al_action に含まれていないと audit_logs INSERT が CHECK 違反で失敗する。
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE "audit_logs" DROP CONSTRAINT "ck_al_action";
+
+ALTER TABLE "audit_logs"
+  ADD CONSTRAINT "ck_al_action" CHECK ("action" IN (
+    'login',
+    'logout',
+    'complete_signup',
+    'update_profile',
+    'toss',
+    'untoss',
+    'complete',
+    'auto_toss',
+    'share_access',
+    'share_create',
+    'share_revoke',
+    'share_toss',
+    'share_complete'
+  ));


### PR DESCRIPTION
PR #23 のレビュー 4 件に対応します。

## 対応内容

1. **アカウント編集/パスワード変更でエラー（バグ修正）**
   - 原因: `audit_logs` の CHECK 制約 `ck_al_action` が `'update_profile'`（および差し戻しの `'untoss'`）を許可しておらず、監査ログ INSERT が制約違反で 500 になっていた。
   - 修正: migration `20260601000003_extend_audit_actions` で許可 action を追加。**ローカル DB へ適用済み**（`pnpm db:deploy`）で、プロフィール/パスワード変更・TOSS 差し戻しが成功するようになりました。

2. **画面デザインを shadcn 準拠で統一（一貫性パス）**
   - 共通 `PageHeader` / `PageContainer` を新設し、全ページのヘッダ・最大幅・余白・タイポグラフィを統一。`Card`/`Button`/`Skeleton` の既存 shadcn 資産を踏襲（新規 Radix 依存なし）。

3. **上部ヘッダの統一（ページごとに情報を出し分け）**
   - 各ページが独自に組んでいたヘッダを `PageHeader`（title / description / breadcrumb / actions）に集約。スケジュールは `fullWidth` バリアントで全幅のまま統一トーンに。

4. **サイドバー下部のユーザー情報を全ページ共通で常時表示**
   - 原因: ルートが `min-h-screen` で `main` がコンテンツに応じて伸び、縦長ページでフッターが画面外に出ていた。
   - 修正: `h-screen` + `main` 内部スクロールに変更し、フッターを `shrink-0` で常時画面内に固定。読込中は Skeleton を表示。`Avatar` コンポーネントを新設しサイドバー/ProfileModal で共通化。

## 検証
- ✅ ローカル DB の `ck_al_action` に `update_profile` / `untoss` が含まれることを確認。migration 適用済み。
- ✅ `type-check` / `lint`（warning 0）/ `test`（54 件）/ `build`
- ⚠️ ブラウザ実機確認は稼働中 dev スタックとの衝突回避のため未実施。
- 注: 本番/他環境では `pnpm db:deploy` で `20260601000003`（＋未適用なら `20260601000002`）の適用が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)