### PR TITLE
fix(plans): 実施者/確認者未設定の予定作成を許可し500を解消 (#55)

### DIFF
--- a/packages/db/prisma/migrations/20260620000002_relax_plans_toss_members/migration.sql
+++ b/packages/db/prisma/migrations/20260620000002_relax_plans_toss_members/migration.sql
@@ -1,0 +1,16 @@
+-- -----------------------------------------------------------------------------
+-- Migration: 20260620000002_relax_plans_toss_members
+-- ck_plans_toss_members を緩和し、実施者(FROM)/確認者(TO) 未設定の予定作成を許可する。
+--  - 実施者/確認者は任意で後から設定できる仕様 (#55) に DB CHECK を合わせる。
+--  - 旧 CHECK は plan_type='toss' のとき from/to を NOT NULL 必須としており、
+--    {title, category, scheduledDate} のみの予定作成が CHECK 違反 (500) になっていた。
+--  - 新 CHECK は「両方指定された場合のみ from <> to を強制」し、NULL は許容する。
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE "plans" DROP CONSTRAINT "ck_plans_toss_members";
+
+ALTER TABLE "plans" ADD CONSTRAINT "ck_plans_toss_members" CHECK (
+    "from_member_id" IS NULL
+    OR "to_member_id" IS NULL
+    OR "from_member_id" <> "to_member_id"
+);


### PR DESCRIPTION
## 概要
予定追加時に API が **500 エラー**を返す問題を修正します。

例: `{title: "コーディング", category: "coding", scheduledDate: "2026-06-28"}` のように
実施者(FROM)/確認者(TO) を指定せず作成すると 500 になっていました。

## 原因
DB の CHECK 制約 `ck_plans_toss_members`（`20260526000001_init_plans`）が
`plan_type='toss'` のとき `from_member_id` / `to_member_id` を **NOT NULL 必須**と
していました。一方アプリ側は #55 で実施者/確認者を**任意（後から設定可）**にして
おり（Zod スキーマ・Prisma カラムともに nullable）、両者が矛盾。未設定で作成すると
Postgres の CHECK 違反 → 500 になっていました。この制約を緩和するマイグレーションが
未作成（DDL適用漏れ）だったのが根本原因です。

## 修正
新規マイグレーション `20260620000002_relax_plans_toss_members` を追加し、CHECK を
緩和します。

- 旧: `plan_type<>'toss' OR (from NOT NULL AND to NOT NULL AND from<>to)`
- 新: `from IS NULL OR to IS NULL OR from<>to`（両方指定時のみ from≠to を強制、NULL許容）

スキーマ／サービス層は既に任意化済みのためコード変更は不要です。

## 確認
- `prisma format` で schema.prisma に差分が出ないこと（CHECK は migration 管理）を確認。
- 反映には対象DBへの `prisma migrate deploy`（本番は Release）が必要です。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)