### PR TITLE
fix(plans): FROM/TOラベルを実施者/確認者に (#70)

### DIFF
--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -154,13 +154,13 @@ export function BallDetailModal({
                     <dd>{format(new Date(plan.scheduledDate), 'yyyy/M/d')}</dd>
                     <dt className="text-muted-foreground">終了日</dt>
                     <dd>{plan.dueDate ? format(new Date(plan.dueDate), 'yyyy/M/d') : '—'}</dd>
-                    <dt className="text-muted-foreground">FROM</dt>
+                    <dt className="text-muted-foreground">実施者(FROM)</dt>
                     <dd>
                       {plan.fromMember
                         ? `${plan.fromMember.name} (${plan.fromMember.organizationName || '—'})`
                         : '—'}
                     </dd>
-                    <dt className="text-muted-foreground">TO</dt>
+                    <dt className="text-muted-foreground">確認者(TO)</dt>
                     <dd>
                       {plan.toMember
                         ? `${plan.toMember.name} (${plan.toMember.organizationName || '—'})`

--- a/apps/web/src/features/plans/CreatePlanModal.tsx
+++ b/apps/web/src/features/plans/CreatePlanModal.tsx
@@ -44,14 +44,14 @@ const schema = z
     category: z.enum(PLAN_CATEGORIES.map((c) => c.value) as [PlanCategory, ...PlanCategory[]]),
     scheduledDate: isoDate,
     dueDate: z.union([isoDate, z.literal('')]).optional(),
-    fromMemberId: z.string().uuid('FROM を選択してください'),
-    toMemberId: z.string().uuid('TO を選択してください'),
+    fromMemberId: z.string().uuid('実施者(FROM) を選択してください'),
+    toMemberId: z.string().uuid('確認者(TO) を選択してください'),
     successorPlanId: z.string().optional(),
     memo: z.string().max(2000).optional(),
   })
   .refine((v) => v.fromMemberId !== v.toMemberId, {
     path: ['toMemberId'],
-    message: 'FROM と TO は異なるメンバーを選んでください',
+    message: '実施者(FROM)と確認者(TO)は異なるメンバーを選んでください',
   })
   .refine((v) => !v.dueDate || v.dueDate >= v.scheduledDate, {
     path: ['dueDate'],
@@ -204,7 +204,7 @@ export function CreatePlanModal({
 
           <div className="grid grid-cols-2 gap-3">
             <Field
-              label="FROM (現在のホルダー)"
+              label="実施者(FROM)"
               error={form.formState.errors.fromMemberId?.message}
             >
               <SelectField
@@ -215,7 +215,7 @@ export function CreatePlanModal({
                 placeholder="選択"
               />
             </Field>
-            <Field label="TO (次の担当)" error={form.formState.errors.toMemberId?.message}>
+            <Field label="確認者(TO)" error={form.formState.errors.toMemberId?.message}>
               <SelectField
                 value={form.watch('toMemberId') || undefined}
                 onChange={(v) => form.setValue('toMemberId', v)}
@@ -227,7 +227,7 @@ export function CreatePlanModal({
           </div>
           {mode === 'edit' && !fromToEditable && (
             <p className="text-[11px] text-muted-foreground">
-              TOSS 後のため FROM/TO は変更できません。
+              TOSS 後のため 実施者(FROM)/確認者(TO) は変更できません。
             </p>
           )}
 

--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -884,11 +884,11 @@ function BallChip({
       {tier === 'normal' && (
         <div className="mt-1 border-t border-current/10 pt-1 text-[10px] leading-tight">
           <div className="flex items-center gap-1">
-            <span className="opacity-60">FROM</span>
+            <span className="opacity-60">実施者</span>
             <span className="line-clamp-1 font-medium">{plan.fromMember?.name ?? '—'}</span>
           </div>
           <div className="flex items-center gap-1">
-            <span className="opacity-60">TO</span>
+            <span className="opacity-60">確認者</span>
             <span className="line-clamp-1 font-medium">{plan.toMember?.name ?? '—'}</span>
             {plan.ballHolder && (
               <Badge variant="secondary" className="ml-auto px-1 py-0 text-[9px]">


### PR DESCRIPTION
## 対応 issue
Closes #70

## 概要
予定の FROM/TO が実務上「タスクの実施者」「確認者」を表すことが伝わるよう、ラベルを変更。

## 変更内容
- 作成/編集フォーム（`CreatePlanModal.tsx`）: 「FROM (現在のホルダー)」→「実施者(FROM)」、「TO (次の担当)」→「確認者(TO)」。バリデーションメッセージ・TOSS後の注記も更新。
- 予定詳細（`BallDetailModal.tsx`）: 「FROM」→「実施者(FROM)」、「TO」→「確認者(TO)」。
- スケジュールカード（`ItemSchedulePage.tsx` BallChip）: 省スペースのため「実施者」「確認者」。

## 完了挙動の確認（issue 後半）
`completePlan`（`ballActions.ts`）は、後続(successor)が active かつ ready なら自動でボールを渡す（auto_chain）。FE のボタンも後続ありなら「次のタスクへトス」、なければ「完了する」と出し分け済み。**issue の考え方どおり動作することを確認**したため、完了関連のラベル・ロジックは現状維持。

## 検証
- type-check / lint(zero-warnings) OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)