### PR TITLE
fix(ui): ボタン文言を短いラベルに統一 (#67)

### DIFF
--- a/apps/web/src/features/auth/SC01LoginPage.tsx
+++ b/apps/web/src/features/auth/SC01LoginPage.tsx
@@ -290,7 +290,7 @@ function EmailSent({
           disabled={cooldown > 0 || resending || !email}
           onClick={resend}
         >
-          {cooldown > 0 ? `再送する (${cooldown}s)` : '再送する'}
+          {cooldown > 0 ? `再送 (${cooldown}s)` : '再送'}
         </Button>
         <Button
           type="button"
@@ -435,7 +435,7 @@ function CreateAccountForm() {
           {serverError && <p className="text-sm text-destructive">{serverError}</p>}
           <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
             {form.formState.isSubmitting && <Loader2 className="size-4 animate-spin" />}
-            登録を完了する
+            登録
           </Button>
         </form>
       </CardContent>

--- a/apps/web/src/features/invitations/InvitationAcceptPage.tsx
+++ b/apps/web/src/features/invitations/InvitationAcceptPage.tsx
@@ -132,7 +132,7 @@ export function InvitationAcceptPage() {
                   ) : (
                     <CheckCircle2 className="size-4" />
                   )}
-                  招待を承諾する
+                  承諾
                 </Button>
               ) : (
                 <Button
@@ -144,7 +144,7 @@ export function InvitationAcceptPage() {
                   }
                 >
                   <LogIn className="size-4" />
-                  ログインして承諾する
+                  ログインして承諾
                 </Button>
               )}
             </CardContent>

--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -235,7 +235,7 @@ export function BallDetailModal({
                         ) : (
                           <Send className="size-4" />
                         )}
-                        TOSS する
+                        TOSS
                       </Button>
                     )}
                     {plan.ballState === 'ready' && canAct && (!plan.fromMember || !plan.toMember) && (
@@ -267,7 +267,7 @@ export function BallDetailModal({
                         ) : (
                           <CheckCircle2 className="size-4" />
                         )}
-                        {hasSuccessor ? '次のタスクへトス' : '完了する'}
+                        {hasSuccessor ? '次のタスクへトス' : '完了'}
                       </Button>
                     )}
                     <Button variant="outline" onClick={onClose}>
@@ -297,7 +297,7 @@ export function BallDetailModal({
               }}
               disabled={deleteMut.isPending}
             >
-              削除する
+              削除
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/features/plans/MemberKanbanTab.tsx
+++ b/apps/web/src/features/plans/MemberKanbanTab.tsx
@@ -437,7 +437,7 @@ function PlanCard({
           ) : (
             <CheckCircle2 className="size-3" />
           )}
-          完了する
+          完了
         </Button>
       </div>
     </div>

--- a/apps/web/src/features/projects/MembersPage.tsx
+++ b/apps/web/src/features/projects/MembersPage.tsx
@@ -239,7 +239,7 @@ function ManageTab({ projectId }: { projectId: string }) {
               }}
               disabled={removeMut.isPending}
             >
-              削除する
+              削除
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/features/projects/ProjectEditPage.tsx
+++ b/apps/web/src/features/projects/ProjectEditPage.tsx
@@ -314,7 +314,7 @@ function ItemsSection({
               }}
               disabled={deleteMut.isPending}
             >
-              削除する
+              削除
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/features/shareLinks/ShareLinksPage.tsx
+++ b/apps/web/src/features/shareLinks/ShareLinksPage.tsx
@@ -194,7 +194,7 @@ function Inner({ projectId }: { projectId: string }) {
               }}
               disabled={revokeMut.isPending}
             >
-              失効する
+              失効
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -308,7 +308,7 @@ function CreateDialog({
             }
           >
             {createMut.isPending && <Loader2 className="size-4 animate-spin" />}
-            発行する
+            発行
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## 概要
Issue #67「ボタン文言の表記ルール」対応。ボタン文言を「動作を説明する文章」ではなく「操作対象・操作結果を示す短いラベル」に統一しました。文言のみの変更でロジックは不変です。

## 変更一覧（12箇所 / 7ファイル）
| ファイル | 変更前 | 変更後 |
|---|---|---|
| MemberKanbanTab.tsx | 完了する | 完了 |
| BallDetailModal.tsx | TOSS する | TOSS |
| BallDetailModal.tsx | 完了する | 完了 |
| BallDetailModal.tsx | 削除する | 削除 |
| SC01LoginPage.tsx | 再送する | 再送 |
| SC01LoginPage.tsx | 登録を完了する | 登録 |
| MembersPage.tsx | 削除する | 削除 |
| ProjectEditPage.tsx | 削除する | 削除 |
| ShareLinksPage.tsx | 失効する | 失効 |
| ShareLinksPage.tsx | 発行する | 発行 |
| InvitationAcceptPage.tsx | 招待を承諾する | 承諾 |
| InvitationAcceptPage.tsx | ログインして承諾する | ログインして承諾 |

## 意図的に変更しなかったもの
- `次のタスクへトス` — 既に短い具体ラベル
- `ログイン状態を保存する` — ボタンではなくチェックボックスのラベル（設定状態の説明）
- `差し戻す` / `閉じる` / `キャンセル` / `招待を送信` / `保存` / `追加` — 既にラベル化済み・曖昧回避のため具体化済み

## 検証
- `pnpm --filter @trakon/web type-check` ✅
- `pnpm --filter @trakon/web lint` (--max-warnings 0) ✅

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)