### PR TITLE
feat(plans): 予定間コネクトの視認性を向上 (#64)

### DIFF
--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -29,6 +29,7 @@ import { useSetSuccessor } from './useOptimisticBallAction';
 import {
   assignLanes,
   ballTier,
+  chipVerticalBounds,
   dayIndex,
   isActiveNow,
   isOverdue,
@@ -341,6 +342,42 @@ function isValidLinkTarget(source: Plan, target: Plan, itemPlans: Plan[]): boole
   return true;
 }
 
+/**
+ * planId が属する後続チェーン (前後双方向にたどった全 plan) と、
+ * その内部リンク (チェーン内の先行→後続) の source id 集合を返す。
+ * ホバー時のチェーン強調に使う。
+ */
+function computeChain(
+  itemPlans: Plan[],
+  planId: string,
+): { chainIds: Set<string>; linkSourceIds: Set<string> } {
+  const byId = new Map(itemPlans.map((p) => [p.id, p]));
+  const predOf = new Map<string, string>(); // successorId -> predecessorId
+  for (const p of itemPlans) {
+    if (p.successorPlanId) predOf.set(p.successorPlanId, p.id);
+  }
+  const chainIds = new Set<string>();
+  // 後続方向
+  let cur: Plan | undefined = byId.get(planId);
+  while (cur && !chainIds.has(cur.id)) {
+    chainIds.add(cur.id);
+    cur = cur.successorPlanId ? byId.get(cur.successorPlanId) : undefined;
+  }
+  // 先行方向
+  let prevId = predOf.get(planId);
+  while (prevId && !chainIds.has(prevId)) {
+    chainIds.add(prevId);
+    prevId = predOf.get(prevId);
+  }
+  // チェーン内リンク (両端がチェーンに含まれる先行 plan)
+  const linkSourceIds = new Set<string>();
+  for (const id of chainIds) {
+    const succ = byId.get(id)?.successorPlanId;
+    if (succ && chainIds.has(succ)) linkSourceIds.add(id);
+  }
+  return { chainIds, linkSourceIds };
+}
+
 function ScheduleBoard({
   days,
   items,
@@ -371,6 +408,9 @@ function ScheduleBoard({
   const [linkDrag, setLinkDrag] = useState<LinkDrag | null>(null);
   const linkRef = useRef<LinkDrag | null>(null);
   linkRef.current = linkDrag;
+
+  // ホバー中の予定 (チェーン強調用)。ドラッグ中は抑制する。
+  const [hoveredPlanId, setHoveredPlanId] = useState<string | null>(null);
 
   const startLink = (e: React.PointerEvent, plan: Plan) => {
     e.stopPropagation();
@@ -421,6 +461,10 @@ function ScheduleBoard({
   const [createDrag, setCreateDrag] = useState<CreateDrag | null>(null);
   const createDragRef = useRef<CreateDrag | null>(null);
   createDragRef.current = createDrag;
+
+  // ドラッグ系の操作中はホバー強調を抑制する。
+  const interacting = drag !== null || linkDrag !== null || createDrag !== null;
+  const activeHoverId = interacting ? null : hoveredPlanId;
 
   useEffect(() => {
     if (!createDrag) return;
@@ -552,6 +596,17 @@ function ScheduleBoard({
           const repHolder = activePlans.length
             ? activePlans[activePlans.length - 1]!.ballHolder
             : null;
+          // コネクト印用: 先行 (誰かの後続として指されている) plan の id 集合
+          const predecessorTargetIds = new Set(
+            itemPlans
+              .map((p) => p.successorPlanId)
+              .filter((id): id is string => id !== null),
+          );
+          // ホバー中の予定がこの列に属するならチェーンを算出
+          const chain =
+            activeHoverId && itemPlans.some((p) => p.id === activeHoverId)
+              ? computeChain(itemPlans, activeHoverId)
+              : null;
           return (
             <div
               key={item.id}
@@ -623,17 +678,6 @@ function ScheduleBoard({
                   );
                 })}
 
-                {/* 後続リンク (同一列内) を線で可視化 */}
-                <LinkLayer
-                  plans={itemPlans}
-                  laneOf={laneOf}
-                  days={days}
-                  rowHeight={rowHeight}
-                  laneWidth={laneWidth}
-                  width={colWidth}
-                  height={totalHeight}
-                />
-
                 {/* ボール */}
                 {itemPlans.map((plan) => (
                   <BallChip
@@ -646,7 +690,11 @@ function ScheduleBoard({
                     today={today}
                     drag={drag?.plan.id === plan.id ? drag : null}
                     linkTarget={linkDrag?.targetId === plan.id}
+                    hasSuccessor={plan.successorPlanId !== null}
+                    hasPredecessor={predecessorTargetIds.has(plan.id)}
+                    inChain={chain?.chainIds.has(plan.id) ?? false}
                     onActivate={() => onOpenDetail(plan.id)}
+                    onHoverChange={setHoveredPlanId}
                     onPointerDownConnector={(e) => startLink(e, plan)}
                     onPointerDownBall={(e, mode) => {
                       e.stopPropagation();
@@ -661,6 +709,19 @@ function ScheduleBoard({
                     }}
                   />
                 ))}
+
+                {/* 後続コネクト (同一列内) を線で可視化。チップより後ろに描き前面に出す */}
+                <LinkLayer
+                  plans={itemPlans}
+                  laneOf={laneOf}
+                  days={days}
+                  rowHeight={rowHeight}
+                  laneWidth={laneWidth}
+                  width={colWidth}
+                  height={totalHeight}
+                  highlightSourceIds={chain?.linkSourceIds ?? null}
+                  dimOthers={chain !== null}
+                />
               </div>
             </div>
           );
@@ -700,11 +761,10 @@ function chipCenters(
   const { start, end } = planRange(plan);
   const startIdx = dayIndex(days, start);
   const endIdx = dayIndex(days, end);
-  const top = startIdx * rowHeight + 1;
-  const height = (endIdx - startIdx + 1) * rowHeight - 3;
+  const { top, bottom } = chipVerticalBounds(startIdx, endIdx, rowHeight);
   const lane = laneOf.get(plan.id) ?? 0;
   const cx = lane * laneWidth + 6 + (laneWidth - 12) / 2;
-  return { cx, top, bottom: top + height };
+  return { cx, top, bottom };
 }
 
 function LinkLayer({
@@ -715,6 +775,8 @@ function LinkLayer({
   laneWidth,
   width,
   height,
+  highlightSourceIds,
+  dimOthers,
 }: {
   plans: Plan[];
   laneOf: Map<string, number>;
@@ -723,43 +785,66 @@ function LinkLayer({
   laneWidth: number;
   width: number;
   height: number;
+  // チェーン強調対象 (先行 plan の id 集合)。null ならホバー強調なし
+  highlightSourceIds: Set<string> | null;
+  // ホバー中、チェーン外のリンクを減光するか
+  dimOthers: boolean;
 }) {
   const byId = new Map(plans.map((p) => [p.id, p]));
-  const links: { x1: number; y1: number; x2: number; y2: number }[] = [];
+  const links: { x1: number; y1: number; x2: number; y2: number; sourceId: string }[] = [];
   for (const p of plans) {
     if (!p.successorPlanId) continue;
     const succ = byId.get(p.successorPlanId);
     if (!succ) continue; // 別制作物 or 未ロード
     const a = chipCenters(p, days, rowHeight, laneWidth, laneOf);
     const b = chipCenters(succ, days, rowHeight, laneWidth, laneOf);
-    links.push({ x1: a.cx, y1: a.bottom, x2: b.cx, y2: b.top });
+    links.push({ x1: a.cx, y1: a.bottom, x2: b.cx, y2: b.top, sourceId: p.id });
   }
   if (links.length === 0) return null;
   return (
     <svg
-      className="pointer-events-none absolute inset-0 z-0"
+      className="pointer-events-none absolute inset-0 z-20"
       width={width}
       height={height}
       style={{ overflow: 'visible' }}
       aria-hidden
     >
       <defs>
-        <marker id="succ-arrow" markerWidth="6" markerHeight="6" refX="4.5" refY="3" orient="auto">
-          <path d="M0,0 L6,3 L0,6 Z" className="fill-sky-400" />
+        <marker id="succ-arrow" markerWidth="7" markerHeight="7" refX="5" refY="3.5" orient="auto">
+          <path d="M0,0 L7,3.5 L0,7 Z" className="fill-sky-500" />
+        </marker>
+        <marker
+          id="succ-arrow-hl"
+          markerWidth="8"
+          markerHeight="8"
+          refX="5.5"
+          refY="4"
+          orient="auto"
+        >
+          <path d="M0,0 L8,4 L0,8 Z" className="fill-sky-600" />
         </marker>
       </defs>
       {links.map((l, i) => {
         const midY = (l.y1 + l.y2) / 2;
         const d = `M ${l.x1} ${l.y1} C ${l.x1} ${midY}, ${l.x2} ${midY}, ${l.x2} ${l.y2}`;
+        const highlighted = highlightSourceIds?.has(l.sourceId) ?? false;
+        const dimmed = dimOthers && !highlighted;
         return (
-          <path
-            key={i}
-            d={d}
-            strokeWidth={1.5}
-            strokeDasharray="3 3"
-            markerEnd="url(#succ-arrow)"
-            className="fill-none stroke-sky-400"
-          />
+          <g key={i} className={cn(dimmed && 'opacity-30')}>
+            {/* 白い裏地 (halo): 背景色差に負けず線を浮き立たせる */}
+            <path
+              d={d}
+              strokeWidth={highlighted ? 5 : 4}
+              className="fill-none stroke-background opacity-80"
+            />
+            <path
+              d={d}
+              strokeWidth={highlighted ? 2.5 : 2}
+              strokeDasharray="4 3"
+              markerEnd={highlighted ? 'url(#succ-arrow-hl)' : 'url(#succ-arrow)'}
+              className={cn('fill-none', highlighted ? 'stroke-sky-600' : 'stroke-sky-500')}
+            />
+          </g>
         );
       })}
     </svg>
@@ -779,7 +864,11 @@ function BallChip({
   today,
   drag,
   linkTarget,
+  hasSuccessor,
+  hasPredecessor,
+  inChain,
   onActivate,
+  onHoverChange,
   onPointerDownBall,
   onPointerDownConnector,
 }: {
@@ -791,7 +880,11 @@ function BallChip({
   today: Date;
   drag: DragState | null;
   linkTarget: boolean;
+  hasSuccessor: boolean;
+  hasPredecessor: boolean;
+  inChain: boolean;
   onActivate: () => void;
+  onHoverChange: (planId: string | null) => void;
   onPointerDownBall: (e: React.PointerEvent, mode: DragState['mode']) => void;
   onPointerDownConnector: (e: React.PointerEvent) => void;
 }) {
@@ -811,8 +904,7 @@ function BallChip({
     }
   }
 
-  const top = startIdx * rowHeight + 1;
-  const height = (endIdx - startIdx + 1) * rowHeight - 3;
+  const { top, height } = chipVerticalBounds(startIdx, endIdx, rowHeight);
   const tier = ballTier(height);
   const style = CATEGORY_STYLE[plan.category];
   const completed = plan.status === 'completed';
@@ -830,6 +922,15 @@ function BallChip({
         ? 'border-slate-300 bg-slate-100 text-slate-600'
         : cn(style.bg, style.border, style.text);
 
+  // リング表現は排他にして色の衝突を避ける (紐づけ対象 > チェーン > 進行中)
+  const ringClass = linkTarget
+    ? 'ring-2 ring-primary ring-offset-1'
+    : inChain
+      ? 'ring-2 ring-sky-500'
+      : active && !completed
+        ? 'ring-2 ring-primary/40'
+        : undefined;
+
   return (
     <div
       role="button"
@@ -842,11 +943,12 @@ function BallChip({
       }}
       data-plan-id={plan.id}
       onPointerDown={(e) => onPointerDownBall(e, 'move')}
+      onPointerEnter={() => onHoverChange(plan.id)}
+      onPointerLeave={() => onHoverChange(null)}
       className={cn(
         'group absolute overflow-hidden rounded-md border px-2 py-1 text-xs shadow-sm',
         cardClass,
-        active && !completed && 'ring-2 ring-primary/40',
-        linkTarget && 'ring-2 ring-primary ring-offset-1',
+        ringClass,
         drag?.mode === 'move' && 'opacity-70',
         editable ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
       )}
@@ -862,6 +964,14 @@ function BallChip({
         <div
           onPointerDown={(e) => onPointerDownBall(e, 'resize-top')}
           className="absolute inset-x-0 top-0 h-1.5 cursor-ns-resize"
+          aria-hidden
+        />
+      )}
+
+      {/* 先行コネクトの受け口 (上端中央): 先行予定がある場合に常時表示する線の終点アンカー */}
+      {hasPredecessor && (
+        <div
+          className="pointer-events-none absolute left-1/2 top-0 z-10 size-2.5 -translate-x-1/2 rounded-full border-2 border-background bg-sky-500 shadow"
           aria-hidden
         />
       )}
@@ -908,12 +1018,24 @@ function BallChip({
         />
       )}
 
-      {/* 後続紐づけコネクタ (下端中央): ドラッグして別カードに重ねると後続に設定 */}
+      {/* 後続コネクトの起点 (下端中央): 後続予定がある場合に常時表示する線の起点アンカー。
+          編集可・mini以外ではホバー時に作成/張り替えハンドルへ譲る。 */}
+      {hasSuccessor && (
+        <div
+          className={cn(
+            'pointer-events-none absolute bottom-0 left-1/2 z-10 size-2.5 -translate-x-1/2 rounded-full border-2 border-background bg-sky-500 shadow',
+            editable && tier !== 'mini' && 'transition-opacity group-hover:opacity-0',
+          )}
+          aria-hidden
+        />
+      )}
+
+      {/* 後続紐づけハンドル (下端中央): ドラッグして別カードに重ねると後続に設定/張り替え */}
       {editable && tier !== 'mini' && (
         <div
           onPointerDown={onPointerDownConnector}
-          className="absolute bottom-0 left-1/2 z-10 size-3 -translate-x-1/2 cursor-crosshair rounded-full border-2 border-background bg-sky-500 opacity-0 shadow transition-opacity group-hover:opacity-100"
-          title="ドラッグして後続タスクに紐づけ"
+          className="absolute bottom-0 left-1/2 z-20 size-3 -translate-x-1/2 cursor-crosshair rounded-full border-2 border-background bg-sky-500 opacity-0 shadow transition-opacity group-hover:opacity-100"
+          title={hasSuccessor ? 'ドラッグして後続予定を張り替え' : 'ドラッグして後続予定に紐づけ'}
           aria-hidden
         />
       )}

--- a/apps/web/src/features/plans/scheduleLayout.ts
+++ b/apps/web/src/features/plans/scheduleLayout.ts
@@ -15,6 +15,26 @@ export const ROW_HEIGHT_DEFAULT = 40;
 export const ROW_HEIGHT_STEP = 5;
 
 /**
+ * カードの上下インセット px。隣接日のカード間に `CARD_INSET_Y*2` の隙間を生み、
+ * 後続コネクト線と矢印を描く余白を確保する (#64)。
+ */
+export const CARD_INSET_Y = 4;
+
+/**
+ * 行インデックス範囲からカードの縦位置 (top/height/bottom) を求める共通関数。
+ * BallChip の配置と LinkLayer の端点計算で同じ式を使い、線とカードのズレを防ぐ。
+ */
+export function chipVerticalBounds(
+  startIdx: number,
+  endIdx: number,
+  rowHeight: number,
+): { top: number; height: number; bottom: number } {
+  const top = startIdx * rowHeight + CARD_INSET_Y;
+  const height = (endIdx - startIdx + 1) * rowHeight - CARD_INSET_Y * 2;
+  return { top, height, bottom: top + height };
+}
+
+/**
  * 縦方向のズーム量 (rowHeight) から横方向の倍率を導出する。
  * 拡大バー1本で縦横を連動させるための共通係数 (既定40で1.0 / 20で0.5 / 80で2.0)。
  */


### PR DESCRIPTION
## 概要
Issue #64「予定と予定の間に『コネクト』が見えるようにしたい」対応。スケジュール（`ItemSchedulePage.tsx`）上の後続コネクト（同一制作物内の `Plan.successorPlanId`）を見やすくする FE のみの改善。

issue 本文が空（タイトルのみ）のため、方向性をユーザーに確認のうえ「**視認性の向上（FEのみ）**」で実装。制作物をまたぐコネクト（BE データモデル変更）は対象外。

## 変更点
- **カードに上下インセット**: `scheduleLayout.ts` に `CARD_INSET_Y` と `chipVerticalBounds()` を追加。隣接日にカードが並んでも線を描く隙間（3px→8px）を確保。`BallChip` と `chipCenters` の重複した縦位置計算を一本化しズレを防止。
- **コネクト線を前面・強調**: `LinkLayer` をチップ後（DOM順）に移して `z-20` で前面化（`pointer-events-none`）。白い裏地(halo)＋太め(2px)＋sky-500＋大きめ矢印で視認性を強化。
- **チップにコネクト印**: 後続あり／先行ありのカードに、線の起点・終点に一致する常時アンカーを表示（mini ズームでも見える）。未接続カードは従来どおりホバーで作成ハンドル。
- **ホバーでチェーン強調**: カードにホバーすると前後の後続チェーン（線＋カード）をハイライト。チェーン外の線は減光。ドラッグ操作中は抑制。

## 動作・互換
- ドラッグでの後続作成／張り替え、詳細モーダルでの解除など既存機能はそのまま。
- BE・Prisma・スキーマ変更なし。

## 検証
- `pnpm --filter @trakon/web type-check` ✅
- `pnpm --filter @trakon/web lint`（警告ゼロ）✅
- ※ ローカル実行（Supabase）はワークトリーに `.env.local` が無いため未実施。レビュー環境（Vercel Preview）での目視確認を推奨。

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)