### PR TITLE
fix(db): Prisma で pgbouncer=true を保証し Supabase プーラの 42P05 を解消

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,9 +5,27 @@ declare global {
   var __trakonPrisma: PrismaClient | undefined;
 }
 
+/**
+ * Supabase の Transaction モードプーラ (pgbouncer, port 6543) では接続が使い回されるため、
+ * Prisma の prepared statement が衝突し `42P05 prepared statement "s0" already exists` で
+ * クエリが失敗する。これを避けるには接続文字列に `pgbouncer=true` が必要 (prepared statement
+ * を無効化する)。env 側で付け忘れても確実に効くようコード側で補完する。
+ * - 既に `pgbouncer=` 指定済みなら尊重する
+ * - 直結 DB (ローカル等) でも prepared statement を使わなくなるだけで動作に支障はない
+ */
+function resolveDatasourceUrl(): string | undefined {
+  const url = process.env.DATABASE_URL;
+  if (!url) return undefined; // 未設定時は schema / env からの既定解決に委ねる
+  if (/[?&]pgbouncer=/.test(url)) return url;
+  return `${url}${url.includes('?') ? '&' : '?'}pgbouncer=true`;
+}
+
+const datasourceUrl = resolveDatasourceUrl();
+
 export const prisma: PrismaClient =
   globalThis.__trakonPrisma ??
   new PrismaClient({
+    ...(datasourceUrl ? { datasourceUrl } : {}),
     log:
       process.env.NODE_ENV === 'development'
         ? ['query', 'warn', 'error']


### PR DESCRIPTION
## 概要

PR #33 で画面遷移は復旧しましたが、プロフィール登録(`complete-signup`)やログイン直後の `sync` など **DB を叩く API が 504** になっていました。本 PR で解消します。

## 根本原因(Vercel Runtime Log を実取得して断定)

```
PrismaClientUnknownRequestError: Invalid `prisma.user.findUnique()` invocation
PostgresError { code: "42P05", message: "prepared statement \"s0\" already exists" }
    at async syncUser (.../server-bundle/index.js)
--> POST /api/v1/auth/me/sync 200 102ms   ← 成功する場合もある(間欠的)
--> POST /api/v1/auth/me/sync 500 154ms
Vercel Runtime Timeout Error: Task timed out after 30 seconds
```

`42P05 prepared statement already exists` は、**Prisma が Supabase の Transaction モードプーラ(pgbouncer, port 6543)に `pgbouncer=true` 無しで接続したとき固有**のエラーです。pgbouncer が接続を使い回す際に Prisma の prepared statement(`s0`)が衝突します。成功 / 500 / 30秒ハングが混在するのもこの症状と一致します(`DATABASE_URL` は既にプーラを指すが `pgbouncer=true` が欠落)。

## 修正

`packages/db/src/index.ts` で、`DATABASE_URL` に `pgbouncer=true` が無ければ補完した URL を `PrismaClient` の `datasourceUrl` に渡します(prepared statement を無効化 → 42P05 解消)。

- 既に `pgbouncer=` 指定があれば尊重。直結 DB(ローカル)でも無害。
- `datasourceUrl` は Prisma 5.2+ 対応(本プロジェクト 5.22)。
- schema の `directUrl`(マイグレーション専用)には影響なし。
- `@trakon/db` は esbuild バンドルにインライン化されるため、この修正は関数に反映されます。

## 検証

- **URL 補完ロジックを単体確認**: `?` 有無 / 指定済み / 未設定の各ケースで期待通り(重複付与なし)。
- `pnpm --filter @trakon/web build` → 生成バンドルに `pgbouncer` 反映を確認 / `tsc -b` / `eslint` pass。
- マージ後 preview でプロフィール登録を実行し `complete-signup` / `sync` が 200・ダッシュボード遷移、Runtime Log に 42P05 が出ないことを最終確認(`vercel logs <preview-url> --scope trakon-projects`)。

> [!NOTE]
> **推奨(別途・任意)**: サーバーレスのプール枯渇(30秒ハングの一因)対策として、Vercel の Preview/Production の `DATABASE_URL` 末尾に `&connection_limit=1` の追加を推奨します(例: `...pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1`)。本コード修正だけでも 42P05 は解消します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)