### PR TITLE
feat(ball): TOSS取消(差し戻し)を誰でも実行可に / 権限廃止 (#50)

### DIFF
--- a/apps/web/server/routes/v1/plans.ts
+++ b/apps/web/server/routes/v1/plans.ts
@@ -128,7 +128,6 @@ export const plansRoute = new Hono()
       planId,
       currentUserId: c.get('currentUserId'),
       currentMemberId: project.memberId,
-      isDirector: project.isDirector,
     });
     return c.json({ data: result });
   })

--- a/apps/web/server/services/ballActions.ts
+++ b/apps/web/server/services/ballActions.ts
@@ -246,7 +246,6 @@ export async function undoTossPlan(input: {
   planId: string;
   currentUserId: string;
   currentMemberId: string;
-  isDirector: boolean;
 }): Promise<{ plan: PlanDTO }> {
   const result = await prisma.$transaction(async (tx) => {
     const plan = await loadPlanWithIncludes(tx, input.planId, input.itemId);
@@ -258,15 +257,8 @@ export async function undoTossPlan(input: {
       throw new ApiException('NOT_TOSSED', 409, 'Ball is not in a tossed state.');
     }
 
-    // 認可: 現在の Ball Holder (= toMember, 差し戻す本人) または ディレクター
-    const holder = ballHolderMemberId(plan);
-    if (!input.isDirector && holder !== input.currentMemberId) {
-      throw new ApiException(
-        'FORBIDDEN',
-        403,
-        'Only the current ball holder or director can undo a toss.',
-      );
-    }
+    // 誤TOSSの救済として、プロジェクトメンバーなら誰でも差し戻し可能 (#50)。
+    // ボール保持者/ディレクター縛りは廃止 (ルートの requireProjectMember で担保)。
 
     // append-only のため、行削除ではなく toss_undone を追記して ready に戻す
     await tx.ballEvent.create({

--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -237,31 +237,32 @@ export function BallDetailModal({
                         TOSS する
                       </Button>
                     )}
+                    {/* 差し戻し(TOSS取消)は誤TOSS救済のため誰でも実行可 (#50) */}
+                    {plan.ballState === 'tossed' && (
+                      <Button
+                        variant="outline"
+                        onClick={() => undoMut.mutate()}
+                        disabled={undoMut.isPending}
+                      >
+                        {undoMut.isPending ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <Undo2 className="size-4" />
+                        )}
+                        差し戻す
+                      </Button>
+                    )}
                     {plan.ballState === 'tossed' && canAct && (
-                      <>
-                        <Button
-                          variant="outline"
-                          onClick={() => undoMut.mutate()}
-                          disabled={undoMut.isPending}
-                        >
-                          {undoMut.isPending ? (
-                            <Loader2 className="size-4 animate-spin" />
-                          ) : (
-                            <Undo2 className="size-4" />
-                          )}
-                          差し戻す
-                        </Button>
-                        <Button onClick={handleComplete} disabled={completeMut.isPending}>
-                          {completeMut.isPending ? (
-                            <Loader2 className="size-4 animate-spin" />
-                          ) : hasSuccessor ? (
-                            <Send className="size-4" />
-                          ) : (
-                            <CheckCircle2 className="size-4" />
-                          )}
-                          {hasSuccessor ? '次のタスクへトス' : '完了する'}
-                        </Button>
-                      </>
+                      <Button onClick={handleComplete} disabled={completeMut.isPending}>
+                        {completeMut.isPending ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : hasSuccessor ? (
+                          <Send className="size-4" />
+                        ) : (
+                          <CheckCircle2 className="size-4" />
+                        )}
+                        {hasSuccessor ? '次のタスクへトス' : '完了する'}
+                      </Button>
                     )}
                     <Button variant="outline" onClick={onClose}>
                       閉じる


### PR DESCRIPTION
## 対応 issue
Closes #50

## 概要
TOSS取消（差し戻し）機能自体は実装済みだったが、BE 認可で「現在のボール保持者(受け手)またはディレクター」しか取り消せず、誤TOSSの救済として不十分だった。

ユーザー判断（TRAKON は予定管理者側が操作するプロダクトで、受け手がログインして確認する想定ではない）に基づき、**差し戻しの権限を廃止**し、プロジェクトメンバーなら誰でも取り消せるようにした。

## 変更内容
- `services/ballActions.ts` `undoTossPlan`: ボール保持者/ディレクターの認可チェックを削除（状態チェックは維持）。入力から `isDirector` を除去。
- `routes/v1/plans.ts` `/:planId/toss-undo`: `isDirector` を渡すのをやめる。ルートの `requireProjectMember()` で「プロジェクトメンバーであること」は引き続き担保。
- `BallDetailModal.tsx`: 「差し戻す」ボタンを `canAct` に依らず `ballState === 'tossed'` なら常時表示。「完了/次へトス」は従来どおり。
- `MemberKanbanTab.tsx`: 既に tossed で常時表示のため変更なし（BE 緩和で実際に通るようになる）。

## 非対象
- toss / complete の認可は変更なし。
- メール通知（issue で「別途検討」）は別 issue で扱う。

## 検証
- type-check / lint(zero-warnings) / test（plans 20件）OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)