### PR TITLE
fix(auth): プロフィール登録後にダッシュボードへ確実に遷移する

### DIFF
--- a/apps/web/src/features/auth/SC01LoginPage.tsx
+++ b/apps/web/src/features/auth/SC01LoginPage.tsx
@@ -13,7 +13,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { supabase } from '@/lib/supabase';
 import { ApiClientError } from '@/lib/api';
 import { useAuthSession } from './useAuthSession';
-import { authApi } from './api';
+import { authApi, type SyncResponse } from './api';
 import { OAuthButtons } from './OAuthButtons';
 
 // =============================================================================
@@ -351,15 +351,20 @@ function CreateAccountForm() {
   const onSubmit = async (values: CreateAccountInput) => {
     setServerError(null);
     try {
-      await authApi.completeSignup({
+      const user = await authApi.completeSignup({
         fullName: values.fullName,
         displayName: values.displayName,
         password: values.password,
       });
-      // キャッシュの sync 結果（requiresProfileCompletion: true）を無効化する。
-      // これをしないと RequireAuth が古いキャッシュを見て
-      // /login?screen=create-account に戻してしまう。
-      await queryClient.invalidateQueries({ queryKey: ['auth', 'sync'] });
+      // 完了結果で sync キャッシュを「プロフィール完了済み」に確定上書きする。
+      // invalidateQueries は create-account 上で非アクティブな sync クエリを再取得せず
+      // (stale マークのみ)、遷移先の RequireAuth が古い requiresProfileCompletion: true を
+      // 読んで create-account に差し戻してしまうため、setQueryData で確定値を書き込む。
+      // キーは useCurrentUser と同一: ['auth', 'sync', session.user.id]
+      queryClient.setQueryData<SyncResponse>(['auth', 'sync', session.user.id], {
+        user,
+        requiresProfileCompletion: false,
+      });
       navigate('/dashboard', { replace: true });
     } catch (err) {
       if (err instanceof ApiClientError && err.code === 'SAME_EMAIL_DIFFERENT_PROVIDER') {


### PR DESCRIPTION
## 概要

complete-signup API は成功(201)するものの、完了後にダッシュボードへ遷移せず**再びプロフィール登録(create-account)画面が表示される**フロント不具合の修正です。

## 根本原因(React Query キャッシュとガードのレース)

- `useCurrentUser` の sync クエリキーは `['auth', 'sync', session.user.id]`(`staleTime: 60s`)。
- `RequireAuth` は `isLoading` 中のみスピナー、それ以外で `data?.requiresProfileCompletion === true` なら `/login?screen=create-account` へ。
- `CreateAccountForm.onSubmit` は完了後 `invalidateQueries(['auth','sync'])` → `navigate('/dashboard')`。

連鎖:
1. create-account 画面では sync クエリは**非アクティブ**(ページは `useAuthSession` のみ使用)。
2. `invalidateQueries`(既定 `refetchType:'active'`)は**非アクティブクエリを stale マークするだけで再取得しない** → `await` も即解決。キャッシュには**古い `{ requiresProfileCompletion: true }` が残存**。
3. `navigate('/dashboard')` → `RequireAuth` が `useCurrentUser` をマウント。背景再取得が走るが **`data` は古い値・`isLoading` は false**(キャッシュ有り)。
4. → `RequireAuth` が古い `true` を読み **create-account に差し戻す**。

## 修正(`apps/web/src/features/auth/SC01LoginPage.tsx`)

`invalidateQueries` を **`setQueryData` による確定上書き**に置換。`completeSignup()` は作成済みユーザー(`CurrentUser`)を返すので、それで sync キャッシュを確定値に更新してから遷移します:

```ts
const user = await authApi.completeSignup({ ... });
queryClient.setQueryData<SyncResponse>(['auth', 'sync', session.user.id], {
  user,
  requiresProfileCompletion: false,
});
navigate('/dashboard', { replace: true });
```

`setQueryData` はデータを fresh にするため、`RequireAuth` は再取得レースに左右されず `requiresProfileCompletion: false` を読み、ダッシュボードを表示します。

## 検証

- `tsc -b` / `eslint` / `build` pass。
- マージ後 preview: Magic-link → create-account →「登録を完了する」→ **ダッシュボードへ遷移し戻らない**、リロード後も維持、既存ユーザーのログインも回帰なしをご確認ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)