### PR TITLE
fix(deploy): complete-signup の 504(無音ハング)を解消(connection_limit + 診断)

### DIFF
--- a/apps/web/server/lib/supabaseAdmin.ts
+++ b/apps/web/server/lib/supabaseAdmin.ts
@@ -17,11 +17,22 @@ if (typeof globalThis.WebSocket === 'undefined') {
 
 let cached: SupabaseClient | undefined;
 
+// Supabase admin 呼び出しがネットワーク要因で無限ハングするのを防ぐため、fetch に
+// タイムアウト (AbortController) を被せる。サーバーレスの 30s 上限手前で明示的に失敗させる。
+const FETCH_TIMEOUT_MS = 10_000;
+function fetchWithTimeout(...args: Parameters<typeof fetch>): Promise<Response> {
+  const [input, init] = args;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  return fetch(input, { ...init, signal: controller.signal }).finally(() => clearTimeout(timer));
+}
+
 export function getSupabaseAdmin(): SupabaseClient {
   if (cached) return cached;
   const env = getServerEnv();
   cached = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
     auth: { persistSession: false, autoRefreshToken: false },
+    global: { fetch: fetchWithTimeout },
   });
   return cached;
 }

--- a/apps/web/server/services/auth.ts
+++ b/apps/web/server/services/auth.ts
@@ -143,15 +143,23 @@ export async function completeSignup(input: {
   displayName: string;
   password: string;
 }): Promise<CurrentUserDTO> {
+  // 各ステップの所要時間を計測し、どこで滞留するかを Vercel ログから特定できるようにする。
+  const t0 = Date.now();
+  const step = (name: string) => console.log(`[completeSignup] ${name} +${Date.now() - t0}ms`);
+
+  step('findUnique:start');
   const existing = await prisma.user.findUnique({ where: { authUserId: input.authUserId } });
+  step('findUnique:done');
   if (existing) {
     throw new ApiException('ALREADY_COMPLETED', 409, 'Signup is already completed.');
   }
 
   // 同一メール別プロバイダ衝突 (FR-AUTH-12)
+  step('findFirst:start');
   const emailOwner = await prisma.user.findFirst({
     where: { email: input.email, deletedAt: null },
   });
+  step('findFirst:done');
   if (emailOwner) {
     throw new ApiException(
       'SAME_EMAIL_DIFFERENT_PROVIDER',
@@ -162,34 +170,42 @@ export async function completeSignup(input: {
   }
 
   const supabase = getSupabaseAdmin();
+  step('supabase.updateUserById:start');
   const { error: updateError } = await supabase.auth.admin.updateUserById(input.authUserId, {
     password: input.password,
   });
+  step('supabase.updateUserById:done');
   if (updateError) {
     throw new ApiException('SUPABASE_UPDATE_FAILED', 500, updateError.message);
   }
 
-  const user = await prisma.$transaction(async (tx) => {
-    const created = await tx.user.create({
-      data: {
-        authUserId: input.authUserId,
-        email: input.email,
-        fullName: input.fullName,
-        displayName: input.displayName,
-        primaryAuthMethod: 'password',
-      },
-    });
-    await tx.auditLog.create({
-      data: {
-        actorUserId: created.id,
-        action: 'complete_signup',
-        resourceType: 'user',
-        resourceId: created.id,
-        result: 'success',
-      },
-    });
-    return created;
-  });
+  step('transaction:start');
+  const user = await prisma.$transaction(
+    async (tx) => {
+      const created = await tx.user.create({
+        data: {
+          authUserId: input.authUserId,
+          email: input.email,
+          fullName: input.fullName,
+          displayName: input.displayName,
+          primaryAuthMethod: 'password',
+        },
+      });
+      await tx.auditLog.create({
+        data: {
+          actorUserId: created.id,
+          action: 'complete_signup',
+          resourceType: 'user',
+          resourceId: created.id,
+          result: 'success',
+        },
+      });
+      return created;
+    },
+    // 30 秒の無音ハングではなく明示的に早期失敗させる (接続待ち/長期化の検知)
+    { maxWait: 5000, timeout: 15000 },
+  );
+  step('transaction:done');
 
   return toDTO(user);
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,18 +6,29 @@ declare global {
 }
 
 /**
- * Supabase の Transaction モードプーラ (pgbouncer, port 6543) では接続が使い回されるため、
- * Prisma の prepared statement が衝突し `42P05 prepared statement "s0" already exists` で
- * クエリが失敗する。これを避けるには接続文字列に `pgbouncer=true` が必要 (prepared statement
- * を無効化する)。env 側で付け忘れても確実に効くようコード側で補完する。
- * - 既に `pgbouncer=` 指定済みなら尊重する
- * - 直結 DB (ローカル等) でも prepared statement を使わなくなるだけで動作に支障はない
+ * Supabase の Transaction モードプーラ (pgbouncer, port 6543) + サーバーレス向けに接続文字列を補正する。
+ *
+ * - `pgbouncer=true`: prepared statement を無効化。無いと `42P05 prepared statement "s0" already exists`
+ *   でクエリが失敗する。直結 DB (ローカル) でも prepared statement を使わなくなるだけで支障なし。
+ * - `connection_limit=1` (Vercel のみ): サーバーレスでは各インスタンスが多数の接続を開いてプーラを
+ *   枯渇させ、`$transaction` の BEGIN がサーバー接続待ちで滞留 (= 無音の 30s ハング) する。1 接続に
+ *   制限してこれを防ぐ (Prisma + Supabase 公式のサーバーレス推奨)。常駐サーバ (ローカル) では付けない。
+ *
+ * env 側で付け忘れても確実に効くようコードで補完する。既に同名パラメータがあれば尊重する。
  */
 function resolveDatasourceUrl(): string | undefined {
-  const url = process.env.DATABASE_URL;
-  if (!url) return undefined; // 未設定時は schema / env からの既定解決に委ねる
-  if (/[?&]pgbouncer=/.test(url)) return url;
-  return `${url}${url.includes('?') ? '&' : '?'}pgbouncer=true`;
+  const raw = process.env.DATABASE_URL;
+  if (!raw) return undefined; // 未設定時は schema / env からの既定解決に委ねる
+
+  const add: Record<string, string> = {};
+  if (!/[?&]pgbouncer=/.test(raw)) add.pgbouncer = 'true';
+  if (process.env.VERCEL && !/[?&]connection_limit=/.test(raw)) add.connection_limit = '1';
+
+  const params = Object.entries(add);
+  if (params.length === 0) return raw;
+
+  const sep = raw.includes('?') ? '&' : '?';
+  return raw + sep + params.map(([k, v]) => `${k}=${v}`).join('&');
 }
 
 const datasourceUrl = resolveDatasourceUrl();


### PR DESCRIPTION
## 概要

PR #34 で `sync` は成功(プロフィール登録画面まで到達)するようになりましたが、「登録を完了する」(`POST /api/v1/auth/me/complete-signup`)が **30 秒で 504** になっていました。本 PR で対処します。

## 調査(Runtime Log を実取得)

- `Vercel Runtime Timeout Error: Task timed out after 30 seconds`
- **Prisma エラーも例外ログも一切無い「無音の 30 秒ハング」**(42P05 のような明示エラーは無し)
- `sync`(password フロー)は成功 = DB 接続も `supabase.auth.admin.getUserById` も動作
- `complete-signup` 固有の処理は `prisma.$transaction`(書き込みトランザクション)

無音ハング(Prisma の maxWait/timeout すら発火しない)は、**pgbouncer 側でサーバー接続の空き待ちにクエリが滞留**しているパターンと整合します。

## 修正

| 変更 | 内容 |
|---|---|
| `packages/db/src/index.ts` | `resolveDatasourceUrl()` を拡張し、**Vercel 上のみ `connection_limit=1`** を付与(既存の `pgbouncer=true` に追加)。サーバーレスでの接続枯渇 → `BEGIN` 滞留を防ぐ(Prisma+Supabase 公式のサーバーレス推奨)。ローカルは付与せず常駐サーバの複数接続を維持。既指定は尊重 |
| `apps/web/server/services/auth.ts` | `completeSignup` に各ステップ計測ログを追加 + `$transaction` に `{ maxWait: 5000, timeout: 15000 }`。30 秒無音ではなく**早期に明示エラー化**し、万一残ってもハング箇所をログで特定可能に |
| `apps/web/server/lib/supabaseAdmin.ts` | admin の `fetch` に 10 秒タイムアウト(AbortController)。ネットワーク要因の無限ハングを防止 |

最有力は `connection_limit=1`(接続設定)。仮にそれで直らなくても、計測ログと各タイムアウトにより **30 秒無音ハングは解消**し、次のログでハング箇所(`findUnique`/`findFirst`/`updateUserById`/`transaction` のどれか)を一意に特定して最終対応できます。

## 検証(ローカルで完結)

- `resolveDatasourceUrl` のロジック単体確認(local=pgbouncer のみ / Vercel=+connection_limit / 既指定尊重 / 未設定)。
- `pnpm --filter @trakon/web build`(バンドルに反映を確認)/ `tsc -b` / `eslint` / `auth.test` pass。
- `vercel build` → `status: ok` / TS エラー 0。

## マージ後の確認手順

1. preview でプロフィール登録を実行 → `complete-signup` が 200・ダッシュボード遷移。
2. `vercel logs <preview-url> --scope trakon-projects` で `[completeSignup] ... +Nms` の各ステップが出ること。万一失敗が残る場合は、止まるステップを教えていただければ最終対応します。

> [!NOTE]
> 併せて Vercel 環境変数の `DATABASE_URL` が Supabase の Transaction プーラ(`pooler.supabase.com:6543`)であること、`DIRECT_URL` が直結(5432)であることをご確認ください(コードは値に依存せず動きますが、構成として正しい前提です)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)