### PR TITLE
feat(plans): 予定モーダルの次タスクへトス/完了 とスケジュール上の後続紐づけ

### DIFF
--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
-import { CheckCircle2, Loader2, Pencil, Send, Trash2, Undo2, Zap } from 'lucide-react';
+import { ArrowRight, CheckCircle2, Link2Off, Loader2, Pencil, Send, Trash2, Undo2, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -28,9 +28,9 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { ApiClientError } from '@/lib/api';
 import { useCurrentUser } from '@/features/auth/useCurrentUser';
 import type { ProjectMember } from '@/features/projects/membersApi';
-import { plansApi, plansQueryKey, type BallEvent } from './api';
+import { plansApi, plansQueryKey, type BallEvent, type Plan } from './api';
 import { CATEGORY_STYLE } from './categoryColor';
-import { useCompletePlan, useTossPlan } from './useOptimisticBallAction';
+import { useCompletePlan, useSetSuccessor, useTossPlan } from './useOptimisticBallAction';
 
 /**
  * SC-08 ボール詳細・TOSS/完了モーダル
@@ -42,6 +42,7 @@ export function BallDetailModal({
   itemId,
   planId,
   members,
+  plans,
   onClose,
   onEdit,
 }: {
@@ -49,6 +50,7 @@ export function BallDetailModal({
   itemId: string;
   planId: string;
   members: ProjectMember[];
+  plans: Plan[];
   onClose: () => void;
   onEdit: () => void;
 }) {
@@ -66,6 +68,7 @@ export function BallDetailModal({
 
   const tossMut = useTossPlan({ projectId, itemId, planId });
   const completeMut = useCompletePlan({ projectId, itemId, planId });
+  const successorMut = useSetSuccessor(projectId);
 
   const undoMut = useMutation({
     mutationFn: () => plansApi.undoToss(projectId, itemId, planId),
@@ -109,9 +112,15 @@ export function BallDetailModal({
               !!plan.ballHolder && !!myMember && plan.ballHolder.id === myMember.id;
             const canAct = plan.status === 'active' && (isBallHolder /* director は BE 側で許可 */);
             const style = CATEGORY_STYLE[plan.category];
+            const successor = plan.successorPlanId
+              ? (plans.find((p) => p.id === plan.successorPlanId) ?? null)
+              : null;
+            const hasSuccessor = plan.successorPlanId !== null;
 
             const handleToss = () => tossMut.mutate(undefined);
             const handleComplete = () => completeMut.mutate();
+            const handleUnlink = () =>
+              successorMut.mutate({ itemId, planId, successorPlanId: null });
 
             return (
               <>
@@ -152,6 +161,32 @@ export function BallDetailModal({
                   {plan.memo && (
                     <div className="rounded-md border border-border bg-muted/40 p-3 text-xs whitespace-pre-wrap">
                       {plan.memo}
+                    </div>
+                  )}
+                  {hasSuccessor && (
+                    <div className="flex items-center gap-2 rounded-md border border-sky-200 bg-sky-50 p-2 text-xs text-sky-800">
+                      <ArrowRight className="size-4 shrink-0" />
+                      <span className="shrink-0 text-sky-600">次のタスク</span>
+                      <span className="truncate font-medium">
+                        {successor ? successor.title : '（別の制作物 / 取得中）'}
+                      </span>
+                      {plan.status === 'active' && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="ml-auto size-7 shrink-0 text-sky-700 hover:text-sky-900"
+                          onClick={handleUnlink}
+                          disabled={successorMut.isPending}
+                          aria-label="後続の紐づけを解除"
+                          title="後続の紐づけを解除"
+                        >
+                          {successorMut.isPending ? (
+                            <Loader2 className="size-4 animate-spin" />
+                          ) : (
+                            <Link2Off className="size-4" />
+                          )}
+                        </Button>
+                      )}
                     </div>
                   )}
                   <Section title="履歴">
@@ -210,10 +245,12 @@ export function BallDetailModal({
                         <Button onClick={handleComplete} disabled={completeMut.isPending}>
                           {completeMut.isPending ? (
                             <Loader2 className="size-4 animate-spin" />
+                          ) : hasSuccessor ? (
+                            <Send className="size-4" />
                           ) : (
                             <CheckCircle2 className="size-4" />
                           )}
-                          完了する
+                          {hasSuccessor ? '次のタスクへトス' : '完了する'}
                         </Button>
                       </>
                     )}

--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -24,6 +24,7 @@ import { PageHeader } from '@/components/layout/PageHeader';
 import { PlanModalsHost } from './PlanModalsHost';
 import { DateChangeConfirmModal } from './DateChangeConfirmModal';
 import { useReschedulePlan, type ReschedulePatch } from './usePlanReschedule';
+import { useSetSuccessor } from './useOptimisticBallAction';
 import {
   assignLanes,
   ballTier,
@@ -81,6 +82,7 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
   });
 
   const reschedule = useReschedulePlan(projectId);
+  const setSuccessor = useSetSuccessor(projectId);
   const [pendingMove, setPendingMove] = useState<{ plan: Plan; dayDelta: number } | null>(null);
 
   const project = projectQuery.data;
@@ -179,6 +181,14 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
     setPendingMove(null);
   };
 
+  const commitLink = (source: Plan, target: Plan) => {
+    setSuccessor.mutate({
+      itemId: source.itemId,
+      planId: source.id,
+      successorPlanId: target.id,
+    });
+  };
+
   const commitResize = (plan: Plan, edge: 'top' | 'bottom', dayDelta: number) => {
     if (dayDelta === 0) return;
     const { start, end } = planRange(plan);
@@ -268,6 +278,7 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
           onOpenDetail={openDetailModal}
           onMove={commitMove}
           onResize={commitResize}
+          onLink={commitLink}
         />
       )}
 
@@ -300,6 +311,35 @@ type DragState = {
   moved: boolean;
 };
 
+// 後続紐づけドラッグ (カード下部コネクタ → 別カード)。座標はビューポート基準 (client)。
+type LinkDrag = {
+  source: Plan;
+  start: { x: number; y: number };
+  pointer: { x: number; y: number };
+  targetId: string | null;
+};
+
+/**
+ * source の後続として target を設定できるか (BE assertSuccessorAvailable のミラー)。
+ * 同一制作物・自己参照禁止・active・他から後続参照されていない・直接循環なし。
+ */
+function isValidLinkTarget(source: Plan, target: Plan, itemPlans: Plan[]): boolean {
+  if (target.id === source.id) return false;
+  if (target.itemId !== source.itemId) return false;
+  if (target.status !== 'active') return false;
+  if (itemPlans.some((p) => p.id !== source.id && p.successorPlanId === target.id)) return false;
+  // target のチェーンが source へ戻る場合は循環になるので不可
+  const byId = new Map(itemPlans.map((p) => [p.id, p]));
+  const seen = new Set<string>();
+  let cur: Plan | undefined = target;
+  while (cur && !seen.has(cur.id)) {
+    seen.add(cur.id);
+    if (cur.id === source.id) return false;
+    cur = cur.successorPlanId ? byId.get(cur.successorPlanId) : undefined;
+  }
+  return true;
+}
+
 function ScheduleBoard({
   days,
   items,
@@ -309,6 +349,7 @@ function ScheduleBoard({
   onOpenDetail,
   onMove,
   onResize,
+  onLink,
 }: {
   days: Date[];
   items: ProjectItem[];
@@ -318,11 +359,61 @@ function ScheduleBoard({
   onOpenDetail: (planId: string) => void;
   onMove: (plan: Plan, dayDelta: number) => void;
   onResize: (plan: Plan, edge: 'top' | 'bottom', dayDelta: number) => void;
+  onLink: (source: Plan, target: Plan) => void;
 }) {
   const today = new Date();
   const [drag, setDrag] = useState<DragState | null>(null);
   const dragRef = useRef<DragState | null>(null);
   dragRef.current = drag;
+
+  // 後続紐づけドラッグ
+  const [linkDrag, setLinkDrag] = useState<LinkDrag | null>(null);
+  const linkRef = useRef<LinkDrag | null>(null);
+  linkRef.current = linkDrag;
+
+  const startLink = (e: React.PointerEvent, plan: Plan) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setLinkDrag({
+      source: plan,
+      start: { x: e.clientX, y: e.clientY },
+      pointer: { x: e.clientX, y: e.clientY },
+      targetId: null,
+    });
+  };
+
+  useEffect(() => {
+    if (!linkDrag) return;
+    const onMovePointer = (e: PointerEvent) => {
+      const ld = linkRef.current;
+      if (!ld) return;
+      const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
+      const chip = el?.closest('[data-plan-id]') as HTMLElement | null;
+      const overId = chip?.getAttribute('data-plan-id') ?? null;
+      const itemPlans = plansByItem.get(ld.source.itemId) ?? [];
+      let targetId: string | null = null;
+      if (overId && overId !== ld.source.id) {
+        const target = itemPlans.find((p) => p.id === overId);
+        if (target && isValidLinkTarget(ld.source, target, itemPlans)) targetId = overId;
+      }
+      setLinkDrag({ ...ld, pointer: { x: e.clientX, y: e.clientY }, targetId });
+    };
+    const onUpPointer = () => {
+      const ld = linkRef.current;
+      setLinkDrag(null);
+      if (ld && ld.targetId) {
+        const itemPlans = plansByItem.get(ld.source.itemId) ?? [];
+        const target = itemPlans.find((p) => p.id === ld.targetId);
+        if (target) onLink(ld.source, target);
+      }
+    };
+    window.addEventListener('pointermove', onMovePointer);
+    window.addEventListener('pointerup', onUpPointer);
+    return () => {
+      window.removeEventListener('pointermove', onMovePointer);
+      window.removeEventListener('pointerup', onUpPointer);
+    };
+  }, [linkDrag, plansByItem, onLink]);
 
   // 空セルの縦ドラッグで期間付き新規作成
   type CreateDrag = { itemId: string; startIdx: number; endIdx: number };
@@ -402,6 +493,7 @@ function ScheduleBoard({
   );
 
   return (
+    <>
     <div className="flex-1 overflow-auto">
       <div className="flex w-max select-none">
         {/* 日付軸 (sticky left) */}
@@ -527,6 +619,16 @@ function ScheduleBoard({
                   );
                 })}
 
+                {/* 後続リンク (同一列内) を線で可視化 */}
+                <LinkLayer
+                  plans={itemPlans}
+                  laneOf={laneOf}
+                  days={days}
+                  rowHeight={rowHeight}
+                  width={colWidth}
+                  height={totalHeight}
+                />
+
                 {/* ボール */}
                 {itemPlans.map((plan) => (
                   <BallChip
@@ -537,7 +639,9 @@ function ScheduleBoard({
                     lane={laneOf.get(plan.id) ?? 0}
                     today={today}
                     drag={drag?.plan.id === plan.id ? drag : null}
+                    linkTarget={linkDrag?.targetId === plan.id}
                     onActivate={() => onOpenDetail(plan.id)}
+                    onPointerDownConnector={(e) => startLink(e, plan)}
                     onPointerDownBall={(e, mode) => {
                       e.stopPropagation();
                       if (plan.status !== 'active' && mode !== 'move') return;
@@ -557,6 +661,94 @@ function ScheduleBoard({
         })}
       </div>
     </div>
+
+      {/* 紐づけドラッグのプレビュー線 (ビューポート基準) */}
+      {linkDrag && (
+        <svg className="pointer-events-none fixed inset-0 z-50 h-full w-full">
+          <line
+            x1={linkDrag.start.x}
+            y1={linkDrag.start.y}
+            x2={linkDrag.pointer.x}
+            y2={linkDrag.pointer.y}
+            strokeWidth={2}
+            strokeDasharray="4 3"
+            className={linkDrag.targetId ? 'stroke-primary' : 'stroke-muted-foreground'}
+          />
+        </svg>
+      )}
+    </>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// 後続リンク描画 (列内 SVG オーバーレイ)
+// -----------------------------------------------------------------------------
+
+function chipCenters(plan: Plan, days: Date[], rowHeight: number, laneOf: Map<string, number>) {
+  const { start, end } = planRange(plan);
+  const startIdx = dayIndex(days, start);
+  const endIdx = dayIndex(days, end);
+  const top = startIdx * rowHeight + 1;
+  const height = (endIdx - startIdx + 1) * rowHeight - 3;
+  const lane = laneOf.get(plan.id) ?? 0;
+  const cx = lane * LANE_WIDTH + 6 + (LANE_WIDTH - 12) / 2;
+  return { cx, top, bottom: top + height };
+}
+
+function LinkLayer({
+  plans,
+  laneOf,
+  days,
+  rowHeight,
+  width,
+  height,
+}: {
+  plans: Plan[];
+  laneOf: Map<string, number>;
+  days: Date[];
+  rowHeight: number;
+  width: number;
+  height: number;
+}) {
+  const byId = new Map(plans.map((p) => [p.id, p]));
+  const links: { x1: number; y1: number; x2: number; y2: number }[] = [];
+  for (const p of plans) {
+    if (!p.successorPlanId) continue;
+    const succ = byId.get(p.successorPlanId);
+    if (!succ) continue; // 別制作物 or 未ロード
+    const a = chipCenters(p, days, rowHeight, laneOf);
+    const b = chipCenters(succ, days, rowHeight, laneOf);
+    links.push({ x1: a.cx, y1: a.bottom, x2: b.cx, y2: b.top });
+  }
+  if (links.length === 0) return null;
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0 z-0"
+      width={width}
+      height={height}
+      style={{ overflow: 'visible' }}
+      aria-hidden
+    >
+      <defs>
+        <marker id="succ-arrow" markerWidth="6" markerHeight="6" refX="4.5" refY="3" orient="auto">
+          <path d="M0,0 L6,3 L0,6 Z" className="fill-sky-400" />
+        </marker>
+      </defs>
+      {links.map((l, i) => {
+        const midY = (l.y1 + l.y2) / 2;
+        const d = `M ${l.x1} ${l.y1} C ${l.x1} ${midY}, ${l.x2} ${midY}, ${l.x2} ${l.y2}`;
+        return (
+          <path
+            key={i}
+            d={d}
+            strokeWidth={1.5}
+            strokeDasharray="3 3"
+            markerEnd="url(#succ-arrow)"
+            className="fill-none stroke-sky-400"
+          />
+        );
+      })}
+    </svg>
   );
 }
 
@@ -571,8 +763,10 @@ function BallChip({
   lane,
   today,
   drag,
+  linkTarget,
   onActivate,
   onPointerDownBall,
+  onPointerDownConnector,
 }: {
   plan: Plan;
   days: Date[];
@@ -580,8 +774,10 @@ function BallChip({
   lane: number;
   today: Date;
   drag: DragState | null;
+  linkTarget: boolean;
   onActivate: () => void;
   onPointerDownBall: (e: React.PointerEvent, mode: DragState['mode']) => void;
+  onPointerDownConnector: (e: React.PointerEvent) => void;
 }) {
   const { start, end } = planRange(plan);
   let startIdx = dayIndex(days, start);
@@ -628,11 +824,13 @@ function BallChip({
           onActivate(); // キーボードでは詳細を開く (移動はマウスのみ)
         }
       }}
+      data-plan-id={plan.id}
       onPointerDown={(e) => onPointerDownBall(e, 'move')}
       className={cn(
-        'absolute overflow-hidden rounded-md border px-2 py-1 text-xs shadow-sm',
+        'group absolute overflow-hidden rounded-md border px-2 py-1 text-xs shadow-sm',
         cardClass,
         active && !completed && 'ring-2 ring-primary/40',
+        linkTarget && 'ring-2 ring-primary ring-offset-1',
         drag?.mode === 'move' && 'opacity-70',
         editable ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
       )}
@@ -690,6 +888,16 @@ function BallChip({
         <div
           onPointerDown={(e) => onPointerDownBall(e, 'resize-bottom')}
           className="absolute inset-x-0 bottom-0 h-1.5 cursor-ns-resize"
+          aria-hidden
+        />
+      )}
+
+      {/* 後続紐づけコネクタ (下端中央): ドラッグして別カードに重ねると後続に設定 */}
+      {editable && tier !== 'mini' && (
+        <div
+          onPointerDown={onPointerDownConnector}
+          className="absolute bottom-0 left-1/2 z-10 size-3 -translate-x-1/2 cursor-crosshair rounded-full border-2 border-background bg-sky-500 opacity-0 shadow transition-opacity group-hover:opacity-100"
+          title="ドラッグして後続タスクに紐づけ"
           aria-hidden
         />
       )}

--- a/apps/web/src/features/plans/PlanModalsHost.tsx
+++ b/apps/web/src/features/plans/PlanModalsHost.tsx
@@ -67,6 +67,7 @@ export function PlanModalsHost({
         itemId={planItemId ?? fallbackItemId}
         planId={planId}
         members={members}
+        plans={plans}
         onClose={closeModal}
         onEdit={() => {
           setParams(

--- a/apps/web/src/features/plans/useOptimisticBallAction.ts
+++ b/apps/web/src/features/plans/useOptimisticBallAction.ts
@@ -86,6 +86,32 @@ export function useTossPlan(input: { projectId: string; itemId: string; planId: 
   });
 }
 
+/**
+ * 後続予定 (successorPlanId) の紐づけ / 解除。
+ * - スケジュールのドラッグ紐づけ・モーダルの解除で共用するため projectId のみ固定し、
+ *   itemId / planId / successorPlanId は mutate 引数で受ける。
+ * - 楽観更新はせず onSuccess で再フェッチ (BE 真値で正当化)。
+ */
+export function useSetSuccessor(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation<
+    Plan,
+    ApiClientError,
+    { itemId: string; planId: string; successorPlanId: string | null }
+  >({
+    mutationFn: ({ itemId, planId, successorPlanId }) =>
+      plansApi.setSuccessor(projectId, itemId, planId, successorPlanId),
+    onSuccess: (_plan, { itemId, planId, successorPlanId }) => {
+      qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+      qc.invalidateQueries({ queryKey: plansQueryKey.detail(projectId, itemId, planId) });
+      qc.invalidateQueries({ queryKey: plansQueryKey.projectList(projectId) });
+      toast.success(successorPlanId ? '後続を紐づけました' : '後続の紐づけを解除しました');
+    },
+    onError: (err) =>
+      toast.error(err instanceof ApiClientError ? err.message : '後続の更新に失敗しました'),
+  });
+}
+
 export function useCompletePlan(input: { projectId: string; itemId: string; planId: string }) {
   const qc = useQueryClient();
   const listKey = plansQueryKey.list(input.projectId, input.itemId);


### PR DESCRIPTION
## 背景

制作物列スケジュールには「予定(plan)」をボールに見立てたトス/完了フローがあり、各予定は後続タスク(`successorPlanId`)を1件持てて、完了すると後続が自動トスされる仕組みが**バックエンドに既に実装済み**。一方UIには次の課題があった:

1. 予定確認モーダルの終端アクションが「完了する」のみで、後続へ流れが続くことが伝わらない。
2. 後続タスクの設定が編集モーダルのセレクトのみで直感的でない。

本PRは**フロントエンドUIのみ**の追加で、バックエンドは無変更。

## 変更内容

### ① 予定確認モーダルの「次のタスクへトス / 完了」出し分け
`BallDetailModal.tsx` / `PlanModalsHost.tsx`
- ボールが TO 担当者に渡った状態で、**後続ありはボタンを「次のタスクへトス」**・**なしは「完了する」**に出し分け(裏側は既存 `completePlan`)。
- 詳細に「次のタスク: ○○」行を追加し、その場で**紐づけ解除**可能に。
- 既存の担当者間 TOSS / 差し戻しは維持。

### ② スケジュール上のドラッグで後続を紐づけ＋線で可視化
`ItemSchedulePage.tsx`
- カード下端中央に**専用コネクタ(ノブ)**を追加。ドラッグして同一制作物列の別カードに重ねると後続に設定。
- **既存の後続リンクを SVG の線＋矢印で可視化**(列内オーバーレイ)。ドラッグ中はプレビュー線＋有効ターゲットのハイライト。
- バリデーションは BE の `assertSuccessorAvailable` をフロントでミラー(同一制作物・自己参照禁止・active・他から未参照・循環なし)。

### 共通基盤
- `useOptimisticBallAction.ts` に `useSetSuccessor` フックを新設し、紐づけ/解除を両画面で再利用(既存 `plansApi.setSuccessor` を利用)。

## 確認

- `pnpm --filter web type-check` ✅
- `eslint`(変更ファイル) ✅
- `pnpm --filter web test`(56件) ✅
- 実機確認は未実施(ローカル Supabase 起動が必要)。要確認:
  1. 後続あり予定のモーダルが「次のタスクへトス」/ なしが「完了する」になること
  2. カード下端ノブを別カードにドラッグ→線が描かれ「後続を紐づけました」、別制作物や参照済みカードには紐づかないこと
  3. モーダルの解除で線が消えること
  4. 回帰: 下端リサイズ(期日変更)・日程ドラッグ移動が従来どおり動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)