### PR TITLE
fix(ui): トーストを画面下中央に表示 (#60)

### DIFF
--- a/apps/web/src/app/SidebarLayout.tsx
+++ b/apps/web/src/app/SidebarLayout.tsx
@@ -146,7 +146,7 @@ export function SidebarLayout() {
         />
       )}
 
-      <Toaster richColors position="top-right" />
+      <Toaster richColors position="bottom-center" />
     </div>
   );
 }


### PR DESCRIPTION
Closes #60

## 概要
通知トースト(sonner)の表示位置を画面右上(top-right)から**画面下中央(bottom-center)**に変更。

## 変更内容
- `apps/web/src/app/SidebarLayout.tsx`: `<Toaster>` の `position` を変更。

## 検証
- `pnpm --filter @trakon/web type-check` / `lint`(zero-warnings) OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)