### PR TITLE
feat(plans): 予定作成をタイトル+カテゴリのみで可能に (#55)

### DIFF
--- a/apps/web/server/schemas/plans.test.ts
+++ b/apps/web/server/schemas/plans.test.ts
@@ -20,6 +20,15 @@ describe('createPlanBodySchema', () => {
     expect(createPlanBodySchema.safeParse(base).success).toBe(true);
   });
 
+  it('accepts a body with only title + category + scheduledDate (no from/to)', () => {
+    const r = createPlanBodySchema.safeParse({
+      title: 'ワイヤー作成',
+      category: 'design',
+      scheduledDate: '2026-06-01',
+    });
+    expect(r.success).toBe(true);
+  });
+
   it('rejects identical from / to', () => {
     const r = createPlanBodySchema.safeParse({
       ...base,

--- a/apps/web/server/schemas/plans.ts
+++ b/apps/web/server/schemas/plans.ts
@@ -23,12 +23,13 @@ export const createPlanBodySchema = z
     category: planCategorySchema,
     scheduledDate: isoDate,
     dueDate: isoDate.optional(),
-    fromMemberId: uuid,
-    toMemberId: uuid,
+    // 実施者(FROM)/確認者(TO) は任意。後から設定できる (#55)
+    fromMemberId: uuid.optional(),
+    toMemberId: uuid.optional(),
     successorPlanId: uuid.optional(),
     memo: z.string().max(2000).optional(),
   })
-  .refine((v) => v.fromMemberId !== v.toMemberId, {
+  .refine((v) => !v.fromMemberId || !v.toMemberId || v.fromMemberId !== v.toMemberId, {
     path: ['toMemberId'],
     message: 'fromMemberId and toMemberId must differ.',
   })

--- a/apps/web/server/services/ballActions.ts
+++ b/apps/web/server/services/ballActions.ts
@@ -92,6 +92,14 @@ export async function tossPlan(input: {
     if (currentBallState(plan) !== 'ready') {
       throw new ApiException('ALREADY_TOSSED', 409, 'Ball has already been tossed.');
     }
+    // 実施者(FROM)/確認者(TO) 未設定の予定は TOSS できない (#55)
+    if (!plan.fromMemberId || !plan.toMemberId) {
+      throw new ApiException(
+        'INCOMPLETE_PLAN',
+        422,
+        '実施者(FROM)と確認者(TO)を設定してください。',
+      );
+    }
 
     // 認可: 現在の Ball Holder (= fromMember) または ディレクター
     const holder = ballHolderMemberId(plan);

--- a/apps/web/server/services/plans.ts
+++ b/apps/web/server/services/plans.ts
@@ -282,7 +282,10 @@ export async function createPlan(input: {
 }): Promise<PlanDTO> {
   await assertMembersBelongToProject({
     projectId: input.projectId,
-    memberIds: [input.body.fromMemberId, input.body.toMemberId],
+    // 任意項目のため、指定されたものだけ検証する (#55)
+    memberIds: [input.body.fromMemberId, input.body.toMemberId].filter(
+      (id): id is string => !!id,
+    ),
   });
   if (input.body.successorPlanId) {
     await assertSuccessorAvailable({
@@ -298,8 +301,8 @@ export async function createPlan(input: {
       category: input.body.category,
       scheduledDate: new Date(`${input.body.scheduledDate}T00:00:00Z`),
       dueDate: input.body.dueDate ? new Date(`${input.body.dueDate}T00:00:00Z`) : null,
-      fromMemberId: input.body.fromMemberId,
-      toMemberId: input.body.toMemberId,
+      fromMemberId: input.body.fromMemberId ?? null,
+      toMemberId: input.body.toMemberId ?? null,
       successorPlanId: input.body.successorPlanId ?? null,
       memo: input.body.memo ?? null,
     },

--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -227,7 +227,8 @@ export function BallDetailModal({
                     )}
                   </div>
                   <div className="flex gap-2">
-                    {plan.ballState === 'ready' && canAct && (
+                    {/* 実施者/確認者が揃って初めて TOSS 可能 (#55) */}
+                    {plan.ballState === 'ready' && canAct && plan.fromMember && plan.toMember && (
                       <Button onClick={handleToss} disabled={tossMut.isPending}>
                         {tossMut.isPending ? (
                           <Loader2 className="size-4 animate-spin" />
@@ -236,6 +237,11 @@ export function BallDetailModal({
                         )}
                         TOSS する
                       </Button>
+                    )}
+                    {plan.ballState === 'ready' && canAct && (!plan.fromMember || !plan.toMember) && (
+                      <span className="self-center text-[11px] text-muted-foreground">
+                        実施者・確認者を設定するとTOSSできます
+                      </span>
                     )}
                     {/* 差し戻し(TOSS取消)は誤TOSS救済のため誰でも実行可 (#50) */}
                     {plan.ballState === 'tossed' && (

--- a/apps/web/src/features/plans/CreatePlanModal.tsx
+++ b/apps/web/src/features/plans/CreatePlanModal.tsx
@@ -44,12 +44,13 @@ const schema = z
     category: z.enum(PLAN_CATEGORIES.map((c) => c.value) as [PlanCategory, ...PlanCategory[]]),
     scheduledDate: isoDate,
     dueDate: z.union([isoDate, z.literal('')]).optional(),
-    fromMemberId: z.string().uuid('実施者(FROM) を選択してください'),
-    toMemberId: z.string().uuid('確認者(TO) を選択してください'),
+    // 実施者/確認者は任意。後から設定できる (#55)
+    fromMemberId: z.union([z.string().uuid(), z.literal('')]).optional(),
+    toMemberId: z.union([z.string().uuid(), z.literal('')]).optional(),
     successorPlanId: z.string().optional(),
     memo: z.string().max(2000).optional(),
   })
-  .refine((v) => v.fromMemberId !== v.toMemberId, {
+  .refine((v) => !v.fromMemberId || !v.toMemberId || v.fromMemberId !== v.toMemberId, {
     path: ['toMemberId'],
     message: '実施者(FROM)と確認者(TO)は異なるメンバーを選んでください',
   })
@@ -121,8 +122,8 @@ export function CreatePlanModal({
         category: v.category,
         scheduledDate: v.scheduledDate,
         dueDate: v.dueDate || undefined,
-        fromMemberId: v.fromMemberId,
-        toMemberId: v.toMemberId,
+        fromMemberId: v.fromMemberId || undefined,
+        toMemberId: v.toMemberId || undefined,
         successorPlanId: v.successorPlanId || undefined,
         memo: v.memo || undefined,
       }),
@@ -148,7 +149,7 @@ export function CreatePlanModal({
         memo: v.memo ?? null,
         // FROM/TO は TOSS 前のみ送信 (ロック中はサーバ側でも拒否される)
         ...(fromToEditable
-          ? { fromMemberId: v.fromMemberId, toMemberId: v.toMemberId }
+          ? { fromMemberId: v.fromMemberId || undefined, toMemberId: v.toMemberId || undefined }
           : {}),
       });
     },
@@ -204,7 +205,7 @@ export function CreatePlanModal({
 
           <div className="grid grid-cols-2 gap-3">
             <Field
-              label="実施者(FROM)"
+              label="実施者(FROM)（任意）"
               error={form.formState.errors.fromMemberId?.message}
             >
               <SelectField
@@ -215,7 +216,7 @@ export function CreatePlanModal({
                 placeholder="選択"
               />
             </Field>
-            <Field label="確認者(TO)" error={form.formState.errors.toMemberId?.message}>
+            <Field label="確認者(TO)（任意）" error={form.formState.errors.toMemberId?.message}>
               <SelectField
                 value={form.watch('toMemberId') || undefined}
                 onChange={(v) => form.setValue('toMemberId', v)}

--- a/apps/web/src/features/plans/api.ts
+++ b/apps/web/src/features/plans/api.ts
@@ -73,8 +73,9 @@ export type CreatePlanInput = {
   category: PlanCategory;
   scheduledDate: string;
   dueDate?: string;
-  fromMemberId: string;
-  toMemberId: string;
+  // 実施者/確認者は任意 (#55)
+  fromMemberId?: string;
+  toMemberId?: string;
   successorPlanId?: string;
   memo?: string;
 };


### PR DESCRIPTION
## 対応 issue
Closes #55

## 概要
スケジュールをサクサク plot できるよう、予定作成の必須項目を **タイトル + カテゴリ** のみにした（開始日はセルクリック/既定で自動補完）。実施者(FROM)/確認者(TO) は任意とし、後から設定 → TOSS する運用。

DB の `from_member_id`/`to_member_id` は元々 nullable のためマイグレーション不要。`deriveBallHolder` も null を安全に処理（holder=null / state=ready）。

## 変更内容
### BE
- `createPlanBodySchema`: `fromMemberId`/`toMemberId` を optional 化。from≠to の検証は両方入力時のみ。
- `createPlan`: 未指定の from/to は null 保存、メンバー所属検証は指定分のみ。
- `tossPlan`: from/to 未設定の予定の TOSS を 422 (`INCOMPLETE_PLAN`) でガード。

### FE
- `CreatePlanModal`: from/to を任意化（空可）、ラベルに「（任意）」。送信時は空→undefined。
- `BallDetailModal`: from/to 未設定時は TOSS ボタンを出さず「実施者・確認者を設定するとTOSSできます」とヒント表示。
- `MemberKanbanTab` は既に `toMember` 存在を条件にしているため変更なし。

## 検証
- type-check / lint(zero-warnings) / test（plans 21件、from/to なし作成の成功ケース追加）OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)