### PR TITLE
feat(projects): プロジェクトのアーカイブと一覧表示 (#61 #62)

### DIFF
--- a/apps/web/server/routes/v1/projects.test.ts
+++ b/apps/web/server/routes/v1/projects.test.ts
@@ -29,4 +29,16 @@ describe('projects routes', () => {
     const res = await app.request('/api/v1/projects/abc/items');
     expect(res.status).toBe(401);
   });
+
+  it('requires authentication for POST /projects/:id/archive', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/projects/abc/archive', { method: 'POST' });
+    expect(res.status).toBe(401);
+  });
+
+  it('requires authentication for POST /projects/:id/unarchive', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/projects/abc/unarchive', { method: 'POST' });
+    expect(res.status).toBe(401);
+  });
 });

--- a/apps/web/server/routes/v1/projects.ts
+++ b/apps/web/server/routes/v1/projects.ts
@@ -14,9 +14,11 @@ import {
   updateProjectBodySchema,
 } from '../../schemas/projects.js';
 import {
+  archiveProject,
   createProject,
   getProjectDetail,
   listProjects,
+  unarchiveProject,
   updateProject,
 } from '../../services/projects.js';
 import {
@@ -41,7 +43,7 @@ export const projectsRoute = new Hono()
   .get('/', async (c) => {
     const userId = c.get('currentUserId');
     const q = listProjectsQuerySchema.parse({
-      status: c.req.query('status'),
+      archived: c.req.query('archived'),
       limit: c.req.query('limit'),
       offset: c.req.query('offset'),
     });
@@ -75,6 +77,37 @@ export const projectsRoute = new Hono()
     });
     return c.json({ data: result.project, warnings: result.warnings });
   })
+
+  // ----------------------------- /projects/:projectId/archive -----------------------------
+  .post(
+    '/:projectId/archive',
+    requireProjectMember(),
+    requireProjectDirector(),
+    async (c) => {
+      const userId = c.get('currentUserId');
+      const project = c.get('project');
+      const detail = await archiveProject({
+        projectId: project.projectId,
+        currentUserId: userId,
+      });
+      return c.json({ data: detail });
+    },
+  )
+
+  .post(
+    '/:projectId/unarchive',
+    requireProjectMember(),
+    requireProjectDirector(),
+    async (c) => {
+      const userId = c.get('currentUserId');
+      const project = c.get('project');
+      const detail = await unarchiveProject({
+        projectId: project.projectId,
+        currentUserId: userId,
+      });
+      return c.json({ data: detail });
+    },
+  )
 
   // ----------------------------- /projects/:projectId/items -----------------------------
   .get('/:projectId/items', requireProjectMember(), async (c) => {

--- a/apps/web/server/schemas/projects.test.ts
+++ b/apps/web/server/schemas/projects.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   createProjectBodySchema,
+  listProjectsQuerySchema,
   updateProjectBodySchema,
 } from './projects.js';
 
@@ -61,5 +62,32 @@ describe('updateProjectBodySchema', () => {
       endDate: '2026-01-01',
     });
     expect(r.success).toBe(false);
+  });
+});
+
+describe('listProjectsQuerySchema', () => {
+  it("parses archived='true' as boolean true", () => {
+    const r = listProjectsQuerySchema.parse({ archived: 'true' });
+    expect(r.archived).toBe(true);
+  });
+
+  it("parses archived='false' as boolean false", () => {
+    const r = listProjectsQuerySchema.parse({ archived: 'false' });
+    expect(r.archived).toBe(false);
+  });
+
+  it('leaves archived undefined when omitted', () => {
+    const r = listProjectsQuerySchema.parse({});
+    expect(r.archived).toBeUndefined();
+  });
+
+  it('rejects an invalid archived value', () => {
+    expect(listProjectsQuerySchema.safeParse({ archived: 'yes' }).success).toBe(false);
+  });
+
+  it('applies default limit/offset', () => {
+    const r = listProjectsQuerySchema.parse({});
+    expect(r.limit).toBe(50);
+    expect(r.offset).toBe(0);
   });
 });

--- a/apps/web/server/schemas/projects.ts
+++ b/apps/web/server/schemas/projects.ts
@@ -58,7 +58,12 @@ export const updateProjectBodySchema = z
 export type UpdateProjectBody = z.infer<typeof updateProjectBodySchema>;
 
 export const listProjectsQuerySchema = z.object({
-  status: z.enum(['active', 'closed']).optional(),
+  // 'true' のときのみアーカイブ済みを返す。未指定/'false' は未アーカイブのみ。
+  // z.coerce.boolean() は 'false' も true になるため使わない。
+  archived: z
+    .enum(['true', 'false'])
+    .transform((v) => v === 'true')
+    .optional(),
   limit: z.coerce.number().int().min(1).max(200).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });

--- a/apps/web/server/services/projects.ts
+++ b/apps/web/server/services/projects.ts
@@ -9,6 +9,8 @@ export type ProjectSummaryDTO = {
   startDate: string;
   endDate: string;
   status: 'active' | 'closed';
+  /// アーカイブ日時 (null = 未アーカイブ)
+  archivedAt: string | null;
   role: 'director' | 'member';
   createdBy: string;
   createdAt: string;
@@ -34,6 +36,7 @@ function toSummary(
     startDate: Date;
     endDate: Date;
     status: string;
+    archivedAt: Date | null;
     createdBy: string;
     createdAt: Date;
     updatedAt: Date;
@@ -46,6 +49,7 @@ function toSummary(
     startDate: toDateString(p.startDate),
     endDate: toDateString(p.endDate),
     status: p.status as 'active' | 'closed',
+    archivedAt: p.archivedAt ? p.archivedAt.toISOString() : null,
     role: p.createdBy === currentUserId ? 'director' : 'member',
     createdBy: p.createdBy,
     createdAt: p.createdAt.toISOString(),
@@ -55,20 +59,22 @@ function toSummary(
 
 /**
  * 自分が参加しているプロジェクトのみ返す (project_members を join)
+ * archived=true でアーカイブ済みのみ、それ以外は未アーカイブのみ返す。
  */
 export async function listProjects(
   userId: string,
-  q: { status?: 'active' | 'closed'; limit: number; offset: number },
+  q: { archived?: boolean; limit: number; offset: number },
 ): Promise<{ items: ProjectSummaryDTO[]; total: number }> {
   const where: Prisma.ProjectWhereInput = {
     deletedAt: null,
-    ...(q.status && { status: q.status }),
+    archivedAt: q.archived ? { not: null } : null,
     members: { some: { userId, deletedAt: null } },
   };
   const [rows, total] = await Promise.all([
     prisma.project.findMany({
       where,
-      orderBy: { updatedAt: 'desc' },
+      // アーカイブ一覧はアーカイブした順、それ以外は更新順
+      orderBy: q.archived ? { archivedAt: 'desc' } : { updatedAt: 'desc' },
       take: q.limit,
       skip: q.offset,
     }),
@@ -203,4 +209,34 @@ export async function updateProject(input: {
     project: await getProjectDetail(updated.id, input.currentUserId),
     warnings,
   };
+}
+
+/**
+ * プロジェクトをアーカイブする (archived_at を立てる)。
+ * 既にアーカイブ済みでも冪等に成功する。
+ */
+export async function archiveProject(input: {
+  projectId: string;
+  currentUserId: string;
+}): Promise<ProjectDetailDTO> {
+  await prisma.project.update({
+    where: { id: input.projectId },
+    data: { archivedAt: new Date() },
+  });
+  return getProjectDetail(input.projectId, input.currentUserId);
+}
+
+/**
+ * プロジェクトのアーカイブを解除する (復元)。
+ * 未アーカイブでも冪等に成功する。
+ */
+export async function unarchiveProject(input: {
+  projectId: string;
+  currentUserId: string;
+}): Promise<ProjectDetailDTO> {
+  await prisma.project.update({
+    where: { id: input.projectId },
+    data: { archivedAt: null },
+  });
+  return getProjectDetail(input.projectId, input.currentUserId);
 }

--- a/apps/web/src/features/projects/ProjectEditPage.tsx
+++ b/apps/web/src/features/projects/ProjectEditPage.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Loader2, Pencil, Plus, Trash2, Users, ArrowLeft, AlertCircle, CalendarDays, Link2 } from 'lucide-react';
+import { Loader2, Pencil, Plus, Trash2, Users, ArrowLeft, AlertCircle, CalendarDays, Link2, Archive, ArchiveRestore } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -176,8 +176,111 @@ function ProjectEditInner({ projectId, onBack }: { projectId: string; onBack: ()
           </Button>
         </CardContent>
       </Card>
+
+      {project.role === 'director' && (
+        <ArchiveCard
+          projectId={projectId}
+          name={project.name}
+          archived={project.archivedAt !== null}
+          onUnarchived={onBack}
+        />
+      )}
       </PageContainer>
     </>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// アーカイブセクション (director のみ)
+// -----------------------------------------------------------------------------
+function ArchiveCard({
+  projectId,
+  name,
+  archived,
+  onUnarchived,
+}: {
+  projectId: string;
+  name: string;
+  archived: boolean;
+  onUnarchived: () => void;
+}) {
+  const qc = useQueryClient();
+  const [confirming, setConfirming] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      archived ? projectsApi.unarchive(projectId) : projectsApi.archive(projectId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: projectsQueryKey.detail(projectId) });
+      qc.invalidateQueries({ queryKey: projectsQueryKey.all });
+      qc.invalidateQueries({ queryKey: projectsQueryKey.archived });
+      toast.success(archived ? 'プロジェクトを復元しました' : 'プロジェクトをアーカイブしました');
+      setConfirming(false);
+      // アーカイブした直後は一覧に残らないため一覧へ戻す
+      if (!archived) onUnarchived();
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '操作に失敗しました'),
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">アーカイブ</CardTitle>
+      </CardHeader>
+      <CardContent className="flex items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          {archived
+            ? 'このプロジェクトはアーカイブ済みです。復元すると一覧・サイドバーに再表示されます。'
+            : 'アーカイブするとプロジェクト一覧とサイドバーから非表示になります。'}
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setConfirming(true)}
+          disabled={mutation.isPending}
+        >
+          {archived ? (
+            <>
+              <ArchiveRestore className="size-4" />
+              復元する
+            </>
+          ) : (
+            <>
+              <Archive className="size-4" />
+              アーカイブする
+            </>
+          )}
+        </Button>
+      </CardContent>
+
+      <AlertDialog open={confirming} onOpenChange={(o) => !o && setConfirming(false)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {archived ? `「${name}」を復元しますか？` : `「${name}」をアーカイブしますか？`}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {archived
+                ? 'アーカイブを解除し、進行中の一覧に戻します。'
+                : 'プロジェクト一覧とサイドバーから非表示になります。アーカイブ済みタブから復元できます。'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                mutation.mutate();
+              }}
+              disabled={mutation.isPending}
+            >
+              {archived ? '復元する' : 'アーカイブする'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
   );
 }
 

--- a/apps/web/src/features/projects/ProjectListPage.tsx
+++ b/apps/web/src/features/projects/ProjectListPage.tsx
@@ -1,23 +1,32 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { Plus, ArrowRight, AlertCircle, Pencil } from 'lucide-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, ArrowRight, AlertCircle, Pencil, Archive, ArchiveRestore } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { PageContainer } from '@/components/layout/PageContainer';
 import { PageHeader } from '@/components/layout/PageHeader';
-import { projectsApi, projectsQueryKey } from './api';
+import { ApiClientError } from '@/lib/api';
+import { projectsApi, projectsQueryKey, type ProjectSummary } from './api';
 
 const dateFmt = new Intl.DateTimeFormat('ja-JP', { dateStyle: 'medium' });
 
 export function ProjectListPage() {
-  const { data, isLoading, error } = useQuery({
-    queryKey: projectsQueryKey.all,
-    queryFn: projectsApi.list,
-  });
-
   return (
     <>
       <PageHeader
@@ -34,75 +43,187 @@ export function ProjectListPage() {
         }
       />
       <PageContainer width="lg">
-        {isLoading && <ListSkeleton />}
+        <Tabs defaultValue="active">
+          <TabsList>
+            <TabsTrigger value="active">進行中</TabsTrigger>
+            <TabsTrigger value="archived">アーカイブ済み</TabsTrigger>
+          </TabsList>
+          <TabsContent value="active" className="mt-4">
+            <ProjectList archived={false} />
+          </TabsContent>
+          <TabsContent value="archived" className="mt-4">
+            <ProjectList archived={true} />
+          </TabsContent>
+        </Tabs>
+      </PageContainer>
+    </>
+  );
+}
 
-      {error && (
-        <Card>
-          <CardContent className="flex items-center gap-2 pt-6 text-sm text-destructive">
-            <AlertCircle className="size-4" />
-            プロジェクト一覧の取得に失敗しました。
-          </CardContent>
-        </Card>
-      )}
+function ProjectList({ archived }: { archived: boolean }) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: archived ? projectsQueryKey.archived : projectsQueryKey.all,
+    queryFn: () => projectsApi.list({ archived }),
+  });
 
-      {data && data.length === 0 && (
-        <Card>
-          <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
-            <p className="text-sm text-muted-foreground">
-              まだプロジェクトがありません。
-            </p>
+  if (isLoading) return <ListSkeleton />;
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="flex items-center gap-2 pt-6 text-sm text-destructive">
+          <AlertCircle className="size-4" />
+          プロジェクト一覧の取得に失敗しました。
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (data && data.length === 0) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+          <p className="text-sm text-muted-foreground">
+            {archived
+              ? 'アーカイブされたプロジェクトはありません。'
+              : 'まだプロジェクトがありません。'}
+          </p>
+          {!archived && (
             <Button asChild size="sm">
               <Link to="/projects/new">最初のプロジェクトを作成</Link>
             </Button>
-          </CardContent>
-        </Card>
-      )}
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
 
-      {data && data.length > 0 && (
-        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {data.map((p) => (
-            <li key={p.id}>
-              <Card className="hover:border-foreground/30 transition-colors">
-                <CardHeader>
-                  <div className="flex items-start justify-between gap-2">
-                    <CardTitle className="text-base">{p.name}</CardTitle>
-                    <div className="flex shrink-0 items-center gap-1">
-                      <Badge variant={p.status === 'active' ? 'default' : 'secondary'}>
-                        {p.status === 'active' ? '進行中' : '終了'}
-                      </Badge>
-                      <Button variant="ghost" size="icon" className="size-7" asChild>
-                        <Link to={`/projects/${p.id}/edit`} aria-label="編集">
-                          <Pencil className="size-4" />
-                        </Link>
-                      </Button>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-3 text-sm">
-                  <div className="text-muted-foreground">
-                    {dateFmt.format(new Date(p.startDate))} —{' '}
-                    {dateFmt.format(new Date(p.endDate))}
-                  </div>
-                  <div className="flex items-center justify-between text-xs text-muted-foreground">
-                    <span>{p.role === 'director' ? 'ディレクター' : 'メンバー'}</span>
-                    <span>更新 {dateFmt.format(new Date(p.updatedAt))}</span>
-                  </div>
-                  <div className="flex gap-2">
-                    <Button variant="outline" size="sm" asChild>
-                      <Link to={`/projects/${p.id}`}>
-                        スケジュール
-                        <ArrowRight className="size-3.5" />
-                      </Link>
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
-            </li>
-          ))}
-        </ul>
-      )}
-      </PageContainer>
-    </>
+  return (
+    <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {(data ?? []).map((p) => (
+        <li key={p.id}>
+          <ProjectCard project={p} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ProjectCard({ project: p }: { project: ProjectSummary }) {
+  const qc = useQueryClient();
+  const [confirming, setConfirming] = useState(false);
+  const isArchived = p.archivedAt !== null;
+  const isDirector = p.role === 'director';
+
+  const mutation = useMutation({
+    mutationFn: () => (isArchived ? projectsApi.unarchive(p.id) : projectsApi.archive(p.id)),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: projectsQueryKey.all });
+      qc.invalidateQueries({ queryKey: projectsQueryKey.archived });
+      qc.invalidateQueries({ queryKey: projectsQueryKey.detail(p.id) });
+      toast.success(isArchived ? 'プロジェクトを復元しました' : 'プロジェクトをアーカイブしました');
+      setConfirming(false);
+    },
+    onError: (err) =>
+      toast.error(err instanceof ApiClientError ? err.message : '操作に失敗しました'),
+  });
+
+  return (
+    <Card className="hover:border-foreground/30 transition-colors">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-base">{p.name}</CardTitle>
+          <div className="flex shrink-0 items-center gap-1">
+            {isArchived ? (
+              <Badge variant="outline">アーカイブ済み</Badge>
+            ) : (
+              <Badge variant={p.status === 'active' ? 'default' : 'secondary'}>
+                {p.status === 'active' ? '進行中' : '終了'}
+              </Badge>
+            )}
+            {!isArchived && (
+              <Button variant="ghost" size="icon" className="size-7" asChild>
+                <Link to={`/projects/${p.id}/edit`} aria-label="編集">
+                  <Pencil className="size-4" />
+                </Link>
+              </Button>
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <div className="text-muted-foreground">
+          {dateFmt.format(new Date(p.startDate))} — {dateFmt.format(new Date(p.endDate))}
+        </div>
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>{p.role === 'director' ? 'ディレクター' : 'メンバー'}</span>
+          <span>
+            {isArchived && p.archivedAt
+              ? `アーカイブ ${dateFmt.format(new Date(p.archivedAt))}`
+              : `更新 ${dateFmt.format(new Date(p.updatedAt))}`}
+          </span>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link to={`/projects/${p.id}`}>
+              スケジュール
+              <ArrowRight className="size-3.5" />
+            </Link>
+          </Button>
+          {isDirector &&
+            (isArchived ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirming(true)}
+                disabled={mutation.isPending}
+              >
+                <ArchiveRestore className="size-3.5" />
+                復元
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirming(true)}
+                disabled={mutation.isPending}
+              >
+                <Archive className="size-3.5" />
+                アーカイブ
+              </Button>
+            ))}
+        </div>
+      </CardContent>
+
+      <AlertDialog open={confirming} onOpenChange={(o) => !o && setConfirming(false)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {isArchived
+                ? `「${p.name}」を復元しますか？`
+                : `「${p.name}」をアーカイブしますか？`}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {isArchived
+                ? 'アーカイブを解除し、進行中の一覧に戻します。'
+                : 'プロジェクト一覧とサイドバーから非表示になります。アーカイブ済みタブから復元できます。'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                mutation.mutate();
+              }}
+              disabled={mutation.isPending}
+            >
+              {isArchived ? '復元する' : 'アーカイブする'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
   );
 }
 

--- a/apps/web/src/features/projects/api.ts
+++ b/apps/web/src/features/projects/api.ts
@@ -6,6 +6,8 @@ export type ProjectSummary = {
   startDate: string;
   endDate: string;
   status: 'active' | 'closed';
+  /** アーカイブ日時 (null = 未アーカイブ) */
+  archivedAt: string | null;
   role: 'director' | 'member';
   createdBy: string;
   createdAt: string;
@@ -51,12 +53,17 @@ export type UpdateProjectInput = Partial<{
 export type Warning = { code: string; message: string };
 
 export const projectsApi = {
-  list: () => apiRequest<ProjectSummary[]>('/projects'),
+  list: (params?: { archived?: boolean }) =>
+    apiRequest<ProjectSummary[]>(`/projects${params?.archived ? '?archived=true' : ''}`),
   get: (projectId: string) => apiRequest<ProjectDetail>(`/projects/${projectId}`),
   create: (body: CreateProjectInput) =>
     apiRequest<ProjectDetail>('/projects', { method: 'POST', body }),
   update: (projectId: string, body: UpdateProjectInput) =>
     apiRequest<ProjectDetail>(`/projects/${projectId}`, { method: 'PATCH', body }),
+  archive: (projectId: string) =>
+    apiRequest<ProjectDetail>(`/projects/${projectId}/archive`, { method: 'POST' }),
+  unarchive: (projectId: string) =>
+    apiRequest<ProjectDetail>(`/projects/${projectId}/unarchive`, { method: 'POST' }),
 
   listItems: (projectId: string) =>
     apiRequest<ProjectItem[]>(`/projects/${projectId}/items`),
@@ -77,6 +84,7 @@ export const projectsApi = {
 
 export const projectsQueryKey = {
   all: ['projects'] as const,
+  archived: ['projects', 'archived'] as const,
   detail: (id: string) => ['projects', id] as const,
   items: (id: string) => ['projects', id, 'items'] as const,
 };


### PR DESCRIPTION
## 概要

完了・不要になったプロジェクトを一覧/サイドバーから片付け（アーカイブ）し、専用タブで見返し・復元できるようにします。

- Closes #61（プロジェクト完了はアーカイブ出来るようにしたい）
- Closes #62（アーカイブされたスケジュール一覧を表示できるようにしたい）

## 方針（ユーザー確認済み）

- **アーカイブは独立フラグ**: 既存だが未使用の `Project.archivedAt`（nullable TIMESTAMPTZ）を使用。`status`（進行中/終了）は変更しない。完了済みかどうかに関わらずいつでもアーカイブ可。
- **マイグレーション不要**: カラム・index は `20260525000001_init_projects` で作成済み。スキーマ変更なし（`prisma format --check` 差分ゼロ）。本番反映もリリース時の `prisma migrate deploy` で適用すべき新規マイグレーションはありません。
- **一覧（#62）**: プロジェクト一覧ページに「進行中／アーカイブ済み」タブを追加。サイドバーのクイック一覧は既定でアーカイブを除外。
- **操作**: プロジェクト編集ページ＋一覧カードからアーカイブ／復元。権限は **director のみ**（既存 PATCH と同じ `requireProjectDirector`）。

## 変更点

### バックエンド
- `services/projects.ts`: `ProjectSummaryDTO.archivedAt` 追加、`listProjects` を `archived` フィルタ対応に、`archiveProject` / `unarchiveProject` を追加（冪等）。
- `schemas/projects.ts`: `listProjectsQuerySchema` に `archived`（`'true'`/`'false'` を安全に boolean 化）を追加。
- `routes/v1/projects.ts`: `GET /projects?archived=` 対応、`POST /projects/:id/archive`・`/unarchive`（director 限定）を追加。

### フロントエンド
- `features/projects/api.ts`: `archivedAt`・`list({archived})`・`archive`/`unarchive`・query key `archived` を追加。
- `ProjectListPage.tsx`: 「進行中／アーカイブ済み」タブ、各カードにアーカイブ/復元操作（確認ダイアログ）。
- `ProjectEditPage.tsx`: アーカイブ/復元カードを追加（director のみ）。
- サイドバーは既定（`list()`）でアーカイブ除外のため変更なし。

## テスト
- `schemas/projects.test.ts`: `archived` パースのテストを追加。
- `routes/v1/projects.test.ts`: `archive`/`unarchive` の未認証 401 ガードを追加。
- 全 71 テスト pass / type-check・lint（警告ゼロ）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)