### PR TITLE
fix(schedule): 曜日を漢字表記に (#53)

### DIFF
--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { addDays, differenceInDays, format, isSameDay, isWeekend, parseISO } from 'date-fns';
+import { ja } from 'date-fns/locale';
 import { isHoliday } from '@holiday-jp/holiday_jp';
 import { CheckCircle2, KanbanSquare, Plus, Settings, ZoomIn, ZoomOut } from 'lucide-react';
 
@@ -529,7 +530,7 @@ function ScheduleBoard({
                         t.holiday && 'text-rose-500',
                       )}
                     >
-                      {format(d, 'EEEEE')}
+                      {format(d, 'EEEEE', { locale: ja })}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
Closes #53

## 概要
スケジュール画面の日付軸の曜日が英字(S/M/T…)で表示されていたため、漢字(日/月/火/水/木/金/土)に変更。

## 変更内容
- `apps/web/src/features/plans/ItemSchedulePage.tsx`: `format(d, 'EEEEE')` に date-fns の `ja` ロケールを適用。

## 検証
- type-check / lint (zero-warnings) OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)