### PR TITLE
fix(db): 主キーをクライアント採番(uuid(7))に統一し DB uuidv7() 滞留(504)を解消

### DIFF
--- a/apps/web/server/services/auth.ts
+++ b/apps/web/server/services/auth.ts
@@ -304,15 +304,25 @@ export async function recordLogin(input: {
   ip?: string;
   userAgent?: string;
 }): Promise<void> {
-  await prisma.auditLog.create({
-    data: {
-      actorUserId: input.userId,
-      action: 'login',
-      resourceType: 'user',
-      resourceId: input.userId,
-      result: 'success',
-      ip: input.ip ?? null,
-      userAgent: input.userAgent ?? null,
-    },
-  });
+  // ログイン監査は best-effort。書き込みが失敗/遅延しても認証フロー (login / complete-signup) の
+  // レスポンスを止めない (id はクライアント採番 = uuid(7) なので DB 関数依存の滞留も避けられる)。
+  try {
+    await withTimeout(
+      prisma.auditLog.create({
+        data: {
+          actorUserId: input.userId,
+          action: 'login',
+          resourceType: 'user',
+          resourceId: input.userId,
+          result: 'success',
+          ip: input.ip ?? null,
+          userAgent: input.userAgent ?? null,
+        },
+      }),
+      STEP_TIMEOUT_MS,
+      'recordLogin',
+    );
+  } catch (err) {
+    console.error('[recordLogin] failed (non-fatal):', err);
+  }
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -28,7 +28,7 @@ datasource db {
 // 設計書 §2.4.1
 // -----------------------------------------------------------------------------
 model User {
-  id                String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  id                String    @id @default(uuid(7)) @db.Uuid
   authUserId        String    @unique(map: "uq_users_auth_user_id") @map("auth_user_id") @db.Uuid
   email             String    @unique(map: "uq_users_email")
   fullName          String    @map("full_name")
@@ -54,7 +54,7 @@ model User {
 // 設計書 §2.4.2
 // -----------------------------------------------------------------------------
 model Project {
-  id             String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  id             String    @id @default(uuid(7)) @db.Uuid
   organizationId String?   @map("organization_id") @db.Uuid
   name           String
   startDate      DateTime  @map("start_date") @db.Date
@@ -84,7 +84,7 @@ model Project {
 // 設計書 §2.4.3
 // -----------------------------------------------------------------------------
 model ProjectMember {
-  id               String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  id               String    @id @default(uuid(7)) @db.Uuid
   projectId        String    @map("project_id") @db.Uuid
   /// 招待受諾前は NULL
   userId           String?   @map("user_id") @db.Uuid
@@ -120,7 +120,7 @@ model ProjectMember {
 // 設計書 §2.4.4
 // -----------------------------------------------------------------------------
 model ProjectItem {
-  id        String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  id        String    @id @default(uuid(7)) @db.Uuid
   projectId String    @map("project_id") @db.Uuid
   name      String
   /// Phase 1+ (page|document|banner|other)
@@ -144,7 +144,7 @@ model ProjectItem {
 // 設計書 §2.4.5
 // -----------------------------------------------------------------------------
 model Plan {
-  id              String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  id              String    @id @default(uuid(7)) @db.Uuid
   itemId          String    @map("item_id") @db.Uuid
   /// 'toss' (Phase 0 / CHECK 制約)
   planType        String    @default("toss") @map("plan_type")
@@ -185,7 +185,7 @@ model Plan {
 // 設計書 §2.4.6
 // -----------------------------------------------------------------------------
 model BallEvent {
-  id            String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  id            String   @id @default(uuid(7)) @db.Uuid
   planId        String   @map("plan_id") @db.Uuid
   /// 'tossed' | 'completed' | 'toss_undone' (CHECK 制約)
   eventType     String   @map("event_type")
@@ -212,7 +212,7 @@ model BallEvent {
 // 設計書 §2.4.8
 // -----------------------------------------------------------------------------
 model Invitation {
-  id              String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  id              String    @id @default(uuid(7)) @db.Uuid
   projectId       String    @map("project_id") @db.Uuid
   invitedMemberId String    @map("invited_member_id") @db.Uuid
   email           String
@@ -236,7 +236,7 @@ model Invitation {
 // 設計書 §2.4.X
 // -----------------------------------------------------------------------------
 model OAuthIdentity {
-  id             String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  id             String   @id @default(uuid(7)) @db.Uuid
   userId         String   @map("user_id") @db.Uuid
   /// 'google' | 'microsoft' (CHECK 制約)
   provider       String
@@ -258,7 +258,7 @@ model OAuthIdentity {
 // 設計書 §2.4.7
 // -----------------------------------------------------------------------------
 model AuditLog {
-  id           String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  id           String   @id @default(uuid(7)) @db.Uuid
   occurredAt   DateTime @default(now()) @map("occurred_at") @db.Timestamptz
   actorUserId  String?  @map("actor_user_id") @db.Uuid
   /// share_links FK は Sub-Phase 0.5 で実装 (share_links テーブル追加時)
@@ -287,7 +287,7 @@ model AuditLog {
 // 設計書 §2.4.9
 // -----------------------------------------------------------------------------
 model ShareLink {
-  id               String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  id               String    @id @default(uuid(7)) @db.Uuid
   projectId        String    @map("project_id") @db.Uuid
   /// 'project' | 'item' | 'plan' (CHECK 制約)
   scopeType        String    @map("scope_type")


### PR DESCRIPTION
## 概要

PR #37 後も `complete-signup` が **30 秒 504**(私の `STEP_TIMEOUT` ではなく Vercel 生の `{code:"504"}`)のままだった件の真因対応です。

## 真因(深掘りの演繹)

- PR #37 の `withTimeout` は **`completeSignup` の内部ステップのみ**を保護。`complete-signup` ルートは `completeSignup` の**後に `recordLogin` を呼ぶ(withTimeout の外)**。→ `STEP_TIMEOUT` が出ず Vercel 生 504 になる。
- `sync`(password フロー)は `requires_profile_completion` を返し **`recordLogin` を呼ばない**ので通る。complete-signup は必ず呼ぶ → ここで詰まる(「sync は通るが complete-signup だけ落ちる」を完全に説明)。
- `recordLogin` は `audit_logs` へ **id 未指定(DB 既定 `dbgenerated("uuidv7()")`)** で INSERT。一方 PR #37 の completeSignup は**同じ `audit_logs`** へ **id をアプリ採番**して INSERT し成功(STEP_TIMEOUT 出ず)。
- → 同一テーブル・同一プーラで**差は id 生成元のみ**。**INSERT 時に評価される DB 関数 `uuidv7()` の滞留**が真因(advisory lock 等を使う実装だと Transaction プーラ下でロック/滞留しエラーにならず 30s 詰まり得る)。全モデルの主キーが `dbgenerated("uuidv7()")` のため、**書き込み全般に影響するシステミック不具合**。schema コメントも本来「`@default(uuid(7))`」意図と明記。

## 修正

| 変更 | 内容 |
|---|---|
| `packages/db/prisma/schema.prisma` | 全 `@id @default(dbgenerated("uuidv7()"))` → **`@default(uuid(7))`**(Prisma 5.14+ のクライアント側 UUIDv7 採番)。Prisma が全 create で id を採番し INSERT に含めるため **DB 関数 `uuidv7()` を呼ばなくなり、全書き込みの滞留が根絶**。生成クライアントの DMMF が `dbgenerated`→`uuid(7)` に変わったことを確認。DB カラムの `DEFAULT uuidv7()` は未使用で残存(無害)・移行不要 |
| `apps/web/server/services/auth.ts` | `recordLogin` を **best-effort 化**(`withTimeout` + try/catch、失敗時 `console.error`)。監査ログ書き込みが login / complete-signup を止めない防御 |

## 検証(ローカル完結)

- `pnpm --filter @trakon/db generate` → DMMF が client-side `uuid(7)` に切替を確認。
- `auth.test`(7)/ `tsc -b` / `eslint` / `build` / `vercel build`(status ok, TS 0)すべて pass。

## マージ後の確認

- complete-signup が **201・ダッシュボード遷移**。
- 既存ユーザーの **login**(sync→ready→recordLogin)も 200。
- 続けて **プロジェクト作成など他の書き込み**も成功すること(= システミック修正の確認。これらも従来 `uuidv7()` 既定依存で同様に詰まっていたはず)。

> [!NOTE]
> schema と DB の間に「DB 側 `DEFAULT uuidv7()` が残る」ドリフトが生じますが無害(Prisma が常に id を渡す)。気になる場合は後日マイグレーションで DB 既定を DROP して整理可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)