### PR TITLE
feat(plans): 予定編集で FROM/TO/後続の予定を編集可能にする

### DIFF
--- a/apps/web/server/routes/v1/plans.ts
+++ b/apps/web/server/routes/v1/plans.ts
@@ -74,10 +74,11 @@ export const plansRoute = new Hono()
 
   .patch('/:planId', async (c) => {
     const itemId = c.get('itemId');
+    const project = c.get('project');
     const planId = c.req.param('planId');
     if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
     const body = updatePlanBodySchema.parse(await c.req.json());
-    const plan = await updatePlan({ itemId, planId, body });
+    const plan = await updatePlan({ itemId, planId, projectId: project.projectId, body });
     return c.json({ data: plan });
   })
 

--- a/apps/web/server/schemas/plans.test.ts
+++ b/apps/web/server/schemas/plans.test.ts
@@ -50,12 +50,40 @@ describe('createPlanBodySchema', () => {
 });
 
 describe('updatePlanBodySchema', () => {
+  const fromId = '11111111-1111-1111-1111-111111111111';
+  const toId = '22222222-2222-2222-2222-222222222222';
+
   it('accepts an empty body', () => {
     expect(updatePlanBodySchema.safeParse({}).success).toBe(true);
   });
 
   it('accepts memo = null (clears memo)', () => {
     expect(updatePlanBodySchema.safeParse({ memo: null }).success).toBe(true);
+  });
+
+  it('accepts fromMemberId / toMemberId update', () => {
+    expect(
+      updatePlanBodySchema.safeParse({ fromMemberId: fromId, toMemberId: toId }).success,
+    ).toBe(true);
+  });
+
+  it('rejects identical from / to when both provided', () => {
+    expect(
+      updatePlanBodySchema.safeParse({ fromMemberId: fromId, toMemberId: fromId }).success,
+    ).toBe(false);
+  });
+
+  it('accepts updating only one of from / to', () => {
+    expect(updatePlanBodySchema.safeParse({ toMemberId: toId }).success).toBe(true);
+  });
+
+  it('accepts successorPlanId set and null (clear)', () => {
+    expect(updatePlanBodySchema.safeParse({ successorPlanId: fromId }).success).toBe(true);
+    expect(updatePlanBodySchema.safeParse({ successorPlanId: null }).success).toBe(true);
+  });
+
+  it('rejects malformed successorPlanId', () => {
+    expect(updatePlanBodySchema.safeParse({ successorPlanId: 'not-a-uuid' }).success).toBe(false);
   });
 });
 

--- a/apps/web/server/schemas/plans.ts
+++ b/apps/web/server/schemas/plans.ts
@@ -44,6 +44,9 @@ export const updatePlanBodySchema = z
     category: planCategorySchema.optional(),
     scheduledDate: isoDate.optional(),
     dueDate: isoDate.nullable().optional(),
+    fromMemberId: uuid.optional(),
+    toMemberId: uuid.optional(),
+    successorPlanId: uuid.nullable().optional(),
     memo: z.string().max(2000).nullable().optional(),
   })
   .refine(
@@ -52,6 +55,13 @@ export const updatePlanBodySchema = z
       return true;
     },
     { path: ['dueDate'], message: 'dueDate must be on or after scheduledDate.' },
+  )
+  .refine(
+    (v) => {
+      if (v.fromMemberId && v.toMemberId) return v.fromMemberId !== v.toMemberId;
+      return true;
+    },
+    { path: ['toMemberId'], message: 'fromMemberId and toMemberId must differ.' },
   );
 export type UpdatePlanBody = z.infer<typeof updatePlanBodySchema>;
 

--- a/apps/web/server/services/plans.ts
+++ b/apps/web/server/services/plans.ts
@@ -311,17 +311,22 @@ export async function createPlan(input: {
 export async function updatePlan(input: {
   itemId: string;
   planId: string;
+  projectId: string;
   body: UpdatePlanBody;
 }): Promise<PlanDTO> {
   const existing = await prisma.plan.findFirst({
     where: { id: input.planId, itemId: input.itemId, deletedAt: null },
+    include: {
+      ballEvents: { orderBy: { occurredAt: 'desc' }, select: { eventType: true } },
+    },
   });
   if (!existing) throw new ApiException('NOT_FOUND', 404, 'Plan not found.');
   if (existing.status !== 'active') {
     throw new ApiException('PLAN_NOT_ACTIVE', 422, 'Plan is not editable.');
   }
 
-  const data: Prisma.PlanUpdateInput = {};
+  // PlanUncheckedUpdateInput を使うことでスカラ FK (fromMemberId 等) を直接指定できる。
+  const data: Prisma.PlanUncheckedUpdateInput = {};
   if (input.body.title !== undefined) data.title = input.body.title;
   if (input.body.category !== undefined) data.category = input.body.category;
   if (input.body.scheduledDate !== undefined)
@@ -329,6 +334,56 @@ export async function updatePlan(input: {
   if (input.body.dueDate !== undefined)
     data.dueDate = input.body.dueDate ? new Date(`${input.body.dueDate}T00:00:00Z`) : null;
   if (input.body.memo !== undefined) data.memo = input.body.memo;
+
+  // FROM/TO は TOSS 前 (ball が動いていない) の予定でのみ変更可。
+  // ball state 判定は ballActions.currentBallState と同じセマンティクス:
+  // 最新イベントが無い or toss_undone なら ready。
+  if (input.body.fromMemberId !== undefined || input.body.toMemberId !== undefined) {
+    const latest = existing.ballEvents[0];
+    const isReady = !latest || latest.eventType === 'toss_undone';
+    if (!isReady) {
+      throw new ApiException(
+        'FROM_TO_LOCKED',
+        422,
+        'FROM/TO cannot be changed after the ball has been tossed.',
+      );
+    }
+    const nextFrom = input.body.fromMemberId ?? existing.fromMemberId;
+    const nextTo = input.body.toMemberId ?? existing.toMemberId;
+    if (nextFrom === nextTo) {
+      throw new ApiException(
+        'INVALID_MEMBER',
+        422,
+        'fromMemberId and toMemberId must differ.',
+      );
+    }
+    const changedMemberIds: string[] = [];
+    if (input.body.fromMemberId !== undefined) changedMemberIds.push(input.body.fromMemberId);
+    if (input.body.toMemberId !== undefined) changedMemberIds.push(input.body.toMemberId);
+    await assertMembersBelongToProject({
+      projectId: input.projectId,
+      memberIds: changedMemberIds,
+    });
+    if (input.body.fromMemberId !== undefined) data.fromMemberId = input.body.fromMemberId;
+    if (input.body.toMemberId !== undefined) data.toMemberId = input.body.toMemberId;
+  }
+
+  // 後続の予定 (setPlanSuccessor と同じ検証ロジック)。
+  if (input.body.successorPlanId !== undefined) {
+    if (input.body.successorPlanId === null) {
+      data.successorPlanId = null;
+    } else {
+      if (input.body.successorPlanId === input.planId) {
+        throw new ApiException('SELF_SUCCESSOR', 422, 'A plan cannot be its own successor.');
+      }
+      await assertSuccessorAvailable({
+        successorPlanId: input.body.successorPlanId,
+        itemId: input.itemId,
+        excludePlanId: input.planId,
+      });
+      data.successorPlanId = input.body.successorPlanId;
+    }
+  }
 
   const row = await prisma.plan.update({
     where: { id: input.planId },

--- a/apps/web/src/features/plans/CreatePlanModal.tsx
+++ b/apps/web/src/features/plans/CreatePlanModal.tsx
@@ -144,7 +144,12 @@ export function CreatePlanModal({
         category: v.category,
         scheduledDate: v.scheduledDate,
         dueDate: v.dueDate || null,
+        successorPlanId: v.successorPlanId || null,
         memo: v.memo ?? null,
+        // FROM/TO は TOSS 前のみ送信 (ロック中はサーバ側でも拒否される)
+        ...(fromToEditable
+          ? { fromMemberId: v.fromMemberId, toMemberId: v.toMemberId }
+          : {}),
       });
     },
     onSuccess: () => {
@@ -165,6 +170,9 @@ export function CreatePlanModal({
     (p) => p.itemId === itemId && p.id !== editingPlan?.id && p.status === 'active',
   );
 
+  // FROM/TO は新規作成時、または TOSS 前 (ボール未移動) の予定編集時のみ変更可。
+  const fromToEditable = mode === 'create' || editingPlan?.ballState === 'ready';
+
   return (
     <Sheet open onOpenChange={(o) => !o && onClose()}>
       <SheetContent>
@@ -172,7 +180,7 @@ export function CreatePlanModal({
           <SheetTitle>{mode === 'edit' ? '予定を編集' : '予定を追加'}</SheetTitle>
           <SheetDescription>
             {mode === 'edit'
-              ? '日付やメモなどの基本情報を変更します（TOSS 後は FROM/TO の変更不可）。カレンダー上でカードをドラッグして期間を変更することもできます。'
+              ? 'FROM/TO・後続の予定を含む基本情報を変更します（FROM/TO は TOSS 前のみ変更可）。カレンダー上でカードをドラッグして期間を変更することもできます。'
               : 'カレンダー上に予定（ボール）を作成します'}
           </SheetDescription>
         </SheetHeader>
@@ -202,7 +210,7 @@ export function CreatePlanModal({
               <SelectField
                 value={form.watch('fromMemberId') || undefined}
                 onChange={(v) => form.setValue('fromMemberId', v)}
-                disabled={mode === 'edit'}
+                disabled={!fromToEditable}
                 options={members.map((m) => ({ value: m.id, label: `${m.name} (${m.organizationName || '—'})` }))}
                 placeholder="選択"
               />
@@ -211,12 +219,17 @@ export function CreatePlanModal({
               <SelectField
                 value={form.watch('toMemberId') || undefined}
                 onChange={(v) => form.setValue('toMemberId', v)}
-                disabled={mode === 'edit'}
+                disabled={!fromToEditable}
                 options={members.map((m) => ({ value: m.id, label: `${m.name} (${m.organizationName || '—'})` }))}
                 placeholder="選択"
               />
             </Field>
           </div>
+          {mode === 'edit' && !fromToEditable && (
+            <p className="text-[11px] text-muted-foreground">
+              TOSS 後のため FROM/TO は変更できません。
+            </p>
+          )}
 
           <div className="grid grid-cols-2 gap-3">
             <Field label="開始日" error={form.formState.errors.scheduledDate?.message}>
@@ -234,7 +247,6 @@ export function CreatePlanModal({
             <SelectField
               value={form.watch('successorPlanId') || undefined}
               onChange={(v) => form.setValue('successorPlanId', v === '__none__' ? '' : v)}
-              disabled={mode === 'edit'}
               options={[
                 { value: '__none__', label: '紐付けない' },
                 ...successorCandidates.map((p) => ({ value: p.id, label: p.title })),

--- a/apps/web/src/features/plans/api.ts
+++ b/apps/web/src/features/plans/api.ts
@@ -84,6 +84,9 @@ export type UpdatePlanInput = Partial<{
   category: PlanCategory;
   scheduledDate: string;
   dueDate: string | null;
+  fromMemberId: string;
+  toMemberId: string;
+  successorPlanId: string | null;
   memo: string | null;
 }>;
 


### PR DESCRIPTION
## 概要
カレンダー上の予定編集モーダル（`CreatePlanModal` の edit モード）で、**FROM・TO・後続の予定**が編集できなかった問題を、フロント・バックエンドの両層で修正します。

原因は 2 層にありました:
- **フロント**: 編集モード時に 3 つの `<SelectField>` が `disabled` で固定され、更新 payload も `title/category/scheduledDate/dueDate/memo` のみだった。
- **バックエンド**: `PATCH /plans/:id`（`updatePlanBodySchema` / `updatePlan`）が FROM/TO/successor を受け付けていなかった。

## 仕様（確認済み）
- **FROM / TO は「TOSS 前（`ballState='ready'`）のみ」編集可**。TOSS 済みはサーバ側で `FROM_TO_LOCKED`（422）として拒否し、ボール履歴の整合性を保護。
- **後続の予定**は履歴整合性の懸念がないため、予定が `active` の間は編集可能。
- 保存は単一の「保存」＝単一 `PATCH /plans/:id` に統合（successor も update に内包）。

## 変更点
### バックエンド
- `server/schemas/plans.ts` — `updatePlanBodySchema` に `fromMemberId` / `toMemberId` / `successorPlanId` を追加し、両方指定時の from≠to バリデーションを追加。
- `server/services/plans.ts` — `updatePlan` を拡張。FROM/TO の TOSS 前ガード（`FROM_TO_LOCKED`）・プロジェクト所属チェック・from≠to、後続は `setPlanSuccessor` と同じ検証（自己参照/既使用/スコープ外）を再利用。`projectId` を引数に追加。
- `server/routes/v1/plans.ts` — `PATCH` で `projectId` を `updatePlan` に渡す。

### フロントエンド
- `src/features/plans/api.ts` — `UpdatePlanInput` に 3 フィールド追加。
- `src/features/plans/CreatePlanModal.tsx` — `disabled` を `fromToEditable`（新規 or TOSS 前）で制御、後続は常時編集可に。更新 payload に `successorPlanId`（+ 編集可時のみ FROM/TO）を送信。説明文言を更新し、TOSS 後はロック理由のヒントを表示。

## テスト
- `server/schemas/plans.test.ts` に `updatePlanBodySchema` のケースを追加。
- `type-check` ✓ / `lint`（警告0）✓ / plans スキーマ・ルートテスト **20/20** ✓。
- ※ `share.test.ts` の1件はローカル Supabase 接続待ちのタイムアウトで本変更とは無関係（該当ファイル未編集）。

## 手動確認の推奨手順
1. 予定を新規作成（TOSS 前）→ 編集 → FROM/TO/後続を変更 → 保存 → 反映を確認。
2. TOSS 後に再編集 → FROM/TO がロック（グレーアウト）、後続は編集可を確認。
3. 後続を「紐付けない」に変更 → クリアを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)