### PR TITLE
feat(share): 共有リンクの有効期限を既定1週間+無期限可に (#69)

### DIFF
--- a/apps/web/server/schemas/shareLinks.test.ts
+++ b/apps/web/server/schemas/shareLinks.test.ts
@@ -41,4 +41,19 @@ describe('createShareLinkBodySchema', () => {
     });
     expect(r.success).toBe(false);
   });
+
+  it('defaults expiresInHours to 168h (1 week)', () => {
+    const r = createShareLinkBodySchema.safeParse({ scopeType: 'project' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.expiresInHours).toBe(168);
+  });
+
+  it('accepts null expiresInHours (no expiry)', () => {
+    const r = createShareLinkBodySchema.safeParse({
+      scopeType: 'project',
+      expiresInHours: null,
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.expiresInHours).toBeNull();
+  });
 });

--- a/apps/web/server/schemas/shareLinks.ts
+++ b/apps/web/server/schemas/shareLinks.ts
@@ -8,7 +8,8 @@ export const createShareLinkBodySchema = z
   .object({
     scopeType: shareScopeSchema,
     scopeTargetId: z.string().uuid().optional(),
-    expiresInHours: z.number().int().min(1).max(24 * 30).default(72),
+    // null = 無期限 (有効期限なし)。デフォルト 168h(1週間)、上限 720h(30日)
+    expiresInHours: z.number().int().min(1).max(24 * 30).nullable().default(168),
   })
   .superRefine((v, ctx) => {
     if (v.scopeType === 'project' && v.scopeTargetId !== undefined) {

--- a/apps/web/server/services/shareAccess.ts
+++ b/apps/web/server/services/shareAccess.ts
@@ -10,7 +10,8 @@ export type ShareViewDTO = {
     id: string;
     scopeType: 'project' | 'item' | 'plan';
     scopeTargetId: string | null;
-    expiresAt: string;
+    /** null = 無期限 */
+    expiresAt: string | null;
   };
   project: { id: string; name: string };
   items: Array<{ id: string; name: string }>;
@@ -93,7 +94,7 @@ export async function viewShare(input: {
       id: share.id,
       scopeType: share.scopeType as 'project' | 'item' | 'plan',
       scopeTargetId: share.scopeTargetId,
-      expiresAt: share.expiresAt.toISOString(),
+      expiresAt: share.expiresAt?.toISOString() ?? null,
     },
     project: { id: project.id, name: project.name },
     items: items.map((it) => ({ id: it.id, name: it.name })),

--- a/apps/web/server/services/shareLinks.ts
+++ b/apps/web/server/services/shareLinks.ts
@@ -12,7 +12,8 @@ export type ShareLinkDTO = {
   scopeTargetId: string | null;
   issuedByMemberId: string;
   issuedAt: string;
-  expiresAt: string;
+  /** null = 無期限 */
+  expiresAt: string | null;
   revokedAt: string | null;
   lastAccessedAt: string | null;
   status: 'active' | 'revoked' | 'expired';
@@ -26,10 +27,10 @@ export type CreateShareLinkResult = {
   url: string;
 };
 
-function statusOf(r: { revokedAt: Date | null; expiresAt: Date }): ShareLinkDTO['status'] {
+function statusOf(r: { revokedAt: Date | null; expiresAt: Date | null }): ShareLinkDTO['status'] {
   if (r.revokedAt) return 'revoked';
-  if (r.expiresAt.getTime() <= Date.now()) return 'expired';
-  return 'active';
+  if (r.expiresAt && r.expiresAt.getTime() <= Date.now()) return 'expired';
+  return 'active'; // expiresAt が null なら無期限
 }
 
 function toDTO(r: {
@@ -39,7 +40,7 @@ function toDTO(r: {
   scopeTargetId: string | null;
   issuedByMemberId: string;
   issuedAt: Date;
-  expiresAt: Date;
+  expiresAt: Date | null;
   revokedAt: Date | null;
   lastAccessedAt: Date | null;
 }): ShareLinkDTO {
@@ -50,7 +51,7 @@ function toDTO(r: {
     scopeTargetId: r.scopeTargetId,
     issuedByMemberId: r.issuedByMemberId,
     issuedAt: r.issuedAt.toISOString(),
-    expiresAt: r.expiresAt.toISOString(),
+    expiresAt: r.expiresAt?.toISOString() ?? null,
     revokedAt: r.revokedAt?.toISOString() ?? null,
     lastAccessedAt: r.lastAccessedAt?.toISOString() ?? null,
     status: statusOf(r),
@@ -90,7 +91,11 @@ export async function createShareLink(input: {
   }
 
   const { raw, hash } = generateInvitationToken();
-  const expiresAt = new Date(Date.now() + body.expiresInHours * 60 * 60 * 1000);
+  // expiresInHours が null の場合は無期限 (expiresAt = null)
+  const expiresAt =
+    body.expiresInHours == null
+      ? null
+      : new Date(Date.now() + body.expiresInHours * 60 * 60 * 1000);
   const created = await prisma.shareLink.create({
     data: {
       projectId: input.projectId,
@@ -160,7 +165,8 @@ export async function findActiveShareLinkByRawToken(rawToken: string) {
     where: {
       tokenHash: hash,
       revokedAt: null,
-      expiresAt: { gt: new Date() },
+      // expiresAt が null (無期限) または未来日のものを有効とみなす
+      OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
     },
   });
   if (!row) {

--- a/apps/web/src/features/shareLinks/ShareLinksPage.tsx
+++ b/apps/web/src/features/shareLinks/ShareLinksPage.tsx
@@ -138,7 +138,9 @@ function Inner({ projectId }: { projectId: string }) {
                     </span>
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    期限 {format(new Date(s.expiresAt), 'yyyy/M/d HH:mm')}
+                    {s.expiresAt
+                      ? `期限 ${format(new Date(s.expiresAt), 'yyyy/M/d HH:mm')}`
+                      : '期限 無期限'}
                     {s.lastAccessedAt &&
                       ` ・ 最終アクセス ${format(new Date(s.lastAccessedAt), 'M/d HH:mm')}`}
                   </p>
@@ -215,7 +217,8 @@ function CreateDialog({
 }) {
   const [scope, setScope] = useState<'project' | 'item'>('project');
   const [itemId, setItemId] = useState<string>('');
-  const [hours, setHours] = useState<number>(72);
+  // 有効期限プリセット (null = 無期限)。デフォルトは 1週間
+  const [hours, setHours] = useState<number | null>(168);
 
   const createMut = useMutation({
     mutationFn: () =>
@@ -275,15 +278,22 @@ function CreateDialog({
             </div>
           )}
           <div className="space-y-1.5">
-            <Label>有効期限 (時間)</Label>
-            <Input
-              type="number"
-              min={1}
-              max={24 * 30}
-              value={hours}
-              onChange={(e) => setHours(Number(e.target.value) || 72)}
-            />
-            <p className="text-[11px] text-muted-foreground">最大 30 日 (720 時間)</p>
+            <Label>有効期限</Label>
+            <Select
+              value={hours === null ? 'none' : String(hours)}
+              onValueChange={(v) => setHours(v === 'none' ? null : Number(v))}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="24">1日</SelectItem>
+                <SelectItem value="72">3日</SelectItem>
+                <SelectItem value="168">1週間</SelectItem>
+                <SelectItem value="720">30日</SelectItem>
+                <SelectItem value="none">無期限</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
         </div>
         <DialogFooter>

--- a/apps/web/src/features/shareLinks/SharePage.tsx
+++ b/apps/web/src/features/shareLinks/SharePage.tsx
@@ -110,7 +110,9 @@ function Layout({ view, children }: { view: ShareView; children: React.ReactNode
           </div>
           <h1 className="text-xl font-semibold tracking-tight">{view.project.name}</h1>
           <p className="text-xs text-muted-foreground">
-            有効期限 {format(new Date(view.share.expiresAt), 'yyyy/M/d HH:mm')} まで
+            {view.share.expiresAt
+              ? `有効期限 ${format(new Date(view.share.expiresAt), 'yyyy/M/d HH:mm')} まで`
+              : '有効期限なし (無期限)'}
           </p>
         </div>
         <Badge variant="secondary">

--- a/apps/web/src/features/shareLinks/api.ts
+++ b/apps/web/src/features/shareLinks/api.ts
@@ -10,7 +10,8 @@ export type ShareLink = {
   scopeTargetId: string | null;
   issuedByMemberId: string;
   issuedAt: string;
-  expiresAt: string;
+  /** null = 無期限 */
+  expiresAt: string | null;
   revokedAt: string | null;
   lastAccessedAt: string | null;
   status: 'active' | 'revoked' | 'expired';
@@ -25,7 +26,8 @@ export type CreateShareLinkResult = {
 export type CreateShareLinkInput = {
   scopeType: ShareScope;
   scopeTargetId?: string;
-  expiresInHours?: number;
+  /** null = 無期限 */
+  expiresInHours?: number | null;
 };
 
 export type ShareView = {
@@ -33,7 +35,8 @@ export type ShareView = {
     id: string;
     scopeType: ShareScope;
     scopeTargetId: string | null;
-    expiresAt: string;
+    /** null = 無期限 */
+    expiresAt: string | null;
   };
   project: { id: string; name: string };
   items: Array<{ id: string; name: string }>;

--- a/packages/db/prisma/migrations/20260620000001_share_link_nullable_expiry/migration.sql
+++ b/packages/db/prisma/migrations/20260620000001_share_link_nullable_expiry/migration.sql
@@ -1,0 +1,9 @@
+-- -----------------------------------------------------------------------------
+-- Migration: 20260620000001_share_link_nullable_expiry
+-- share_links.expires_at を NULL 許容にする (NULL = 無期限 / 有効期限なし)
+--  - 共有リンク発行時に「有効期限を設定しない」選択を可能にする (#69)
+--  - CHECK 制約 ck_sl_expires_after_issued ("expires_at" > "issued_at") は
+--    NULL 比較が UNKNOWN → CHECK は FALSE でない限り通過するため変更不要。
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE "share_links" ALTER COLUMN "expires_at" DROP NOT NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -297,7 +297,8 @@ model ShareLink {
   tokenHash        String    @unique(map: "uq_sl_token_hash") @map("token_hash")
   issuedByMemberId String    @map("issued_by_member_id") @db.Uuid
   issuedAt         DateTime  @default(now()) @map("issued_at") @db.Timestamptz
-  expiresAt        DateTime  @map("expires_at") @db.Timestamptz
+  /// NULL = 無期限 (有効期限なし)
+  expiresAt        DateTime? @map("expires_at") @db.Timestamptz
   revokedAt        DateTime? @map("revoked_at") @db.Timestamptz
   lastAccessedAt   DateTime? @map("last_accessed_at") @db.Timestamptz
 


### PR DESCRIPTION
## 対応 issue
Closes #69

## 概要
共有リンクの有効期限について、(1) デフォルトを 72時間 → **1週間** に変更、(2) **無期限**（有効期限を設定しない）リンクの発行を可能にした。

## 変更内容
### BE / DB
- `share_links.expires_at` を NULL 許容化（マイグレーション `20260620000001_share_link_nullable_expiry` + Prisma schema `DateTime?`）。NULL = 無期限。
- `createShareLinkBodySchema.expiresInHours`: 既定 168（1週間）、`null`（無期限）を許可、上限 720h（30日）維持。
- `services/shareLinks.ts`: `createShareLink` で null→無期限、`statusOf` / `findActiveShareLinkByRawToken` / DTO を null 対応（無期限リンクは期限切れにならない）。
- `services/shareAccess.ts`: 共有閲覧 DTO の `expiresAt` を nullable に。

### FE
- 発行ダイアログの有効期限を **プリセット選択**（1日 / 3日 / 1週間 / 30日 / 無期限）に変更。デフォルト「1週間」。
- 共有リンク一覧・`/share/:token` 閲覧ページで無期限を「無期限」表示。

## 検証
- `pnpm db:generate` / `prisma format` ✅
- `pnpm --filter @trakon/web type-check` / `lint`（zero-warnings）✅
- `pnpm --filter @trakon/web test share`（10 tests）✅ — 無期限/既定168hのバリデーションテストを追加

> 注: 本番反映時はリリースの `prisma migrate deploy` で `expires_at` の NOT NULL 解除が適用されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)