### PR TITLE
fix(deploy): VercelファンクションビルドのTypeScriptエラーを解消

### DIFF
--- a/apps/web/api/tsconfig.json
+++ b/apps/web/api/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../server/**/*.ts"]
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,6 +9,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "postinstall": "prisma generate",
     "generate": "prisma generate",
     "migrate": "dotenv -e ../../apps/web/.env.local -- prisma migrate dev",
     "migrate:local": "dotenv -e ../../apps/web/.env.local -- prisma migrate deploy",


### PR DESCRIPTION
## 概要

Vercel の preview デプロイ時に `api/index.ts`(Hono Serverless Function)の型チェックフェーズで出ていた TypeScript エラーを修正します。

```
server/lib/sentry.ts(16,5): error TS2353: ... 'dsn' does not exist in type 'BaseNodeOptions'.
server/routes/v1/projects.ts(48,57): error TS2345: ... 'limit' is optional ...
server/services/auth.ts(74,47): error TS2339: Property 'admin' does not exist on type 'SupabaseAuthClient'.
../../packages/db/src/index.ts(1,10): error TS2305: Module '"@prisma/client"' has no exported member 'PrismaClient'.
```

`vite build`(フロント)は成功しており、エラーはすべて Vercel がファンクションを型チェックするフェーズで発生していました。原因は2系統です。

## 原因と修正

### ① Prisma クライアント未生成(`packages/db` エラー + 実行時クラッシュ)
Vercel の install は `pnpm install --frozen-lockfile` のみで `prisma generate` が走らず、`@prisma/client` が `PrismaClient`/`Prisma` を export しない状態でした(生成しないと `.prisma/client` への re-export が解決されない)。型エラーだけでなく **API が実行時に落ちる** 問題でもあります。

→ `packages/db/package.json` に `postinstall: "prisma generate"` を追加。`pnpm install` のたびに自動生成され、Vercel の2回の install フェーズ両方でクライアントが用意されます。

### ② Vercel のファンクション型チェックが誤った tsconfig を使用(sentry / supabase / projects エラー)
`apps/web/tsconfig.json` は `files: []` + references だけのソリューションファイルで compilerOptions が空のため、`@vercel/node` がデフォルト設定(`moduleResolution` が `Bundler` でない)で型チェックし、conditional exports を持つパッケージ(`@sentry/node` の `dsn`、`@supabase/supabase-js` の `auth.admin`、zod 由来の `limit/offset`)の型が誤解決されていました。

→ entrypoint 直下に `apps/web/api/tsconfig.json` を追加。`@vercel/node` は entrypoint からの上位探索で最初に見つかるこの tsconfig を使うため、`moduleResolution: Bundler` + `types: ["node"]` で正しく解決されます。

## 検証

- `pnpm install --frozen-lockfile`(Vercel と同コマンド)で postinstall が走り Prisma クライアントが再生成されることを確認
- `tsc -p apps/web/api/tsconfig.json --noEmit` → **exit 0(エラーなし)**
- 既存の `pnpm --filter @trakon/web type-check`(`tsc -b`)も引き続き通過(他ツールへの影響なし)

> [!NOTE]
> ② の tsconfig 解決は `@vercel/node` の探索挙動に依存するため、実際の preview デプロイで最終確認するのが確実です。① は実行時クラッシュも防ぐため、いずれにせよ必須の修正です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)