### PR TITLE
fix(deploy): Hono を Node ランタイム用アダプタに変更し API の 504/404 を解消

### DIFF
--- a/apps/web/server-bundle/index.d.ts
+++ b/apps/web/server-bundle/index.d.ts
@@ -1,5 +1,6 @@
 // scripts/build-server.mjs が生成する server-bundle/index.js の型宣言 (コミット対象)。
 // 実体の .js は gitignore されビルド時に生成される。default export は Vercel の
-// Node ランタイム向け Hono ハンドラ (hono/vercel の handle() の戻り値)。
-declare const handler: (request: Request) => Response | Promise<Response>;
+// Node ランタイム向け Hono ハンドラ (@hono/node-server/vercel の handle() の戻り値 =
+// (req, res) => void の Node リスナー)。
+declare const handler: (...args: unknown[]) => unknown;
 export default handler;

--- a/apps/web/server/vercel.ts
+++ b/apps/web/server/vercel.ts
@@ -1,4 +1,8 @@
-import { handle } from 'hono/vercel';
+// Vercel の Node ランタイム用アダプタ。hono/vercel (Edge 用, fetch 形式) ではなく
+// @hono/node-server/vercel (Node の (req,res) 形式 = getRequestListener) を使う。
+// 前者は Node の IncomingMessage を app.fetch に渡すため URL が壊れて 404 になり、
+// 返り値 Response も Node ランタイムに無視されてレスポンス未送出 → 30s で 504 になる。
+import { handle } from '@hono/node-server/vercel';
 
 import { app } from './app.js';
 


### PR DESCRIPTION
## 概要

#32(サーバーのバンドル化)で関数の起動クラッシュ(`ERR_MODULE_NOT_FOUND`)は解消しましたが、preview で全 API が **30 秒後に 504 Gateway Timeout**、ルーティングは **404** になっていました。本 PR で解消します。

## 根本原因(Vercel Runtime Log を実取得して断定)

```
WARN: default export returned a `Response`. ... returns are ignored.
       You likely meant the Web `fetch`-style API.
<-- POST /me/sync
--> POST /me/sync 404 4ms
Vercel Runtime Timeout Error: Task timed out after 30 seconds
```

`apps/web/server/vercel.ts` が **Edge 用アダプタ** `hono/vercel` の `handle`(`(app) => (req) => app.fetch(req)`、Web `Response` を返す fetch 形式)を使っていたためです。本関数は **Node ランタイム**(`runtime: 'nodejs'`、Prisma / ws など Node 依存のため Edge 不可)で動くので:

1. **404** — Node の `IncomingMessage` をそのまま `app.fetch()` に渡すため URL が正しく parse されず、Hono が受け取るパスが `/me/sync` や `s` 等に壊れて全ルート 404。
2. **504** — Node ランタイムは `(req, res) => void` を期待し、返された `Response` を無視。レスポンスが送出されず 30 秒でタイムアウト。

> 環境変数(`DATABASE_URL` / `DIRECT_URL` / `SUPABASE_URL` / `SUPABASE_SECRET_KEY` / `APP_ENV` 等)は実プロジェクト `trakon-app-web` に Preview/Production とも設定済みを `vercel env ls` で確認済み(env は原因ではない)。

## 修正

`server/vercel.ts` のアダプタを **`@hono/node-server/vercel`** の `handle` に変更(`getRequestListener(app.fetch)` = Node の `(req, res)` 形式)。`req` から正しい Web Request を構築し `res` に書き込むため、ルーティングが正しく機能し、レスポンスも送出される。`@hono/node-server` は既存依存のため追加なし。

## 検証(ローカルで完結)

- **疎通**: 生成バンドル `server-bundle/index.js` の default(= Node ハンドラ)を `http.createServer` に載せ、`GET /api/v1/healthz` → **200**(正常 JSON)を確認。旧アダプタではここで 404/ハングしていた。
- `vercel build` → `status: ok` / **TS エラー 0** / 関数に `@hono/node-server` をトレース。
- `tsc -b` / `eslint` pass。

> [!NOTE]
> マージ後の preview で `/api/v1/healthz` が 200・ログイン後にダッシュボードが表示されることを最終確認してください。万一データ取得系のみ遅い/500 になる場合は `DATABASE_URL` が Supabase のコネクションプーラ(pgbouncer / port 6543)を指しているかご確認ください(サーバーレスでは直結 5432 は不安定。env 値の問題で別件)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)