### PR TITLE
fix(auth): complete-signup をバッチTxに変更しプーラ滞留(504)を解消 + 自己診断

### DIFF
--- a/apps/web/server/services/auth.test.ts
+++ b/apps/web/server/services/auth.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import type { syncUser as SyncUserType } from './auth.js';
+import type { syncUser as SyncUserType, completeSignup as CompleteSignupType } from './auth.js';
 
 // =============================================================================
 // Mocks
@@ -76,18 +76,28 @@ const prismaMock = {
         (u) => u.email === where.email && u.deletedAt === null,
       ) ?? null;
     }),
+    // バッチ (配列) トランザクション用。tx 版と同一挙動。
+    create: userTx.create,
   },
-  $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
-    return fn({ user: userTx, oAuthIdentity: oauthTx, auditLog: auditTx });
+  auditLog: { create: auditTx.create },
+  // 配列形式 ($transaction([...])) とコールバック形式 ($transaction(fn)) の両対応。
+  $transaction: vi.fn(async (arg: unknown) => {
+    if (Array.isArray(arg)) return Promise.all(arg);
+    return (arg as (tx: unknown) => Promise<unknown>)({
+      user: userTx,
+      oAuthIdentity: oauthTx,
+      auditLog: auditTx,
+    });
   }),
 };
 
 vi.mock('@trakon/db', () => ({ prisma: prismaMock }));
 
 const getUserByIdMock = vi.fn();
+const updateUserByIdMock = vi.fn(async () => ({ data: { user: {} }, error: null }));
 vi.mock('../lib/supabaseAdmin.js', () => ({
   getSupabaseAdmin: () => ({
-    auth: { admin: { getUserById: getUserByIdMock, updateUserById: vi.fn() } },
+    auth: { admin: { getUserById: getUserByIdMock, updateUserById: updateUserByIdMock } },
   }),
 }));
 
@@ -96,9 +106,10 @@ vi.mock('../lib/supabaseAdmin.js', () => ({
 // =============================================================================
 
 let syncUser: typeof SyncUserType;
+let completeSignup: typeof CompleteSignupType;
 
 beforeAll(async () => {
-  ({ syncUser } = await import('./auth.js'));
+  ({ syncUser, completeSignup } = await import('./auth.js'));
 });
 
 afterEach(() => {
@@ -217,6 +228,56 @@ describe('syncUser', () => {
       code: 'SAME_EMAIL_DIFFERENT_PROVIDER',
       status: 409,
       details: { primaryAuthMethod: 'password' },
+    });
+  });
+});
+
+describe('completeSignup', () => {
+  const input = {
+    authUserId: 'auth-cs',
+    email: 'cs@example.com',
+    fullName: '河津 正和',
+    displayName: 'Kawazu',
+    password: 'Diag!Passw0rd123',
+  };
+
+  it('creates the user + audit log (batch transaction) and returns the DTO', async () => {
+    const res = await completeSignup(input);
+
+    expect(updateUserByIdMock).toHaveBeenCalledWith('auth-cs', { password: input.password });
+    expect(res).toMatchObject({
+      email: 'cs@example.com',
+      fullName: '河津 正和',
+      displayName: 'Kawazu',
+      primaryAuthMethod: 'password',
+    });
+    // user 行と audit ログが同一 user id で作成される
+    const stored = userStore['auth-cs'];
+    expect(stored).toBeDefined();
+    expect(res.id).toBe(stored?.id);
+    expect(auditStore).toHaveLength(1);
+    expect(auditStore[0]).toMatchObject({
+      actorUserId: res.id,
+      action: 'complete_signup',
+      resourceId: res.id,
+      result: 'success',
+    });
+  });
+
+  it('throws 409 ALREADY_COMPLETED when a users row already exists', async () => {
+    userStore['auth-cs'] = {
+      id: 'u-existing',
+      authUserId: 'auth-cs',
+      email: 'cs@example.com',
+      fullName: 'X',
+      displayName: 'X',
+      primaryAuthMethod: 'password',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      deletedAt: null,
+    };
+    await expect(completeSignup(input)).rejects.toMatchObject({
+      code: 'ALREADY_COMPLETED',
+      status: 409,
     });
   });
 });

--- a/apps/web/server/services/auth.ts
+++ b/apps/web/server/services/auth.ts
@@ -1,7 +1,30 @@
 import { prisma } from '@trakon/db';
+import { uuidv7 } from 'uuidv7';
 
 import { ApiException } from '../lib/errors.js';
 import { getSupabaseAdmin } from '../lib/supabaseAdmin.js';
+
+/**
+ * 個々の await をハードタイムアウトで包む。サーバーレスの 30 秒無音ハングを根絶し、
+ * どのステップで詰まったかをレスポンス body から即特定できるようにする
+ * (実体の処理はキャンセルされないが制御を即返す)。
+ */
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new ApiException('STEP_TIMEOUT', 504, `Operation timed out at: ${label}`)),
+      ms,
+    );
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
+const STEP_TIMEOUT_MS = 10_000;
 
 export type CurrentUserDTO = {
   id: string;
@@ -148,7 +171,11 @@ export async function completeSignup(input: {
   const step = (name: string) => console.log(`[completeSignup] ${name} +${Date.now() - t0}ms`);
 
   step('findUnique:start');
-  const existing = await prisma.user.findUnique({ where: { authUserId: input.authUserId } });
+  const existing = await withTimeout(
+    prisma.user.findUnique({ where: { authUserId: input.authUserId } }),
+    STEP_TIMEOUT_MS,
+    'findUnique',
+  );
   step('findUnique:done');
   if (existing) {
     throw new ApiException('ALREADY_COMPLETED', 409, 'Signup is already completed.');
@@ -156,9 +183,11 @@ export async function completeSignup(input: {
 
   // 同一メール別プロバイダ衝突 (FR-AUTH-12)
   step('findFirst:start');
-  const emailOwner = await prisma.user.findFirst({
-    where: { email: input.email, deletedAt: null },
-  });
+  const emailOwner = await withTimeout(
+    prisma.user.findFirst({ where: { email: input.email, deletedAt: null } }),
+    STEP_TIMEOUT_MS,
+    'findFirst',
+  );
   step('findFirst:done');
   if (emailOwner) {
     throw new ApiException(
@@ -171,39 +200,44 @@ export async function completeSignup(input: {
 
   const supabase = getSupabaseAdmin();
   step('supabase.updateUserById:start');
-  const { error: updateError } = await supabase.auth.admin.updateUserById(input.authUserId, {
-    password: input.password,
-  });
+  const { error: updateError } = await withTimeout(
+    supabase.auth.admin.updateUserById(input.authUserId, { password: input.password }),
+    STEP_TIMEOUT_MS,
+    'supabase.updateUserById',
+  );
   step('supabase.updateUserById:done');
   if (updateError) {
     throw new ApiException('SUPABASE_UPDATE_FAILED', 500, updateError.message);
   }
 
+  // 対話的トランザクションは Supabase の Transaction モードプーラで接続を保持し続けて滞留しやすい。
+  // id をアプリ側で採番し、依存のないバッチ (配列) トランザクションで 1 往復に収める。
   step('transaction:start');
-  const user = await prisma.$transaction(
-    async (tx) => {
-      const created = await tx.user.create({
+  const userId = uuidv7();
+  const [user] = await withTimeout(
+    prisma.$transaction([
+      prisma.user.create({
         data: {
+          id: userId,
           authUserId: input.authUserId,
           email: input.email,
           fullName: input.fullName,
           displayName: input.displayName,
           primaryAuthMethod: 'password',
         },
-      });
-      await tx.auditLog.create({
+      }),
+      prisma.auditLog.create({
         data: {
-          actorUserId: created.id,
+          actorUserId: userId,
           action: 'complete_signup',
           resourceType: 'user',
-          resourceId: created.id,
+          resourceId: userId,
           result: 'success',
         },
-      });
-      return created;
-    },
-    // 30 秒の無音ハングではなく明示的に早期失敗させる (接続待ち/長期化の検知)
-    { maxWait: 5000, timeout: 15000 },
+      }),
+    ]),
+    STEP_TIMEOUT_MS,
+    'transaction',
   );
   step('transaction:done');
 


### PR DESCRIPTION
## 概要

PR #36 で `sync` は復旧しましたが、「登録を完了する」(`complete-signup`)が再び **30 秒で 504** になっていました。本 PR で対処します。

## 深掘り(前提検証込み)

まず **バックエンドはデプロイ済み・稼働中**であることを確認:
- `GET /api/v1/healthz` → **200**(Hono アプリ内ルート)。フロントは相対 `/api/v1` を叩く(同一 Vercel デプロイの関数)。
- `complete-signup` の 504 は Vercel の `{code:"504"}`(30s タイムアウト)= 関数に到達しているが処理が 30s 超過。

切り分け:
- `sync`(単発の読み取り = 接続を即解放)は通る。
- `complete-signup` 固有の**対話的 `prisma.$transaction`**(`BEGIN→create→create→COMMIT` の間 Supabase **Transaction モードプーラ**の接続を保持)だけが詰まる。
- PR #35 で入れた `$transaction {timeout:15000}` すら効かず 30s に達するのは、**`BEGIN` のサーバ接続待ちが Prisma の `maxWait`/`timeout` の被覆外**で滞留するため。

## 修正(`apps/web/server/services/auth.ts`)

1. **対話的トランザクション → バッチ配列トランザクション**: アプリ側で `uuidv7()` により user id を採番し、依存のない `prisma.$transaction([ user.create({id}), auditLog.create({actorUserId:id}) ])` に置換。全ステートメントを **1 往復**で実行し、プーラ接続の保持時間を最小化 → 滞留/枯渇を回避。
2. **各ステップにハードタイムアウト + 自己診断**: `findUnique`/`findFirst`/`updateUserById`/`transaction` を `withTimeout(~10s)` で包む。30 秒無音ハングを根絶し、タイムアウト時は `STEP_TIMEOUT`「Operation timed out at: <step>」を返す → **再現一発で詰まる箇所を Network レスポンスから特定可能**。

## テスト(`auth.test.ts`)

- `$transaction` モックを**配列/コールバック両対応**に拡張し、`prisma.user.create` / `auditLog.create` を追加。
- `completeSignup` の**成功**(user + audit を同一 id で作成)と **`ALREADY_COMPLETED` 409** のテストを追加。
- 全 **7 件 pass**。

## 検証(ローカル完結)

- `tsc -b` / `eslint` / `vitest`(7) / `vercel build`(status ok, TS エラー 0)すべて pass。
- バンドルに `uuidv7` / `STEP_TIMEOUT` 反映を確認。

## マージ後の確認

preview で登録実行 →
- **成功 = 200・ダッシュボード遷移**(根本修正が効いたケース)。
- もし失敗 → レスポンス body に `Operation timed out at: <step>` が出るので、その step をお知らせください(原因を確定し最終対応へ)。

> [!NOTE]
> **システミックな後続(別 PR 想定)**: 同じ対話的 `$transaction` は他の書き込み系(`projects`/`invitations`/`shareAccess`/`ballActions`)でも使用。本修正で「対話的トランザクションのプーラ滞留」が確証できたら、同様のバッチ化、または `DATABASE_URL` を Supabase の **Session モードプーラ(5432)** へ切替(対話的トランザクションを完全サポート)を検討します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)