### PR TITLE
fix(deploy): Vercelデプロイ時のサーバー型エラーを根本解消(pnpm symlink起因)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,9 @@
+# Vercel (@vercel/node) の型チェッカーは realpath を持たないホストで動くため
+# 実質 preserveSymlinks 相当で動作する。pnpm の既定レイアウトでは
+# @sentry/* / @supabase/* のサブ依存 (.pnpm 配下) を辿れず型解決に失敗し、
+# deploy ログに型エラーが出る。これらを top-level node_modules へ hoist して解消する。
+# 既定の public-hoist-pattern (*eslint* / *prettier*) も維持する。
+public-hoist-pattern[]=*eslint*
+public-hoist-pattern[]=*prettier*
+public-hoist-pattern[]=@sentry/*
+public-hoist-pattern[]=@supabase/*

--- a/apps/web/api/tsconfig.json
+++ b/apps/web/api/tsconfig.json
@@ -2,8 +2,8 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ES2022"],
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "noEmit": true,
     "types": ["node"]
   },

--- a/packages/db/.gitignore
+++ b/packages/db/.gitignore
@@ -1,0 +1,1 @@
+/src/generated/

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -14,6 +14,7 @@
 
 generator client {
   provider      = "prisma-client-js"
+  output        = "../src/generated/client"
   binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from './generated/client/index.js';
 
 declare global {
   // eslint-disable-next-line no-var
@@ -18,5 +18,5 @@ if (process.env.NODE_ENV !== 'production') {
   globalThis.__trakonPrisma = prisma;
 }
 
-export type { Prisma } from '@prisma/client';
-export { PrismaClient } from '@prisma/client';
+export type { Prisma } from './generated/client/index.js';
+export { PrismaClient } from './generated/client/index.js';


### PR DESCRIPTION
## 概要

PR #30 マージ後も Vercel の deploy ログに **37件の TypeScript エラー**が残っていた件を根治します。あわせて、**API 関数が実行時にクラッシュする潜在バグ**も修正します。

## 根本原因(`vercel build` をローカル実行して特定)

`@vercel/node` の型チェッカーは **realpath を持たないコンパイラホスト**で動くため、実質 `preserveSymlinks` 相当で動作します。pnpm は依存を `.pnpm/` 配下に置き symlink 参照させるため、この条件下では次が解決できません:

- `@prisma/client` → `.prisma/client`(生成物)への間接参照 → `PrismaClient`/`Prisma` 型が見つからず、`prisma` が `any` 化 → `$transaction((tx) => …)` 等が大量に `implicitly any`(TS7006)
- `@sentry/*` / `@supabase/*` のサブ依存(`@sentry/core`, `@supabase/auth-js` 等)→ `dsn` / `auth.admin` 型エラー

`tsc -b`(ローカル/CI, `moduleResolution: Bundler`)は realpath が効くため**再現せず、Vercel だけで発生**していました。`tsc --preserveSymlinks` で同一エラーを完全再現して確証を得ています。

### さらに重大: 実行時クラッシュ
同じ symlink 解決失敗により、`@vercel/nft` が `@prisma/client` とクエリエンジン(`.node`)を**関数バンドルに含められておらず**、デプロイされた API は実行時に `Cannot find module '@prisma/client'` で落ちる状態でした(型だけの問題ではない)。

## 修正

| 変更 | 内容 |
|---|---|
| `packages/db/prisma/schema.prisma` | `generator client` に `output = "../src/generated/client"` を追加。symlink/`.prisma` 間接参照を排除し、**エンジンを含む自己完結ディレクトリ**を生成。nft が `rhel-openssl-3.0.x` エンジンをトレースすることを直接検証済み |
| `packages/db/src/index.ts` | import 先をローカル生成クライアントへ変更 |
| `packages/db/.gitignore`(新規) | 生成物 `/src/generated/` を ignore |
| `.npmrc`(新規) | `public-hoist-pattern` で `@sentry/*` / `@supabase/*` を top-level へ hoist(型のみの問題。pnpm 既定の `*eslint*`/`*prettier*` も維持) |
| `apps/web/api/tsconfig.json` | `@vercel/node` の ESM 既定に合わせ `NodeNext` へ統一 |

> `@prisma/client` を直接 import している箇所は他に無いことを確認済み(唯一の利用元は `@trakon/db`)。

## 検証

ローカルで **`vercel build`(= 実際に `@vercel/node` を実行)** を使い再現・修正を確認:

| | 修正前 | 修正後 |
|---|---|---|
| TS エラー | **37** | **0** |
| build status | ok(型エラーは非致命) | **ok** |
| 関数バンドル | `@prisma/client`/エンジン **欠落** | エンジン `.node` を **トレース** |

- `pnpm --filter @trakon/web type-check`(`tsc -b`) … pass
- `pnpm --filter @trakon/web lint` … pass
- `vitest` … 53/54 pass(残り1件 `share.test.ts` は **origin/main でも同様にタイムアウト**する DB 環境依存の既存事象で、本変更とは無関係)

> [!NOTE]
> マージ後の preview デプロイで、ログにエラーが出ないこと・API エンドポイント(例: `/api/...`)が 200/正常レスポンスを返すことを最終確認するのがおすすめです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)