### PR TITLE
fix(db): DATABASE_URL を堅牢に正規化し破損(postgres&connection_limit=1)を解消

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,29 +6,42 @@ declare global {
 }
 
 /**
- * Supabase の Transaction モードプーラ (pgbouncer, port 6543) + サーバーレス向けに接続文字列を補正する。
+ * DATABASE_URL を「Supabase Transaction プーラ (pgbouncer, port 6543) + サーバーレス」向けに正規化する。
  *
- * - `pgbouncer=true`: prepared statement を無効化。無いと `42P05 prepared statement "s0" already exists`
- *   でクエリが失敗する。直結 DB (ローカル) でも prepared statement を使わなくなるだけで支障なし。
- * - `connection_limit=1` (Vercel のみ): サーバーレスでは各インスタンスが多数の接続を開いてプーラを
- *   枯渇させ、`$transaction` の BEGIN がサーバー接続待ちで滞留 (= 無音の 30s ハング) する。1 接続に
- *   制限してこれを防ぐ (Prisma + Supabase 公式のサーバーレス推奨)。常駐サーバ (ローカル) では付けない。
+ * - `pgbouncer=true`: prepared statement を無効化。無いと `42P05 prepared statement "s0" already exists`。
+ *   直結 DB (ローカル) でも prepared statement を使わなくなるだけで支障なし。
+ * - `connection_limit=1` (Vercel のみ): サーバーレスでの接続枯渇 (= プール checkout タイムアウト) を防ぐ
+ *   Prisma + Supabase 公式の推奨。常駐サーバ (ローカル) では付けない。
  *
- * env 側で付け忘れても確実に効くようコードで補完する。既に同名パラメータがあれば尊重する。
+ * 接続文字列は env とコードの「二重組み立て」になりがちで、`?` を付け忘れた手編集 (例:
+ * `.../postgres&connection_limit=1`) があると DB 名が `postgres&connection_limit=1` と解釈され
+ * `P1003 Database does not exist` で全クエリが落ちる。これを避けるため、壊れた値も含めて
+ * 「DB 名」と「クエリ」を分離して妥当な URL に組み直す。
+ *
+ * 認証情報を壊さないよう URL パーサは使わず、`@` より後の最初の `/` 以降 (= DB 名 + クエリ部) だけを
+ * 処理する (パスワードに `/` が含まれても安全)。
  */
 function resolveDatasourceUrl(): string | undefined {
   const raw = process.env.DATABASE_URL;
   if (!raw) return undefined; // 未設定時は schema / env からの既定解決に委ねる
 
-  const add: Record<string, string> = {};
-  if (!/[?&]pgbouncer=/.test(raw)) add.pgbouncer = 'true';
-  if (process.env.VERCEL && !/[?&]connection_limit=/.test(raw)) add.connection_limit = '1';
+  const at = raw.lastIndexOf('@'); // 認証情報は @ より前。触らない。
+  const pathStart = raw.indexOf('/', at < 0 ? 0 : at);
+  if (pathStart < 0) return raw; // 想定外フォーマットはそのまま返す
 
-  const params = Object.entries(add);
-  if (params.length === 0) return raw;
+  const prefix = raw.slice(0, pathStart); // postgresql://user:pass@host:6543
+  const rest = raw.slice(pathStart + 1); // "postgres" | "postgres?x=y" | 破損 "postgres&x=y"
 
-  const sep = raw.includes('?') ? '&' : '?';
-  return raw + sep + params.map(([k, v]) => `${k}=${v}`).join('&');
+  const sep = rest.search(/[?&]/);
+  const db = sep < 0 ? rest : rest.slice(0, sep);
+  const paramStr = sep < 0 ? '' : rest.slice(sep + 1).replace(/&{2,}/g, '&').replace(/^&/, '');
+
+  const params = new URLSearchParams(paramStr);
+  if (!params.has('pgbouncer')) params.set('pgbouncer', 'true');
+  if (process.env.VERCEL && !params.has('connection_limit')) params.set('connection_limit', '1');
+
+  const query = params.toString();
+  return query ? `${prefix}/${db}?${query}` : `${prefix}/${db}`;
 }
 
 const datasourceUrl = resolveDatasourceUrl();


### PR DESCRIPTION
## 概要

PR #35 後、`dashboard` / `sync` が **500** を繰り返す状態になっていました。本 PR で根本対処します。

## 根本原因(Runtime Log を実取得して断定)

```
P1003 PrismaClientInitializationError:
  Database "postgres&connection_limit=1" does not exist
  on aws-1-ap-northeast-1.pooler.supabase.com:6543
P1017 Server has closed the connection
ECHECKOUTTIMEOUT: unable to check out connection from the pool after 15000ms (Transaction mode)
```

決定的なのは **DB 名が `postgres&connection_limit=1` と解釈されている**点。`DATABASE_URL` が破損し、`&connection_limit=1` が `?` 無しでパスに付与されていました(`.../postgres&connection_limit=1`)。Prisma が存在しない DB に接続 → 全クエリ 500 → フロントの再試行が殺到 → Supabase プーラ枯渇(`ECHECKOUTTIMEOUT` / `Server has closed the connection`)という連鎖です。

経緯: **接続文字列を「env の手追記」と「コードの文字列連結(PR #35)」で二重に組み立てていた**ことが脆弱性の本質。env に `&connection_limit=1` を `?` 無しで追記 → さらにコードが付与し破損しました。

## 修正

`packages/db/src/index.ts` の `resolveDatasourceUrl` を、**壊れた値も含めて妥当な URL に正規化する堅牢な実装**へ置換しました。

- 認証情報を壊さないよう URL パーサは使わず、`@` の後の最初の `/` 以降(= DB 名 + クエリ部)だけを処理(パスワードに `/` が含まれても安全)。
- `URLSearchParams` で `pgbouncer=true`(+ Vercel 時 `connection_limit=1`)を**冪等**に付与。
- 破損 `.../postgres&connection_limit=1` → `.../postgres?connection_limit=1&pgbouncer=true`(DB 名 `postgres`)へ**自動修復**。
- 既に正しく入っていれば尊重し重複しない。

→ env を再編集しなくても復旧します。URL が妥当化 → クエリ成功 → 再試行が止まり、プーラ枯渇(ECHECKOUTTIMEOUT)も解消する見込みです。

## 検証(ローカルで完結)

- `resolveDatasourceUrl` を代表ケースで単体確認 → いずれも DB 名 `postgres` の妥当 URL:
  - クリーン / **破損 `&connection_limit=1`** / 既に正しい / `pgbouncer` のみ / ローカル(local) / **パスワードに `/` を含む** / `sslmode` 既存 / 未設定
- `pnpm --filter @trakon/web build`(バンドル反映)/ `tsc -b` / `eslint` / `auth.test` pass。
- `vercel build` → `status: ok` / TS エラー 0。

## マージ後の確認

1. preview で `dashboard` / `sync` が 200・ダッシュボード表示。
2. `vercel logs <preview-url> --scope trakon-projects` に `P1003` / `P1017` / `ECHECKOUTTIMEOUT` が出ないこと。

> [!NOTE]
> 併せて Vercel の `DATABASE_URL` から手追記したパラメータ(`&connection_limit=1` 等)を外し、**クエリ無しのクリーンな Transaction プーラ URL**(`...pooler.supabase.com:6543/postgres`)に戻すことを推奨します(パラメータはコードが付与)。`DIRECT_URL` は直結(5432)のまま。
> 万一 URL 修復後も `ECHECKOUTTIMEOUT` のみ残る場合は、Supabase プーラのプールサイズ不足(Supabase 側設定/プラン)の可能性があり別途対応となります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)