### PR TITLE
fix(schedule): スケジュールのデフォルト表示を全制作物に (#49)

### DIFF
--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -61,9 +61,9 @@ export function ItemSchedulePage() {
 function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
   const [, setParams] = useSearchParams();
   const [rowHeight, setRowHeight] = useState(ROW_HEIGHT_DEFAULT);
-  // 表示する制作物: 'all' か特定 itemId。初期は URL の itemId にフォーカス。
-  const [viewItemId, setViewItemId] = useState<string>(itemId);
-  useEffect(() => setViewItemId(itemId), [itemId]);
+  // 表示する制作物: 'all' か特定 itemId。初期は全制作物 (#49)。
+  // 単一に絞る場合は画面内セレクタで選択する。
+  const [viewItemId, setViewItemId] = useState<string>('all');
 
   const projectQuery = useQuery({
     queryKey: projectsQueryKey.detail(projectId),
@@ -235,7 +235,7 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
                 <SelectValue placeholder="制作物" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">すべての制作物</SelectItem>
+                <SelectItem value="all">全て</SelectItem>
                 {items.map((i) => (
                   <SelectItem key={i.id} value={i.id}>
                     {i.name}


### PR DESCRIPTION
Closes #49

## 概要
スケジュール画面に入ると先頭1制作物しか表示されず、複数作成できているか直感的に分からなかった。デフォルトで**全制作物**を表示するようにし、セレクタのラベルを「全て」に変更。

## 変更内容
- `ItemSchedulePage.tsx`: 表示セレクタ `viewItemId` の初期値を `all` に変更し、URL の itemId へ自動追従していた useEffect を削除。
- セレクタ項目ラベル「すべての制作物」→「全て」。

既存の `all` 表示モード(複数列レンダリング)をそのまま活用しており、個別制作物への絞り込みは従来どおりセレクタで可能。

## 検証
- type-check / lint (zero-warnings) OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)