### PR TITLE
fix(projects): プロジェクト一覧の導線とカード表示を改善 (#54)

### DIFF
--- a/apps/web/src/app/SidebarLayout.tsx
+++ b/apps/web/src/app/SidebarLayout.tsx
@@ -96,13 +96,17 @@ export function SidebarLayout() {
                 <span className="truncate">{p.name}</span>
               </NavLink>
             ))}
-            <NavLink
-              to="/projects"
-              className="mt-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
-            >
-              すべて見る →
-            </NavLink>
           </nav>
+        </div>
+
+        {/* 「全て」導線はスクロール領域の外に固定し、プロジェクトが増えても隠れないようにする (#54) */}
+        <div className="shrink-0 px-3 pb-2">
+          <NavLink
+            to="/projects"
+            className="block px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            全て →
+          </NavLink>
         </div>
 
         {/* ユーザー情報フッター: 全ページ共通で常時表示 (読込中は Skeleton) */}

--- a/apps/web/src/features/projects/ProjectListPage.tsx
+++ b/apps/web/src/features/projects/ProjectListPage.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Plus, ArrowRight, AlertCircle } from 'lucide-react';
+import { Plus, ArrowRight, AlertCircle, Pencil } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -66,9 +66,16 @@ export function ProjectListPage() {
                 <CardHeader>
                   <div className="flex items-start justify-between gap-2">
                     <CardTitle className="text-base">{p.name}</CardTitle>
-                    <Badge variant={p.status === 'active' ? 'default' : 'secondary'}>
-                      {p.status === 'active' ? '進行中' : '終了'}
-                    </Badge>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <Badge variant={p.status === 'active' ? 'default' : 'secondary'}>
+                        {p.status === 'active' ? '進行中' : '終了'}
+                      </Badge>
+                      <Button variant="ghost" size="icon" className="size-7" asChild>
+                        <Link to={`/projects/${p.id}/edit`} aria-label="編集">
+                          <Pencil className="size-4" />
+                        </Link>
+                      </Button>
+                    </div>
                   </div>
                 </CardHeader>
                 <CardContent className="space-y-3 text-sm">
@@ -82,11 +89,8 @@ export function ProjectListPage() {
                   </div>
                   <div className="flex gap-2">
                     <Button variant="outline" size="sm" asChild>
-                      <Link to={`/projects/${p.id}/edit`}>編集</Link>
-                    </Button>
-                    <Button variant="ghost" size="sm" asChild>
                       <Link to={`/projects/${p.id}`}>
-                        詳細
+                        スケジュール
                         <ArrowRight className="size-3.5" />
                       </Link>
                     </Button>


### PR DESCRIPTION
Closes #54

## 概要
プロジェクト一覧まわりの導線を直感的に。

## 変更内容
- サイドバー: 「すべて見る →」→「**全て →**」。スクロール領域の外に固定配置し、プロジェクトが増えても隠れないように。
- 一覧カード: 「編集」を**鉛筆アイコン**にしてカード**右上に固定**配置（全カードで位置統一）。
- 一覧カード: 下部の「詳細」→「**スケジュール**」。

## 検証
- type-check / lint(zero-warnings) OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)