### PR TITLE
fix(plans): 予定モーダルでディレクターもトス/完了できるようにする

### DIFF
--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -28,6 +28,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { ApiClientError } from '@/lib/api';
 import { useCurrentUser } from '@/features/auth/useCurrentUser';
 import type { ProjectMember } from '@/features/projects/membersApi';
+import { projectsApi, projectsQueryKey } from '@/features/projects/api';
 import { plansApi, plansQueryKey, type BallEvent, type Plan } from './api';
 import { CATEGORY_STYLE } from './categoryColor';
 import { useCompletePlan, useSetSuccessor, useTossPlan } from './useOptimisticBallAction';
@@ -65,6 +66,14 @@ export function BallDetailModal({
     queryKey: plansQueryKey.detail(projectId, itemId, planId),
     queryFn: () => plansApi.get(projectId, itemId, planId),
   });
+
+  // ディレクター (プロジェクト作成者) は保持者でなくてもトス/完了できる。
+  // スケジュール側では同じ query key で既に取得済みのためキャッシュヒットになる。
+  const projectQuery = useQuery({
+    queryKey: projectsQueryKey.detail(projectId),
+    queryFn: () => projectsApi.get(projectId),
+  });
+  const isDirector = projectQuery.data?.role === 'director';
 
   const tossMut = useTossPlan({ projectId, itemId, planId });
   const completeMut = useCompletePlan({ projectId, itemId, planId });
@@ -110,7 +119,7 @@ export function BallDetailModal({
             const { plan, events } = detailQuery.data;
             const isBallHolder =
               !!plan.ballHolder && !!myMember && plan.ballHolder.id === myMember.id;
-            const canAct = plan.status === 'active' && (isBallHolder /* director は BE 側で許可 */);
+            const canAct = plan.status === 'active' && (isBallHolder || isDirector);
             const style = CATEGORY_STYLE[plan.category];
             const successor = plan.successorPlanId
               ? (plans.find((p) => p.id === plan.successorPlanId) ?? null)


### PR DESCRIPTION
## 背景

実機確認で、予定確認モーダル（BallDetailModal）から**トス/完了ボタンが表示されない**問題が判明。スクリーンショットでは、ログインユーザー（プロジェクト作成者＝ディレクター）がボール保持者ではないため、アクションが一切出なかった。

根因: `canAct = plan.status === 'active' && isBallHolder` が**ボール保持者本人のみ**を許可していた。バックエンド（`ballActions.ts` の `tossPlan`/`completePlan`/`undoTossPlan`）は「保持者**または**ディレクター」を許可しているのに、フロントがディレクター判定をしておらず、コメントに `/* director は BE 側で許可 */` とあるだけで未実装だった。

## 変更内容

`BallDetailModal` 自身が `projectsApi.get` で `ProjectDetail.role`（`'director' | 'member'`、BE 側は `project.createdBy === userId` で算出）を取得し、`isDirector` を `canAct` に OR で加える:

```ts
const isDirector = projectQuery.data?.role === 'director';
const canAct = plan.status === 'active' && (isBallHolder || isDirector);
```

- `PlanModalsHost` 経由で2箇所（スケジュール・メンバーかんばん）から使われるため、props で流すよりモーダル自身が取得する方が堅牢。スケジュール側は同一 query key で既にキャッシュ済みのため追加リクエストなし。
- これでディレクターにも「TOSS する」「次のタスクへトス / 完了する」「差し戻す」が表示・実行できる。BE は元から許可済みのため整合。

## 補足

- 「FROM/TO/後続の編集が戻った」件は調査の結果、編集機能は既に **#41** で main にマージ済み。当時テストされていた旧 main 基準の #43 ブランチに #41 が含まれていなかったため戻ったように見えたもので、現在の main には存在する。本PRに編集機能の差分は含まれない（リベースで冗長分は除外済み）。
- スコープ外: メンバーかんばん（MemberKanbanTab）はトス/完了を全員に表示しており保持者でない一般メンバーが押すと 403 になるが、今回の依頼（モーダル）とは別問題のため未対応。

## 確認

- `pnpm --filter web type-check` ✅ / eslint ✅ / `pnpm --filter web test`（61件）✅
- 実機確認推奨: ディレクターで保持者でない予定を開き、ready なら「TOSS する」、tossed なら「次のタスクへトス/完了する」「差し戻す」が表示・実行できること。保持者でもディレクターでもない一般メンバーには表示されないこと。

🤖 Generated with [Claude Code](https://claude.com/claude-code)