### PR TITLE
fix(share): 共有URLを発行元ドメインで生成し共有画面を閲覧専用カレンダーに (#59)

### DIFF
--- a/apps/web/server/lib/requestOrigin.test.ts
+++ b/apps/web/server/lib/requestOrigin.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { Context } from 'hono';
+
+import { resolveRequestOrigin } from './requestOrigin.js';
+
+/** header マップだけを持つ最小 Context スタブ。 */
+function ctx(headers: Record<string, string>): Context {
+  return {
+    req: {
+      header: (name: string) => headers[name.toLowerCase()],
+    },
+  } as unknown as Context;
+}
+
+describe('resolveRequestOrigin', () => {
+  it('Origin ヘッダを最優先で使う (発行元と同一ドメイン)', () => {
+    expect(
+      resolveRequestOrigin(
+        ctx({ origin: 'https://trakon-app-i0ta680i9-trakon-projects.vercel.app' }),
+      ),
+    ).toBe('https://trakon-app-i0ta680i9-trakon-projects.vercel.app');
+  });
+
+  it('Origin の末尾スラッシュを除去する', () => {
+    expect(resolveRequestOrigin(ctx({ origin: 'https://example.com/' }))).toBe(
+      'https://example.com',
+    );
+  });
+
+  it('Origin が無ければ x-forwarded-proto + x-forwarded-host で組む', () => {
+    expect(
+      resolveRequestOrigin(
+        ctx({ 'x-forwarded-proto': 'https', 'x-forwarded-host': 'preview.vercel.app' }),
+      ),
+    ).toBe('https://preview.vercel.app');
+  });
+
+  it('カンマ区切りの forwarded ヘッダは先頭値を使う', () => {
+    expect(
+      resolveRequestOrigin(
+        ctx({ 'x-forwarded-proto': 'https, http', 'x-forwarded-host': 'a.example.com, b' }),
+      ),
+    ).toBe('https://a.example.com');
+  });
+
+  it('forwarded-host のみなら scheme は https を仮定', () => {
+    expect(resolveRequestOrigin(ctx({ 'x-forwarded-host': 'preview.vercel.app' }))).toBe(
+      'https://preview.vercel.app',
+    );
+  });
+
+  it('Host ヘッダにフォールバックする', () => {
+    expect(resolveRequestOrigin(ctx({ host: 'localhost:5173' }))).toBe('https://localhost:5173');
+  });
+
+  it('Host + x-forwarded-proto なら proto を尊重する', () => {
+    expect(
+      resolveRequestOrigin(ctx({ host: 'localhost:5173', 'x-forwarded-proto': 'http' })),
+    ).toBe('http://localhost:5173');
+  });
+});

--- a/apps/web/server/lib/requestOrigin.ts
+++ b/apps/web/server/lib/requestOrigin.ts
@@ -1,0 +1,39 @@
+import type { Context } from 'hono';
+
+import { getServerEnv } from './env.js';
+
+/**
+ * リクエスト元のオリジン (scheme + host) を解決する。
+ * 共有 URL を「発行元と同じドメイン」で組み立てるために使用する (#59)。
+ *
+ * 解決順序:
+ *  1. `Origin` ヘッダ (ブラウザ fetch が付与)
+ *  2. `x-forwarded-proto` + `x-forwarded-host` (Vercel などのプロキシ経由)
+ *  3. `Host` ヘッダ (scheme は x-forwarded-proto か https を仮定)
+ *  4. `env.PUBLIC_APP_URL` (フォールバック)
+ */
+export function resolveRequestOrigin(c: Context): string {
+  const origin = c.req.header('origin');
+  if (origin && /^https?:\/\//.test(origin)) {
+    return stripTrailingSlash(origin);
+  }
+
+  const forwardedHost = c.req.header('x-forwarded-host');
+  const forwardedProto = c.req.header('x-forwarded-proto');
+  if (forwardedHost) {
+    const proto = forwardedProto?.split(',')[0]?.trim() || 'https';
+    return `${proto}://${forwardedHost.split(',')[0]?.trim()}`;
+  }
+
+  const host = c.req.header('host');
+  if (host) {
+    const proto = forwardedProto?.split(',')[0]?.trim() || 'https';
+    return `${proto}://${host}`;
+  }
+
+  return stripTrailingSlash(getServerEnv().PUBLIC_APP_URL);
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}

--- a/apps/web/server/routes/v1/shareLinks.ts
+++ b/apps/web/server/routes/v1/shareLinks.ts
@@ -5,6 +5,7 @@ import {
   requireProjectDirector,
   requireProjectMember,
 } from '../../middleware/projectAuth.js';
+import { resolveRequestOrigin } from '../../lib/requestOrigin.js';
 import { createShareLinkBodySchema } from '../../schemas/shareLinks.js';
 import {
   createShareLink,
@@ -35,6 +36,7 @@ export const shareLinksRoute = new Hono()
         projectId: project.projectId,
         issuerMemberId: project.memberId,
         body,
+        baseUrl: resolveRequestOrigin(c),
       });
       return c.json({ data: result }, 201);
     },

--- a/apps/web/server/services/shareAccess.ts
+++ b/apps/web/server/services/shareAccess.ts
@@ -13,7 +13,7 @@ export type ShareViewDTO = {
     /** null = 無期限 */
     expiresAt: string | null;
   };
-  project: { id: string; name: string };
+  project: { id: string; name: string; startDate: string; endDate: string };
   items: Array<{ id: string; name: string }>;
   plans: PlanDTO[];
 };
@@ -96,7 +96,13 @@ export async function viewShare(input: {
       scopeTargetId: share.scopeTargetId,
       expiresAt: share.expiresAt?.toISOString() ?? null,
     },
-    project: { id: project.id, name: project.name },
+    project: {
+      id: project.id,
+      name: project.name,
+      // カレンダー日付軸の生成に使用 (YYYY-MM-DD)
+      startDate: project.startDate.toISOString().slice(0, 10),
+      endDate: project.endDate.toISOString().slice(0, 10),
+    },
     items: items.map((it) => ({ id: it.id, name: it.name })),
     plans,
   };

--- a/apps/web/server/services/shareLinks.ts
+++ b/apps/web/server/services/shareLinks.ts
@@ -70,6 +70,8 @@ export async function createShareLink(input: {
   projectId: string;
   issuerMemberId: string;
   body: CreateShareLinkBody;
+  /** 共有 URL の基底オリジン (発行元と同一ドメインにするため)。未指定なら env フォールバック。 */
+  baseUrl?: string;
 }): Promise<CreateShareLinkResult> {
   const { body } = input;
 
@@ -118,11 +120,11 @@ export async function createShareLink(input: {
     },
   });
 
-  const env = getServerEnv();
+  const base = input.baseUrl ?? getServerEnv().PUBLIC_APP_URL;
   return {
     shareLink: toDTO(created),
     rawToken: raw,
-    url: `${env.PUBLIC_APP_URL}/share/${raw}`,
+    url: `${base}/share/${raw}`,
   };
 }
 

--- a/apps/web/src/features/shareLinks/SharePage.tsx
+++ b/apps/web/src/features/shareLinks/SharePage.tsx
@@ -1,31 +1,20 @@
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { format } from 'date-fns';
-import {
-  AlertCircle,
-  CheckCircle2,
-  Loader2,
-  Lock,
-  Send,
-} from 'lucide-react';
-import { toast } from 'sonner';
+import { AlertCircle, Lock } from 'lucide-react';
 
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { cn } from '@/components/ui/utils';
-import { ApiClientError } from '@/lib/api';
-import { CATEGORY_STYLE } from '@/features/plans/categoryColor';
-import type { Plan } from '@/features/plans/api';
+import { ShareSchedule } from './ShareSchedule';
 import { shareAccessApi, type ShareView } from './api';
 
 /**
- * 非会員 URL 操作画面 (`/share/:token`)
+ * 非会員 URL 閲覧画面 (`/share/:token`)
  *  - 未認証可
  *  - クローラ防止 meta タグを document に注入
- *  - share scope 範囲のプラン一覧 + クライアントロール相当の TOSS/完了
+ *  - share scope 範囲のスケジュールを「閲覧専用カレンダー」で表示 (#59)
+ *    (ドラッグ移動・TOSS・完了・作成などの操作は一切不可)
  */
 export function SharePage() {
   const { token } = useParams<{ token: string }>();
@@ -49,34 +38,10 @@ export function SharePage() {
 }
 
 function Inner({ token }: { token: string }) {
-  const qc = useQueryClient();
-  const queryKey = ['share', token] as const;
-
   const viewQuery = useQuery({
-    queryKey,
+    queryKey: ['share', token] as const,
     queryFn: () => shareAccessApi.view(token),
     retry: 0,
-  });
-
-  const tossMut = useMutation({
-    mutationFn: (planId: string) => shareAccessApi.toss(token, planId),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey });
-      toast.success('TOSS しました');
-    },
-    onError: (e) =>
-      toast.error(e instanceof ApiClientError ? e.message : 'TOSS に失敗しました'),
-  });
-
-  const completeMut = useMutation({
-    mutationFn: (planId: string) => shareAccessApi.complete(token, planId),
-    onSuccess: (res) => {
-      qc.invalidateQueries({ queryKey });
-      toast.success('完了しました');
-      if (res.autoTossed) toast.message('後続の予定に自動 TOSS しました');
-    },
-    onError: (e) =>
-      toast.error(e instanceof ApiClientError ? e.message : '完了に失敗しました'),
   });
 
   if (viewQuery.isLoading) return <PageSkeleton />;
@@ -87,162 +52,41 @@ function Inner({ token }: { token: string }) {
   }
   const data = viewQuery.data!;
   return (
-    <Layout view={data}>
-      <PlansList
-        plans={data.plans}
-        items={data.items}
-        onToss={(planId) => tossMut.mutate(planId)}
-        onComplete={(planId) => completeMut.mutate(planId)}
-        busy={tossMut.isPending || completeMut.isPending}
-      />
-    </Layout>
+    <div className="flex h-screen flex-col">
+      <Header view={data} />
+      <ShareSchedule project={data.project} items={data.items} plans={data.plans} />
+    </div>
   );
 }
 
-function Layout({ view, children }: { view: ShareView; children: React.ReactNode }) {
+function Header({ view }: { view: ShareView }) {
   return (
-    <div className="mx-auto max-w-4xl space-y-5 px-6 py-10">
-      <header className="flex items-start justify-between gap-3">
-        <div className="space-y-1">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Lock className="size-3" />
-            共有リンク (非会員)
-          </div>
-          <h1 className="text-xl font-semibold tracking-tight">{view.project.name}</h1>
-          <p className="text-xs text-muted-foreground">
-            {view.share.expiresAt
-              ? `有効期限 ${format(new Date(view.share.expiresAt), 'yyyy/M/d HH:mm')} まで`
-              : '有効期限なし (無期限)'}
-          </p>
+    <header className="flex items-start justify-between gap-3 border-b border-border bg-background px-6 py-4">
+      <div className="space-y-1">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Lock className="size-3" />
+          共有リンク (閲覧専用)
         </div>
-        <Badge variant="secondary">
-          scope: {view.share.scopeType}
-        </Badge>
-      </header>
-      {children}
-    </div>
-  );
-}
-
-function PlansList({
-  plans,
-  items,
-  onToss,
-  onComplete,
-  busy,
-}: {
-  plans: Plan[];
-  items: ShareView['items'];
-  onToss: (planId: string) => void;
-  onComplete: (planId: string) => void;
-  busy: boolean;
-}) {
-  if (plans.length === 0) {
-    return (
-      <Card>
-        <CardContent className="py-10 text-center text-sm text-muted-foreground">
-          表示できる予定はありません。
-        </CardContent>
-      </Card>
-    );
-  }
-
-  // item ごとにグルーピング
-  const itemMap = new Map(items.map((it) => [it.id, it.name] as const));
-  const byItem = new Map<string, Plan[]>();
-  for (const p of plans) {
-    const arr = byItem.get(p.itemId) ?? [];
-    arr.push(p);
-    byItem.set(p.itemId, arr);
-  }
-
-  return (
-    <div className="space-y-4">
-      {Array.from(byItem.entries()).map(([itemId, list]) => (
-        <Card key={itemId}>
-          <CardHeader>
-            <CardTitle className="text-sm">{itemMap.get(itemId) ?? '制作物'}</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2">
-            {list.map((p) => (
-              <PlanRow
-                key={p.id}
-                plan={p}
-                onToss={() => onToss(p.id)}
-                onComplete={() => onComplete(p.id)}
-                busy={busy}
-              />
-            ))}
-          </CardContent>
-        </Card>
-      ))}
-    </div>
-  );
-}
-
-function PlanRow({
-  plan,
-  onToss,
-  onComplete,
-  busy,
-}: {
-  plan: Plan;
-  onToss: () => void;
-  onComplete: () => void;
-  busy: boolean;
-}) {
-  const style = CATEGORY_STYLE[plan.category];
-  const completed = plan.status === 'completed';
-  return (
-    <div
-      className={cn(
-        'flex items-center gap-3 rounded-md border px-3 py-2 text-sm',
-        completed
-          ? 'border-slate-200 bg-slate-50 text-slate-500'
-          : `${style.bg} ${style.border} ${style.text}`,
-      )}
-    >
-      <Badge variant="secondary" className="px-1 py-0 text-[10px]">
-        {style.label}
-      </Badge>
-      <div className="min-w-0 flex-1">
-        <p className={cn('line-clamp-1 font-medium', completed && 'line-through')}>
-          {plan.title}
-        </p>
-        <p className="text-[11px] opacity-80">
-          {format(new Date(plan.scheduledDate), 'M/d')}
-          {plan.dueDate && ` 〜 期日 ${format(new Date(plan.dueDate), 'M/d')}`}
-          {plan.ballHolder && ` ・ ホルダー: ${plan.ballHolder.name}`}
+        <h1 className="text-xl font-semibold tracking-tight">{view.project.name}</h1>
+        <p className="text-xs text-muted-foreground">
+          期間: {format(new Date(view.project.startDate), 'yyyy/M/d')} 〜{' '}
+          {format(new Date(view.project.endDate), 'yyyy/M/d')}
+          {' ・ '}
+          {view.share.expiresAt
+            ? `有効期限 ${format(new Date(view.share.expiresAt), 'yyyy/M/d HH:mm')} まで`
+            : '有効期限なし (無期限)'}
         </p>
       </div>
-      {completed ? (
-        <Badge variant="secondary">完了済み</Badge>
-      ) : (
-        <div className="flex gap-1">
-          {plan.ballState === 'ready' && (
-            <Button size="sm" variant="outline" onClick={onToss} disabled={busy}>
-              {busy ? <Loader2 className="size-3 animate-spin" /> : <Send className="size-3" />}
-              TOSS
-            </Button>
-          )}
-          {plan.ballState === 'tossed' && (
-            <Button size="sm" onClick={onComplete} disabled={busy}>
-              {busy ? <Loader2 className="size-3 animate-spin" /> : <CheckCircle2 className="size-3" />}
-              完了
-            </Button>
-          )}
-        </div>
-      )}
-    </div>
+      <Badge variant="secondary">scope: {view.share.scopeType}</Badge>
+    </header>
   );
 }
 
 function PageSkeleton() {
   return (
-    <div className="mx-auto max-w-4xl space-y-3 px-6 py-10">
+    <div className="space-y-3 p-8">
       <Skeleton className="h-8 w-1/3" />
-      <Skeleton className="h-40 rounded-xl" />
-      <Skeleton className="h-40 rounded-xl" />
+      <Skeleton className="h-[60vh] w-full rounded-md" />
     </div>
   );
 }

--- a/apps/web/src/features/shareLinks/ShareSchedule.tsx
+++ b/apps/web/src/features/shareLinks/ShareSchedule.tsx
@@ -1,0 +1,464 @@
+import { useMemo, useState } from 'react';
+import { addDays, differenceInDays, format, isSameDay, isWeekend, parseISO } from 'date-fns';
+import { ja } from 'date-fns/locale';
+import { isHoliday } from '@holiday-jp/holiday_jp';
+import { CheckCircle2, ZoomIn, ZoomOut } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/components/ui/utils';
+import { CATEGORY_STYLE } from '@/features/plans/categoryColor';
+import type { Plan } from '@/features/plans/api';
+import {
+  assignLanes,
+  ballTier,
+  dayIndex,
+  isActiveNow,
+  isOverdue,
+  itemColor,
+  planRange,
+  ROW_HEIGHT_DEFAULT,
+  ROW_HEIGHT_MAX,
+  ROW_HEIGHT_MIN,
+  ROW_HEIGHT_STEP,
+  scaledLaneWidth,
+  scaledMinColumnWidth,
+} from '@/features/plans/scheduleLayout';
+
+const DATE_AXIS_WIDTH = 76;
+
+type ShareItem = { id: string; name: string };
+
+/**
+ * 共有リンク (非会員) 向けの「閲覧専用」スケジュールカレンダー (#59)。
+ * ItemSchedulePage の ScheduleBoard と同等のレイアウトを描画するが、
+ * ドラッグ移動 / TOSS / 完了 / 作成といった操作ハンドラを一切持たず、
+ * 操作不能であることをコンポーネント構造として保証する。
+ */
+export function ShareSchedule({
+  project,
+  items,
+  plans,
+}: {
+  project: { startDate: string; endDate: string };
+  items: ShareItem[];
+  plans: Plan[];
+}) {
+  const [rowHeight, setRowHeight] = useState(ROW_HEIGHT_DEFAULT);
+
+  const days = useMemo(() => {
+    const start = parseISO(project.startDate);
+    const end = parseISO(project.endDate);
+    const count = Math.max(0, differenceInDays(end, start) + 1);
+    return Array.from({ length: count }, (_, i) => addDays(start, i));
+  }, [project.startDate, project.endDate]);
+
+  const plansByItem = useMemo(() => {
+    const map = new Map<string, Plan[]>();
+    for (const p of plans) {
+      const arr = map.get(p.itemId) ?? [];
+      arr.push(p);
+      map.set(p.itemId, arr);
+    }
+    return map;
+  }, [plans]);
+
+  if (days.length === 0) {
+    return (
+      <p className="m-8 text-sm text-muted-foreground">プロジェクト期間が設定されていません。</p>
+    );
+  }
+  if (items.length === 0) {
+    return <p className="m-8 text-sm text-muted-foreground">表示できる制作物がありません。</p>;
+  }
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <ScheduleBoard days={days} items={items} plansByItem={plansByItem} rowHeight={rowHeight} />
+      <ZoomControl rowHeight={rowHeight} onChange={setRowHeight} />
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Board (read-only)
+// -----------------------------------------------------------------------------
+
+function ScheduleBoard({
+  days,
+  items,
+  plansByItem,
+  rowHeight,
+}: {
+  days: Date[];
+  items: ShareItem[];
+  plansByItem: Map<string, Plan[]>;
+  rowHeight: number;
+}) {
+  const today = new Date();
+  const totalHeight = days.length * rowHeight;
+  const laneWidth = scaledLaneWidth(rowHeight);
+  const minColumnWidth = scaledMinColumnWidth(rowHeight);
+
+  const dayTones = useMemo(
+    () =>
+      days.map((d) => {
+        const weekend = isWeekend(d);
+        const holiday = isHoliday(d);
+        const isToday = isSameDay(d, today);
+        const tone = isToday
+          ? 'bg-amber-50'
+          : holiday
+            ? 'bg-rose-50/60'
+            : weekend
+              ? 'bg-slate-50'
+              : 'bg-background';
+        return { weekend, holiday, today: isToday, tone, first: d.getDate() === 1 };
+      }),
+    // today はマウント時点で固定で良い
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [days, rowHeight],
+  );
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto">
+      <div className="flex w-max select-none">
+        {/* 日付軸 (sticky left) */}
+        <div
+          className="sticky left-0 z-30 shrink-0 border-r border-border bg-background"
+          style={{ width: DATE_AXIS_WIDTH }}
+        >
+          <div className="sticky top-0 z-10 h-16 border-b border-border bg-background" />
+          <div className="relative" style={{ height: totalHeight }}>
+            {days.map((d, i) => {
+              const t = dayTones[i]!;
+              return (
+                <div
+                  key={i}
+                  className={cn(
+                    'absolute left-0 right-0 flex flex-col items-center justify-center border-b border-border text-xs',
+                    t.tone,
+                    t.first && 'border-t-2 border-t-foreground/20',
+                    t.today && 'font-semibold text-amber-700',
+                    t.holiday && 'text-rose-600',
+                  )}
+                  style={{ top: i * rowHeight, height: rowHeight }}
+                >
+                  <span>{format(d, 'M/d')}</span>
+                  {rowHeight >= 30 && (
+                    <span
+                      className={cn(
+                        'text-[10px]',
+                        t.weekend ? 'text-slate-500' : 'text-muted-foreground',
+                        t.holiday && 'text-rose-500',
+                      )}
+                    >
+                      {format(d, 'EEEEE', { locale: ja })}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* 制作物列 */}
+        {items.map((item) => {
+          const itemPlans = (plansByItem.get(item.id) ?? [])
+            .slice()
+            .sort((a, b) => a.scheduledDate.localeCompare(b.scheduledDate));
+          const { laneOf, laneCount } = assignLanes(itemPlans);
+          const colWidth = Math.max(minColumnWidth, laneCount * laneWidth);
+          const color = itemColor(item.id);
+          const activePlans = itemPlans.filter((p) => p.status === 'active');
+          const repHolder = activePlans.length
+            ? activePlans[activePlans.length - 1]!.ballHolder
+            : null;
+          return (
+            <div key={item.id} className="shrink-0 border-r border-border" style={{ width: colWidth }}>
+              {/* 列ヘッダー: 制作物名 ＋ 現在のボール保持者 */}
+              <div className="sticky top-0 z-20 flex h-16 flex-col justify-center gap-0.5 border-b border-border bg-background px-3">
+                <div className="flex items-center gap-2">
+                  <span className={cn('size-2.5 shrink-0 rounded-full', color.dot)} />
+                  <span className="truncate text-sm font-medium">{item.name}</span>
+                  <Badge variant="secondary" className="ml-auto shrink-0 text-[10px]">
+                    {itemPlans.length}件
+                  </Badge>
+                </div>
+                <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                  <span className="shrink-0">ボール保持:</span>
+                  {repHolder ? (
+                    <span className="truncate font-medium text-foreground">
+                      {repHolder.organizationName
+                        ? `${repHolder.organizationName} ${repHolder.name}`
+                        : repHolder.name}
+                    </span>
+                  ) : (
+                    <span>—</span>
+                  )}
+                </div>
+              </div>
+
+              {/* 本体 */}
+              <div className="relative" style={{ height: totalHeight }}>
+                {/* 日付セル (背景のみ。閲覧専用なので操作不可) */}
+                {days.map((d, i) => {
+                  const t = dayTones[i]!;
+                  return (
+                    <div
+                      key={i}
+                      className={cn(
+                        'absolute left-0 right-0 border-b border-border/70',
+                        t.tone,
+                        t.first && 'border-t-2 border-t-foreground/20',
+                      )}
+                      style={{ top: i * rowHeight, height: rowHeight }}
+                      aria-hidden
+                    />
+                  );
+                })}
+
+                {/* 後続リンク (同一列内) */}
+                <LinkLayer
+                  plans={itemPlans}
+                  laneOf={laneOf}
+                  days={days}
+                  rowHeight={rowHeight}
+                  laneWidth={laneWidth}
+                  width={colWidth}
+                  height={totalHeight}
+                />
+
+                {/* ボール */}
+                {itemPlans.map((plan) => (
+                  <BallChip
+                    key={plan.id}
+                    plan={plan}
+                    days={days}
+                    rowHeight={rowHeight}
+                    laneWidth={laneWidth}
+                    lane={laneOf.get(plan.id) ?? 0}
+                    today={today}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// 後続リンク描画 (列内 SVG オーバーレイ)
+// -----------------------------------------------------------------------------
+
+function chipCenters(
+  plan: Plan,
+  days: Date[],
+  rowHeight: number,
+  laneWidth: number,
+  laneOf: Map<string, number>,
+) {
+  const { start, end } = planRange(plan);
+  const startIdx = dayIndex(days, start);
+  const endIdx = dayIndex(days, end);
+  const top = startIdx * rowHeight + 1;
+  const height = (endIdx - startIdx + 1) * rowHeight - 3;
+  const lane = laneOf.get(plan.id) ?? 0;
+  const cx = lane * laneWidth + 6 + (laneWidth - 12) / 2;
+  return { cx, top, bottom: top + height };
+}
+
+function LinkLayer({
+  plans,
+  laneOf,
+  days,
+  rowHeight,
+  laneWidth,
+  width,
+  height,
+}: {
+  plans: Plan[];
+  laneOf: Map<string, number>;
+  days: Date[];
+  rowHeight: number;
+  laneWidth: number;
+  width: number;
+  height: number;
+}) {
+  const byId = new Map(plans.map((p) => [p.id, p]));
+  const links: { x1: number; y1: number; x2: number; y2: number }[] = [];
+  for (const p of plans) {
+    if (!p.successorPlanId) continue;
+    const succ = byId.get(p.successorPlanId);
+    if (!succ) continue; // 別制作物 or 未ロード
+    const a = chipCenters(p, days, rowHeight, laneWidth, laneOf);
+    const b = chipCenters(succ, days, rowHeight, laneWidth, laneOf);
+    links.push({ x1: a.cx, y1: a.bottom, x2: b.cx, y2: b.top });
+  }
+  if (links.length === 0) return null;
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0 z-0"
+      width={width}
+      height={height}
+      style={{ overflow: 'visible' }}
+      aria-hidden
+    >
+      <defs>
+        <marker id="share-succ-arrow" markerWidth="6" markerHeight="6" refX="4.5" refY="3" orient="auto">
+          <path d="M0,0 L6,3 L0,6 Z" className="fill-sky-400" />
+        </marker>
+      </defs>
+      {links.map((l, i) => {
+        const midY = (l.y1 + l.y2) / 2;
+        const d = `M ${l.x1} ${l.y1} C ${l.x1} ${midY}, ${l.x2} ${midY}, ${l.x2} ${l.y2}`;
+        return (
+          <path
+            key={i}
+            d={d}
+            strokeWidth={1.5}
+            strokeDasharray="3 3"
+            markerEnd="url(#share-succ-arrow)"
+            className="fill-none stroke-sky-400"
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Ball chip (read-only)
+// -----------------------------------------------------------------------------
+
+function BallChip({
+  plan,
+  days,
+  rowHeight,
+  laneWidth,
+  lane,
+  today,
+}: {
+  plan: Plan;
+  days: Date[];
+  rowHeight: number;
+  laneWidth: number;
+  lane: number;
+  today: Date;
+}) {
+  const { start, end } = planRange(plan);
+  const startIdx = dayIndex(days, start);
+  const endIdx = dayIndex(days, end);
+
+  const top = startIdx * rowHeight + 1;
+  const height = (endIdx - startIdx + 1) * rowHeight - 3;
+  const tier = ballTier(height);
+  const style = CATEGORY_STYLE[plan.category];
+  const completed = plan.status === 'completed';
+  const tossed = plan.ballState === 'tossed';
+  const overdue = isOverdue(plan, today);
+  const active = isActiveNow(plan, today);
+
+  const cardClass = completed
+    ? 'border-slate-200 bg-slate-100/80 text-slate-500 opacity-60'
+    : overdue
+      ? 'border-red-400 bg-red-50 text-red-700'
+      : tossed
+        ? 'border-slate-300 bg-slate-100 text-slate-600'
+        : cn(style.bg, style.border, style.text);
+
+  return (
+    <div
+      className={cn(
+        'absolute overflow-hidden rounded-md border px-2 py-1 text-xs shadow-sm',
+        cardClass,
+        active && !completed && 'ring-2 ring-primary/40',
+      )}
+      style={{
+        top,
+        height,
+        left: lane * laneWidth + 6,
+        width: laneWidth - 12,
+      }}
+    >
+      <div className="flex items-center justify-between gap-1">
+        <span className="line-clamp-1 font-medium">{plan.title}</span>
+        {completed && <CheckCircle2 className="size-3 shrink-0 text-emerald-500" />}
+      </div>
+
+      {tier !== 'mini' && (
+        <div className="mt-0.5 flex items-center gap-1 text-[10px] opacity-90">
+          <span className="rounded bg-black/5 px-1">{style.label}</span>
+          <span className="line-clamp-1">
+            {format(parseISO(start), 'M/d')}
+            {start !== end && `〜${format(parseISO(end), 'M/d')}`}
+          </span>
+        </div>
+      )}
+
+      {tier === 'normal' && (
+        <div className="mt-1 border-t border-current/10 pt-1 text-[10px] leading-tight">
+          <div className="flex items-center gap-1">
+            <span className="opacity-60">実施者</span>
+            <span className="line-clamp-1 font-medium">{plan.fromMember?.name ?? '—'}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="opacity-60">確認者</span>
+            <span className="line-clamp-1 font-medium">{plan.toMember?.name ?? '—'}</span>
+            {plan.ballHolder && (
+              <Badge variant="secondary" className="ml-auto px-1 py-0 text-[9px]">
+                {plan.ballHolder.name}
+              </Badge>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Zoom control
+// -----------------------------------------------------------------------------
+
+function ZoomControl({
+  rowHeight,
+  onChange,
+}: {
+  rowHeight: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="fixed bottom-6 right-6 z-40 flex items-center gap-3 rounded-lg border border-border bg-background p-3 shadow-lg">
+      <button
+        type="button"
+        aria-label="縮小"
+        className="text-muted-foreground hover:text-foreground"
+        onClick={() => onChange(Math.max(ROW_HEIGHT_MIN, rowHeight - ROW_HEIGHT_STEP))}
+      >
+        <ZoomOut className="size-4" />
+      </button>
+      <input
+        type="range"
+        min={ROW_HEIGHT_MIN}
+        max={ROW_HEIGHT_MAX}
+        step={ROW_HEIGHT_STEP}
+        value={rowHeight}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-28 accent-primary"
+        aria-label="行の高さ"
+      />
+      <button
+        type="button"
+        aria-label="拡大"
+        className="text-muted-foreground hover:text-foreground"
+        onClick={() => onChange(Math.min(ROW_HEIGHT_MAX, rowHeight + ROW_HEIGHT_STEP))}
+      >
+        <ZoomIn className="size-4" />
+      </button>
+      <span className="ml-1 min-w-[2.5rem] text-xs text-muted-foreground">{rowHeight}px</span>
+    </div>
+  );
+}

--- a/apps/web/src/features/shareLinks/api.ts
+++ b/apps/web/src/features/shareLinks/api.ts
@@ -38,7 +38,7 @@ export type ShareView = {
     /** null = 無期限 */
     expiresAt: string | null;
   };
-  project: { id: string; name: string };
+  project: { id: string; name: string; startDate: string; endDate: string };
   items: Array<{ id: string; name: string }>;
   plans: Plan[];
 };
@@ -58,18 +58,9 @@ export const shareLinksApi = {
 };
 
 export const shareAccessApi = {
+  // 共有画面は閲覧専用 (#59)。操作系 (toss/complete) は FE からは呼び出さない。
   view: (token: string) =>
     apiRequest<ShareView>(`/share/${encodeURIComponent(token)}`),
-  toss: (token: string, planId: string) =>
-    apiRequest<{ plan: Plan }>(
-      `/share/${encodeURIComponent(token)}/plans/${planId}/toss`,
-      { method: 'POST' },
-    ),
-  complete: (token: string, planId: string) =>
-    apiRequest<{ plan: Plan; autoTossed: Plan | null }>(
-      `/share/${encodeURIComponent(token)}/plans/${planId}/complete`,
-      { method: 'POST' },
-    ),
 };
 
 export const shareLinksQueryKey = {


### PR DESCRIPTION
## 概要

GitHub issue の共有リンク機能の不具合2点を修正します。

Closes #59

## 1. 共有URLのドメイン不一致を修正

プレビュー環境（例 `https://trakon-app-xxxx-trakon-projects.vercel.app/`）から発行した共有リンクが、固定の `PUBLIC_APP_URL`（`https://trakon-app.vercel.app`）ドメインになり、ドメインが異なるため閲覧できなかった問題を解消。

- `resolveRequestOrigin(c)`（[apps/web/server/lib/requestOrigin.ts](apps/web/server/lib/requestOrigin.ts)）を新規追加。リクエストのオリジンを **`Origin` → `x-forwarded-proto` + `x-forwarded-host` → `Host` → `env.PUBLIC_APP_URL`（フォールバック）** の順で解決。
- `createShareLink` に `baseUrl` を追加し、共有URLを発行元と同一ドメインで組み立て。
- 単体テスト [requestOrigin.test.ts](apps/web/server/lib/requestOrigin.test.ts) を追加。

## 2. 共有画面をスケジュールのカレンダー表示 + 閲覧専用に変更

簡易リスト表示と TOSS/完了操作をやめ、スケジュール画面（`ItemSchedulePage`）と同等のカレンダーレイアウトで表示し、**閲覧専用**にしました。

- 新規 [ShareSchedule.tsx](apps/web/src/features/shareLinks/ShareSchedule.tsx): `scheduleLayout.ts` の純粋関数と `CATEGORY_STYLE` を再利用した **read-only 専用カレンダー**。ドラッグ移動・TOSS・完了・作成などの操作ハンドラを一切持たず、操作不能をコンポーネント構造として保証。日付軸（週末/祝日/今日の色分け）＋制作物列＋ボールチップ＋後続リンク線を表示。閲覧用のズームのみ可。
- [SharePage.tsx](apps/web/src/features/shareLinks/SharePage.tsx): 旧リスト/操作UIを撤去し、ヘッダ（プロジェクト名・期間・有効期限・「閲覧専用」表示）＋ `ShareSchedule` に置き換え。
- [shareAccess.ts](apps/web/server/services/shareAccess.ts): `ShareViewDTO.project` に `startDate`/`endDate` を追加（カレンダー日付軸の生成に必要）。FE 型も同期。
- FE の操作系 API（`shareAccessApi.toss/complete`）呼び出しを削除（BE のルート/サービスは破壊的変更回避のため残置）。

## 検証

- ✅ `pnpm --filter @trakon/web type-check`
- ✅ `pnpm --filter @trakon/web lint`（警告ゼロ）
- ✅ `pnpm --filter @trakon/web test share` / `test requestOrigin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)