### PR TITLE
chore(web): 未使用の @dnd-kit 依存を削除

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,8 +14,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/utilities": "^3.2.2",
     "@holiday-jp/holiday_jp": "^2.4.1",
     "@hono/node-server": "^1.13.7",
     "@hookform/resolvers": "^3.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,12 +27,6 @@ importers:
 
   apps/web:
     dependencies:
-      '@dnd-kit/core':
-        specifier: ^6.3.1
-        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@dnd-kit/utilities':
-        specifier: ^3.2.2
-        version: 3.2.2(react@18.3.1)
       '@holiday-jp/holiday_jp':
         specifier: ^2.4.1
         version: 2.5.1
@@ -349,22 +343,6 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
-
-  '@dnd-kit/accessibility@3.1.1':
-    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
-    peerDependencies:
-      react: '>=16.8.0'
-
-  '@dnd-kit/core@6.3.1':
-    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
-  '@dnd-kit/utilities@3.2.2':
-    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
-    peerDependencies:
-      react: '>=16.8.0'
 
   '@edge-runtime/format@2.2.1':
     resolution: {integrity: sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==}
@@ -4270,24 +4248,6 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
-
-  '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-      tslib: 2.8.1
-
-  '@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
-      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tslib: 2.8.1
-
-  '@dnd-kit/utilities@3.2.2(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-      tslib: 2.8.1
 
   '@edge-runtime/format@2.2.1': {}
 


### PR DESCRIPTION
## 概要

旧「メンバーかんばん」の D&D 実装を撤去し「担当者ボード」（ボタンによるトス）へ作り替えた結果、`@dnd-kit/core` と `@dnd-kit/utilities` が `apps/web` で未使用になりました。`apps/web/package.json` の dependencies とロックファイルから削除します。

撤去コミット（`c3d8db1` / #26）を最新 main から取り込んだ上で、`apps/web/src` 配下の `@dnd-kit` 参照が 0 件であることを確認済みです。

## 変更

- `apps/web/package.json`: `@dnd-kit/core` / `@dnd-kit/utilities` を削除
- `pnpm-lock.yaml`: `pnpm install` で更新（dnd-kit 参照 0 件）

## 検証

- ✅ `pnpm --filter @trakon/web type-check`
- ✅ `pnpm --filter @trakon/web lint`（`--max-warnings 0`）
- ✅ `pnpm --filter @trakon/web test`（14 files / 54 tests pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)