### PR TITLE
fix(projects): プロジェクト情報ページの戻る導線を改善 (#68)

### DIFF
--- a/apps/web/src/features/projects/ProjectEditPage.tsx
+++ b/apps/web/src/features/projects/ProjectEditPage.tsx
@@ -99,10 +99,18 @@ function ProjectEditInner({ projectId, onBack }: { projectId: string; onBack: ()
         title={project.name}
         description="プロジェクト設定"
         actions={
-          <Button variant="ghost" size="sm" onClick={onBack}>
-            <ArrowLeft className="size-4" />
-            一覧に戻る
-          </Button>
+          <div className="flex items-center gap-1">
+            <Button variant="ghost" size="sm" asChild>
+              <Link to={`/projects/${projectId}`}>
+                <CalendarDays className="size-4" />
+                スケジュール
+              </Link>
+            </Button>
+            <Button variant="ghost" size="sm" onClick={onBack}>
+              <ArrowLeft className="size-4" />
+              プロジェクト一覧に戻る
+            </Button>
+          </div>
         }
       />
       <PageContainer width="md">
@@ -398,7 +406,7 @@ function NotFound() {
       <AlertCircle className="size-8 text-muted-foreground" />
       <p className="text-sm text-muted-foreground">プロジェクトが見つかりませんでした。</p>
       <Button asChild variant="outline" size="sm">
-        <Link to="/projects">一覧に戻る</Link>
+        <Link to="/projects">プロジェクト一覧に戻る</Link>
       </Button>
     </div>
   );


### PR DESCRIPTION
## 対応 issue
Closes #68

## 概要
プロジェクト情報ページ（`/projects/:projectId/edit`）上部の導線を改善。

## 変更内容
- 「一覧に戻る」→「**プロジェクト一覧に戻る**」に文言変更。
- 上部に「**スケジュール**」ボタンを追加（`/projects/:projectId` 経由で当該プロジェクトのスケジュールへ遷移）。スケジュールページから遷移してきたケースに対応。
- `NotFound` の戻るボタン文言も合わせて変更。

## 検証
- `pnpm --filter @trakon/web type-check` / `lint`（zero-warnings）✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)