### PR TITLE
style(web): UI 全体をプロトタイプのデザイン言語に寄せる

### DIFF
--- a/apps/web/src/app/DashboardPage.tsx
+++ b/apps/web/src/app/DashboardPage.tsx
@@ -29,8 +29,9 @@ export function DashboardPage() {
   });
 
   return (
-    <PageContainer width="lg">
+    <>
       <PageHeader
+        width="lg"
         title="ダッシュボード"
         description={
           data
@@ -38,8 +39,8 @@ export function DashboardPage() {
             : '今日のボールを集計中…'
         }
       />
-
-      {isLoading && <Loading />}
+      <PageContainer width="lg">
+        {isLoading && <Loading />}
       {error && (
         <Card>
           <CardContent className="py-6 text-sm text-destructive">
@@ -88,7 +89,8 @@ export function DashboardPage() {
           )}
         </>
       )}
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 }
 
@@ -101,36 +103,31 @@ function SummaryCards({
   overdueCount: number;
 }) {
   return (
-    <div className="grid grid-cols-2 gap-3">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <Card>
-        <CardContent className="flex items-center gap-3 py-4">
-          <ListChecks className="size-5 text-primary" />
+        <CardContent className="flex items-center gap-4 py-5">
+          <span className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <ListChecks className="size-5" />
+          </span>
           <div>
-            <p className="text-xs text-muted-foreground">今日のタスク</p>
-            <p className="text-2xl font-semibold">{todayCount}</p>
+            <p className="text-sm text-muted-foreground">今日のタスク</p>
+            <p className="text-2xl font-bold">{todayCount}</p>
           </div>
         </CardContent>
       </Card>
-      <Card
-        className={cn(
-          overdueCount > 0 ? 'border-rose-300 bg-rose-50' : '',
-        )}
-      >
-        <CardContent className="flex items-center gap-3 py-4">
-          <AlertTriangle
+      <Card className={cn(overdueCount > 0 ? 'border-rose-300 bg-rose-50' : '')}>
+        <CardContent className="flex items-center gap-4 py-5">
+          <span
             className={cn(
-              'size-5',
-              overdueCount > 0 ? 'text-rose-500' : 'text-muted-foreground',
+              'flex size-10 items-center justify-center rounded-lg',
+              overdueCount > 0 ? 'bg-rose-100 text-rose-600' : 'bg-muted text-muted-foreground',
             )}
-          />
+          >
+            <AlertTriangle className="size-5" />
+          </span>
           <div>
-            <p className="text-xs text-muted-foreground">期限超過</p>
-            <p
-              className={cn(
-                'text-2xl font-semibold',
-                overdueCount > 0 && 'text-rose-700',
-              )}
-            >
+            <p className="text-sm text-muted-foreground">期限超過</p>
+            <p className={cn('text-2xl font-bold', overdueCount > 0 && 'text-rose-700')}>
               {overdueCount}
             </p>
           </div>

--- a/apps/web/src/app/SidebarLayout.tsx
+++ b/apps/web/src/app/SidebarLayout.tsx
@@ -51,11 +51,11 @@ export function SidebarLayout() {
   };
 
   return (
-    <div className="flex h-screen overflow-hidden bg-background text-foreground">
-      <aside className="flex h-full w-60 shrink-0 flex-col border-r border-border">
+    <div className="flex h-screen overflow-hidden bg-content text-foreground">
+      <aside className="flex h-full w-64 shrink-0 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground">
         <Link
           to="/dashboard"
-          className="shrink-0 px-5 py-5 text-xl font-bold tracking-tight"
+          className="shrink-0 px-6 py-5 text-2xl font-extrabold tracking-[0.2em]"
         >
           TRAKON
         </Link>
@@ -87,8 +87,8 @@ export function SidebarLayout() {
                   cn(
                     'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
                     isActive
-                      ? 'bg-accent text-accent-foreground'
-                      : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground',
+                      ? 'bg-primary/10 font-medium text-primary'
+                      : 'text-muted-foreground hover:bg-accent hover:text-foreground',
                   )
                 }
               >
@@ -133,7 +133,7 @@ export function SidebarLayout() {
         </div>
       </aside>
 
-      <main className="h-full flex-1 overflow-auto">
+      <main className="h-full flex-1 overflow-auto bg-content">
         <Outlet />
       </main>
 
@@ -167,8 +167,8 @@ function SideLink({
         cn(
           'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
           isActive
-            ? 'bg-accent text-accent-foreground'
-            : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground',
+            ? 'bg-primary/10 font-medium text-primary'
+            : 'text-muted-foreground hover:bg-accent hover:text-foreground',
         )
       }
     >

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -1,43 +1,59 @@
 import { cn } from '@/components/ui/utils';
 
+const WIDTHS = {
+  md: 'max-w-3xl',
+  lg: 'max-w-5xl',
+  xl: 'max-w-6xl',
+  full: 'max-w-none',
+} as const;
+
 /**
- * 全ページ共通のページヘッダ。
- * タイトル・説明・パンくず・右側アクションをページごとに出し分ける。
- * - 通常: コンテナ内ヘッダ
- * - fullWidth: 画面全幅に下線を引くヘッダ (スケジュール等のキャンバス系)
+ * 全ページ共通のページヘッダ。プロトタイプ準拠で「白いヘッダ帯」として描画する
+ * (本文のグレー領域に対しコントラストを付ける)。内側は PageContainer と同じ
+ * 最大幅で中央寄せし、タイトル/説明/パンくず/アクションをページごとに出し分ける。
  */
 export function PageHeader({
   title,
   description,
   breadcrumb,
   actions,
-  fullWidth = false,
+  width = 'lg',
+  sticky = true,
   className,
 }: {
   title: React.ReactNode;
   description?: React.ReactNode;
   breadcrumb?: React.ReactNode;
   actions?: React.ReactNode;
-  fullWidth?: boolean;
+  width?: keyof typeof WIDTHS;
+  sticky?: boolean;
   className?: string;
 }) {
-  const inner = (
-    <div className="flex flex-wrap items-start justify-between gap-3">
-      <div className="space-y-1">
-        {breadcrumb && (
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">{breadcrumb}</div>
+  return (
+    <header
+      className={cn(
+        'border-b border-border bg-card',
+        sticky && 'sticky top-0 z-20',
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          'mx-auto flex w-full flex-wrap items-start justify-between gap-3 px-6 py-4',
+          WIDTHS[width],
         )}
-        <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
-        {description && <p className="text-sm text-muted-foreground">{description}</p>}
+      >
+        <div className="space-y-1">
+          {breadcrumb && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              {breadcrumb}
+            </div>
+          )}
+          <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+          {description && <p className="text-sm text-muted-foreground">{description}</p>}
+        </div>
+        {actions && <div className="flex flex-wrap items-center gap-2">{actions}</div>}
       </div>
-      {actions && <div className="flex flex-wrap items-center gap-2">{actions}</div>}
-    </div>
+    </header>
   );
-
-  if (fullWidth) {
-    return (
-      <header className={cn('border-b border-border px-8 py-4', className)}>{inner}</header>
-    );
-  }
-  return <header className={className}>{inner}</header>;
 }

--- a/apps/web/src/features/auth/SC01LoginPage.tsx
+++ b/apps/web/src/features/auth/SC01LoginPage.tsx
@@ -64,7 +64,7 @@ export function SC01LoginPage() {
   return (
     <div className="flex min-h-screen items-start justify-center bg-background px-4 pt-24">
       <div className="w-full max-w-sm">
-        <h1 className="mb-8 text-center text-2xl font-semibold tracking-tight">TRAKON</h1>
+        <h1 className="mb-8 text-center text-3xl font-extrabold tracking-[0.2em]">TRAKON</h1>
         {screen === 'login' && <LoginForm goTo={goTo} />}
         {screen === 'signup' && <SignupForm goTo={goTo} />}
         {screen === 'email-sent' && <EmailSent email={params.get('email') ?? ''} goTo={goTo} />}

--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -202,7 +202,7 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
   return (
     <div className="flex h-full flex-col">
       <PageHeader
-        fullWidth
+        width="full"
         breadcrumb={
           <>
             <Link to={`/projects/${projectId}/edit`} className="hover:text-foreground">

--- a/apps/web/src/features/projects/MembersPage.tsx
+++ b/apps/web/src/features/projects/MembersPage.tsx
@@ -74,8 +74,9 @@ export function MembersPage() {
   if (!projectId) return <NotFound projectId={undefined} />;
 
   return (
-    <PageContainer width="xl">
+    <>
       <PageHeader
+        width="xl"
         title="参加者・かんばん"
         description="プロジェクトのメンバーとボールを管理します"
         actions={
@@ -87,7 +88,7 @@ export function MembersPage() {
           </Button>
         }
       />
-
+      <PageContainer width="xl">
       <Tabs
         value={tab}
         onValueChange={(v) => {
@@ -124,7 +125,8 @@ export function MembersPage() {
       ) : (
         <ManageTab projectId={projectId} />
       )}
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 }
 

--- a/apps/web/src/features/projects/ProjectCreatePage.tsx
+++ b/apps/web/src/features/projects/ProjectCreatePage.tsx
@@ -112,11 +112,9 @@ export function ProjectCreatePage() {
   };
 
   return (
-    <form
-      onSubmit={form.handleSubmit(onSubmit)}
-      className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-8"
-    >
+    <>
       <PageHeader
+        width="md"
         title="プロジェクトを新規作成"
         description="基本情報・制作物・参加者をまとめて入力します"
         actions={
@@ -126,8 +124,11 @@ export function ProjectCreatePage() {
           </Button>
         }
       />
-
-      <Card>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-8"
+      >
+        <Card>
         <CardHeader>
           <CardTitle className="text-base">基本情報</CardTitle>
         </CardHeader>
@@ -286,7 +287,8 @@ export function ProjectCreatePage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </form>
+      </form>
+    </>
   );
 }
 

--- a/apps/web/src/features/projects/ProjectEditPage.tsx
+++ b/apps/web/src/features/projects/ProjectEditPage.tsx
@@ -93,8 +93,9 @@ function ProjectEditInner({ projectId, onBack }: { projectId: string; onBack: ()
   const project = projectQuery.data!;
 
   return (
-    <PageContainer width="md">
+    <>
       <PageHeader
+        width="md"
         title={project.name}
         description="プロジェクト設定"
         actions={
@@ -104,7 +105,7 @@ function ProjectEditInner({ projectId, onBack }: { projectId: string; onBack: ()
           </Button>
         }
       />
-
+      <PageContainer width="md">
       <form onSubmit={form.handleSubmit((v) => updateMut.mutate(v))}>
         <Card>
           <CardHeader>
@@ -167,7 +168,8 @@ function ProjectEditInner({ projectId, onBack }: { projectId: string; onBack: ()
           </Button>
         </CardContent>
       </Card>
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 }
 

--- a/apps/web/src/features/projects/ProjectListPage.tsx
+++ b/apps/web/src/features/projects/ProjectListPage.tsx
@@ -19,8 +19,9 @@ export function ProjectListPage() {
   });
 
   return (
-    <PageContainer width="lg">
+    <>
       <PageHeader
+        width="lg"
         title="プロジェクト"
         description="参加中のプロジェクト一覧"
         actions={
@@ -32,8 +33,8 @@ export function ProjectListPage() {
           </Button>
         }
       />
-
-      {isLoading && <ListSkeleton />}
+      <PageContainer width="lg">
+        {isLoading && <ListSkeleton />}
 
       {error && (
         <Card>
@@ -96,7 +97,8 @@ export function ProjectListPage() {
           ))}
         </ul>
       )}
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 }
 

--- a/apps/web/src/features/shareLinks/ShareLinksPage.tsx
+++ b/apps/web/src/features/shareLinks/ShareLinksPage.tsx
@@ -81,8 +81,9 @@ function Inner({ projectId }: { projectId: string }) {
   });
 
   return (
-    <PageContainer width="lg">
+    <>
       <PageHeader
+        width="lg"
         title="共有リンク"
         description="クライアントなど非会員に閲覧・操作用 URL を発行します"
         actions={
@@ -94,7 +95,7 @@ function Inner({ projectId }: { projectId: string }) {
           </Button>
         }
       />
-
+      <PageContainer width="lg">
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
@@ -196,7 +197,8 @@ function Inner({ projectId }: { projectId: string }) {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 }
 

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,34 +1,55 @@
 @import 'tailwindcss';
 
+@custom-variant dark (&:is(.dark *));
+
 /* =============================================================================
- * shadcn/ui base tokens (from prototype/default_shadcn_theme.css)
- * Sub-Phase 0.0 では最小限のみ取り込み、shadcn コンポーネントの追加と合わせて拡張する
+ * デザイントークン (プロトタイプ prototype/src/styles/theme.css 準拠)
+ * 無彩色グレー基調・primary #2b2b2b・border #e5e5e5・radius 0.5rem。
+ * --input のみ、入力枠を視認できるよう薄グレー (#d4d4d4) に折衷。
  * ============================================================================= */
 
 :root {
   --font-size: 16px;
   --background: #ffffff;
-  --foreground: oklch(0.145 0 0);
+  --foreground: #1f1f1f;
   --card: #ffffff;
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: #030213;
-  --primary-foreground: oklch(1 0 0);
-  --secondary: oklch(0.95 0.0058 264.53);
-  --secondary-foreground: #030213;
-  --muted: #ececf0;
-  --muted-foreground: #717182;
-  --accent: #e9ebef;
-  --accent-foreground: #030213;
-  --destructive: #d4183d;
+  --card-foreground: #1f1f1f;
+  --popover: #ffffff;
+  --popover-foreground: #1f1f1f;
+  --primary: #2b2b2b;
+  --primary-foreground: #ffffff;
+  --secondary: #f7f7f7;
+  --secondary-foreground: #2b2b2b;
+  --muted: #f5f5f5;
+  --muted-foreground: #737373;
+  --accent: #f0f0f0;
+  --accent-foreground: #2b2b2b;
+  --destructive: #dc2626;
   --destructive-foreground: #ffffff;
-  --border: rgba(0, 0, 0, 0.1);
-  /* 入力欄の枠線を明確にするため不可視(transparent)から濃いグレーへ */
-  --input: rgba(0, 0, 0, 0.45);
-  --input-background: #f3f3f5;
-  --ring: oklch(0.708 0 0);
-  --radius: 0.625rem;
+  --border: #e5e5e5;
+  /* proto は transparent だが、入力枠の視認性のため薄グレーに */
+  --input: #d4d4d4;
+  --input-background: #fafafa;
+  --switch-background: #d4d4d4;
+  --font-weight-medium: 500;
+  --font-weight-normal: 400;
+  --ring: #737373;
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --radius: 0.5rem;
+  --sidebar: #ffffff;
+  --sidebar-foreground: #1f1f1f;
+  --sidebar-primary: #2b2b2b;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f5f5f5;
+  --sidebar-accent-foreground: #2b2b2b;
+  --sidebar-border: #e5e5e5;
+  --sidebar-ring: #737373;
+  /* 本文領域の淡いグレー背景 (白ヘッダ帯/白カードと対比) */
+  --content: #fafafa;
 }
 
 .dark {
@@ -49,8 +70,24 @@
   --destructive: oklch(0.396 0.141 25.723);
   --destructive-foreground: oklch(0.637 0.237 25.331);
   --border: oklch(0.269 0 0);
-  --input: oklch(0.269 0 0);
+  --input: oklch(0.34 0 0);
   --ring: oklch(0.439 0 0);
+  --font-weight-medium: 500;
+  --font-weight-normal: 400;
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(0.269 0 0);
+  --sidebar-ring: oklch(0.439 0 0);
+  --content: oklch(0.185 0 0);
 }
 
 @theme inline {
@@ -73,21 +110,94 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-input-background: var(--input-background);
+  --color-switch-background: var(--switch-background);
   --color-ring: var(--ring);
+  --color-content: var(--content);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
 }
 
-body {
-  font-family:
-    'Inter',
-    -apple-system,
-    BlinkMacSystemFont,
-    'Hiragino Kaku Gothic ProN',
-    'Yu Gothic',
-    sans-serif;
-  background: var(--background);
-  color: var(--foreground);
+/* =============================================================================
+ * base レイヤー (プロトタイプ準拠のタイポグラフィ)
+ * Tailwind ユーティリティ (text-sm 等) で個別に上書き可能。
+ * フォントは可読性のため Inter スタックを採用 (proto はシステム既定)。
+ * ============================================================================= */
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+    font-family:
+      'Inter',
+      -apple-system,
+      BlinkMacSystemFont,
+      'Hiragino Kaku Gothic ProN',
+      'Yu Gothic',
+      sans-serif;
+  }
+
+  html {
+    font-size: var(--font-size);
+  }
+
+  h1 {
+    font-size: 1.875rem;
+    font-weight: var(--font-weight-medium);
+    line-height: 1.4;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    font-weight: var(--font-weight-medium);
+    line-height: 1.4;
+  }
+
+  h3 {
+    font-size: 1.125rem;
+    font-weight: var(--font-weight-medium);
+    line-height: 1.5;
+  }
+
+  h4 {
+    font-size: 1rem;
+    font-weight: var(--font-weight-medium);
+    line-height: 1.5;
+  }
+
+  label {
+    font-size: 0.875rem;
+    font-weight: var(--font-weight-medium);
+    line-height: 1.5;
+  }
+
+  button {
+    font-size: 0.9375rem;
+    font-weight: var(--font-weight-medium);
+    line-height: 1.5;
+  }
+
+  input,
+  select {
+    font-size: 0.9375rem;
+    font-weight: var(--font-weight-normal);
+    line-height: 1.5;
+  }
 }


### PR DESCRIPTION
Web アプリの**デザイン・UIパーツ・レイアウト・構成**を、Figma 由来プロトタイプ（`prototype/`）に寄せる純粋なビジュアル刷新です。API/DB/機能は不変。

## 変更内容

### デザイントークン（`globals.css`）
- `prototype/src/styles/theme.css` のパレットに準拠: `--primary #2b2b2b`（やわらかい黒）、無彩色グレーの `--secondary/--muted/--accent`、`--border #e5e5e5`（実線）、`--destructive #dc2626`、`--ring #737373`、**`--radius 0.5rem`（8px に縮小）**。
- **sidebar / chart / switch-background トークン**を追加し `@theme inline` にマッピング。
- 入力枠は可読性のため `--input` を `#d4d4d4`（proto の transparent から折衷）。

### タイポグラフィ
- `@layer base` に h1–h4 / label / button / input の font-size・weight を導入（proto 準拠の型スケール）。フォントは可読性のため Inter スタックを維持。

### レイアウト構成（白ヘッダ帯 + グレー本文 + 白カード）
- `PageHeader` を**全幅の白い sticky ヘッダ帯**に、`main` 背景をグレー（`--content`）に。各ページは header をコンテナ外へ出す構成へ統一。
- サイドバーを白（`bg-sidebar`）・`w-64`・ロゴ letter-spacing・active を **primary ティント**（`bg-primary/10 text-primary`）に。

### UIパーツの質感
- ダッシュボードのサマリーカードをアイコンタイル（`size-10 bg-primary/10 rounded-lg`）化。ログインロゴを letter-spaced 大見出しに。
- `--radius` 縮小により Card/Button/Input/Badge/Tabs がトークン追従で proto に整合。

## 検証
- ✅ `type-check` / `lint`（warning 0）/ `build`
- ✅ **ログイン画面を隔離ポートで起動しスクリーンショット確認**（レターロゴ・やわらか primary・8px 角丸カード・視認できる入力枠が反映）。
- ⚠️ 認証後ページ（白帯＋グレー本文＋サイドバー）の実機スクショはログインセッションが必要なため未取得（構成は build/コードで検証済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)