### PR TITLE
feat(plans): 完了の差し戻し機能 (#89)

### DIFF
--- a/apps/web/server/routes/v1/plans.test.ts
+++ b/apps/web/server/routes/v1/plans.test.ts
@@ -55,4 +55,12 @@ describe('plans routes', () => {
     });
     expect(res.status).toBe(401);
   });
+
+  it('requires authentication for POST /complete-undo', async () => {
+    const { app } = await import('../../app.js');
+    const res = await app.request('/api/v1/projects/abc/items/def/plans/xyz/complete-undo', {
+      method: 'POST',
+    });
+    expect(res.status).toBe(401);
+  });
 });

--- a/apps/web/server/routes/v1/plans.ts
+++ b/apps/web/server/routes/v1/plans.ts
@@ -22,7 +22,12 @@ import {
   setPlanSuccessor,
   updatePlan,
 } from '../../services/plans.js';
-import { completePlan, tossPlan, undoTossPlan } from '../../services/ballActions.js';
+import {
+  completePlan,
+  tossPlan,
+  undoCompletePlan,
+  undoTossPlan,
+} from '../../services/ballActions.js';
 
 /**
  * `/projects/:projectId/items/:itemId/plans` 配下のエンドポイント。
@@ -36,7 +41,9 @@ import { completePlan, tossPlan, undoTossPlan } from '../../services/ballActions
  *  - DELETE /:planId                削除 (ball_events なしのみ)
  *  - PATCH  /:planId/successor      後続紐付け
  *  - POST   /:planId/toss           TOSS 実行
+ *  - POST   /:planId/toss-undo      TOSS 差し戻し
  *  - POST   /:planId/complete       完了
+ *  - POST   /:planId/complete-undo  完了の差し戻し (#89)
  */
 export const plansRoute = new Hono()
   .use('*', requireProjectMember())
@@ -147,6 +154,22 @@ export const plansRoute = new Hono()
     const planId = c.req.param('planId');
     if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
     const result = await completePlan({
+      itemId,
+      projectId: project.projectId,
+      planId,
+      currentUserId: c.get('currentUserId'),
+      currentMemberId: project.memberId,
+      isDirector: project.isDirector,
+    });
+    return c.json({ data: result });
+  })
+
+  .post('/:planId/complete-undo', async (c) => {
+    const itemId = c.get('itemId');
+    const project = c.get('project');
+    const planId = c.req.param('planId');
+    if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
+    const result = await undoCompletePlan({
       itemId,
       projectId: project.projectId,
       planId,

--- a/apps/web/server/services/ballActions.ts
+++ b/apps/web/server/services/ballActions.ts
@@ -40,13 +40,14 @@ async function loadPlanWithIncludes(
 
 /**
  * 最新イベント 1 件で現在の ball state を判定する。
- * toss_undone (差し戻し) は直前の tossed を打ち消し ready に戻す。
+ * toss_undone (差し戻し) は直前の tossed を打ち消し ready に、
+ * completion_undone (完了の差し戻し) は直前の completed を打ち消し tossed に戻す。
  * ball_events は occurredAt DESC で取得しているので [0] が最新。
  */
 function currentBallState(plan: PlanWithIncludes): 'ready' | 'tossed' | 'completed' {
   const latest = plan.ballEvents[0];
   if (!latest || latest.eventType === 'toss_undone') return 'ready';
-  if (latest.eventType === 'tossed') return 'tossed';
+  if (latest.eventType === 'tossed' || latest.eventType === 'completion_undone') return 'tossed';
   return 'completed';
 }
 
@@ -57,7 +58,7 @@ function ballHolderMemberId(plan: PlanWithIncludes): string | null {
 async function recordAudit(input: {
   tx: Prisma.TransactionClient;
   actorUserId: string;
-  action: 'toss' | 'complete' | 'auto_toss' | 'untoss';
+  action: 'toss' | 'complete' | 'auto_toss' | 'untoss' | 'undo_complete';
   planId: string;
 }): Promise<void> {
   await input.tx.auditLog.create({
@@ -282,6 +283,101 @@ export async function undoTossPlan(input: {
       tx,
       actorUserId: input.currentUserId,
       action: 'untoss',
+      planId: plan.id,
+    });
+
+    return loadPlanWithIncludes(tx, plan.id, input.itemId);
+  });
+
+  return { plan: toPlanDTO(result, []) };
+}
+
+// -----------------------------------------------------------------------------
+// Undo Complete (完了の差し戻し) — #89
+// -----------------------------------------------------------------------------
+export async function undoCompletePlan(input: {
+  itemId: string;
+  projectId: string;
+  planId: string;
+  currentUserId: string;
+  currentMemberId: string;
+  isDirector: boolean;
+}): Promise<{ plan: PlanDTO }> {
+  const result = await prisma.$transaction(async (tx) => {
+    const plan = await loadPlanWithIncludes(tx, input.planId, input.itemId);
+
+    if (plan.status !== 'completed') {
+      throw new ApiException('PLAN_NOT_COMPLETED', 422, 'Plan is not completed.');
+    }
+
+    // 認可: 完了直前のボール保持者 (= toMember) または ディレクター。
+    // 完了済みプランの holder は toMember (完了者) なので completePlan と対称。
+    const holder = ballHolderMemberId(plan);
+    if (!input.isDirector && holder !== input.currentMemberId) {
+      throw new ApiException(
+        'FORBIDDEN',
+        403,
+        'Only the ball holder or director can undo a completion.',
+      );
+    }
+
+    // 完了時に後続を自動 TOSS していた場合、その auto_chain TOSS も巻き戻す。
+    // - 後続の最新イベントが auto_chain の tossed → この完了が誘発したもの。toss_undone で ready に戻す。
+    // - 後続が既に完了している → 差し戻すと不整合になるためブロックする。
+    // - それ以外 (自動連鎖していない / 既に人手で操作済み) → 後続には触れない。
+    if (plan.successorPlanId) {
+      const successor = await tx.plan.findFirst({
+        where: { id: plan.successorPlanId, itemId: input.itemId, deletedAt: null },
+        include: PLAN_INCLUDE,
+      });
+      if (successor) {
+        const succLatest = successor.ballEvents[0];
+        const wasAutoChainedByThis =
+          !!succLatest && succLatest.eventType === 'tossed' && succLatest.source === 'auto_chain';
+        if (wasAutoChainedByThis) {
+          await tx.ballEvent.create({
+            data: {
+              planId: successor.id,
+              eventType: 'toss_undone',
+              source: 'human',
+              actorMemberId: input.currentMemberId,
+              actorUserId: input.currentUserId,
+            },
+          });
+          await recordAudit({
+            tx,
+            actorUserId: input.currentUserId,
+            action: 'untoss',
+            planId: successor.id,
+          });
+        } else if (successor.status === 'completed') {
+          throw new ApiException(
+            'SUCCESSOR_ALREADY_COMPLETED',
+            409,
+            '後続予定が完了済みのため、この予定の完了を取り消せません。',
+          );
+        }
+      }
+    }
+
+    // append-only のため、completed 行は削除せず completion_undone を追記して tossed に戻す
+    await tx.ballEvent.create({
+      data: {
+        planId: plan.id,
+        eventType: 'completion_undone',
+        source: 'human',
+        actorMemberId: input.currentMemberId,
+        actorUserId: input.currentUserId,
+      },
+    });
+    await tx.plan.update({
+      where: { id: plan.id },
+      data: { status: 'active', completedAt: null },
+    });
+    await recordAudit({
+      tx,
+      actorUserId: input.currentUserId,
+      action: 'undo_complete',
       planId: plan.id,
     });
 

--- a/apps/web/server/services/plans.ts
+++ b/apps/web/server/services/plans.ts
@@ -19,7 +19,7 @@ export type MemberRef = {
 
 export type BallEventDTO = {
   id: string;
-  eventType: 'tossed' | 'completed' | 'toss_undone';
+  eventType: 'tossed' | 'completed' | 'toss_undone' | 'completion_undone';
   source: 'human' | 'auto_chain';
   actor: MemberRef | null;
   occurredAt: string;
@@ -85,7 +85,7 @@ type PlanRow = Prisma.PlanGetPayload<{
 function toEventDTO(ev: PlanRow['ballEvents'][number]): BallEventDTO {
   return {
     id: ev.id,
-    eventType: ev.eventType as 'tossed' | 'completed' | 'toss_undone',
+    eventType: ev.eventType as 'tossed' | 'completed' | 'toss_undone' | 'completion_undone',
     source: ev.source as 'human' | 'auto_chain',
     actor: toMemberRef(ev.actorMember),
     occurredAt: ev.occurredAt.toISOString(),

--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -93,6 +93,19 @@ export function BallDetailModal({
       toast.error(e instanceof ApiClientError ? e.message : '差し戻しに失敗しました'),
   });
 
+  // 完了の差し戻し (#89)。後続が完了済みの場合は BE が 409 を返す。
+  const undoCompleteMut = useMutation({
+    mutationFn: () => plansApi.undoComplete(projectId, itemId, planId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: plansQueryKey.list(projectId, itemId) });
+      qc.invalidateQueries({ queryKey: plansQueryKey.projectList(projectId) });
+      qc.invalidateQueries({ queryKey: plansQueryKey.detail(projectId, itemId, planId) });
+      toast.success('完了を取り消しました');
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '完了の取り消しに失敗しました'),
+  });
+
   const copyMut = useMutation({
     mutationFn: () => plansApi.copy(projectId, itemId, planId),
     onSuccess: (newPlan) => {
@@ -135,6 +148,8 @@ export function BallDetailModal({
             const isBallHolder =
               !!plan.ballHolder && !!myMember && plan.ballHolder.id === myMember.id;
             const canAct = plan.status === 'active' && (isBallHolder || isDirector);
+            // 完了の差し戻し: 完了者 (= 完了済みプランのホルダー=確認者) かディレクター (#89)
+            const canUndoComplete = plan.status === 'completed' && (isBallHolder || isDirector);
             const style = CATEGORY_STYLE[plan.category];
             const successor = plan.successorPlanId
               ? (plans.find((p) => p.id === plan.successorPlanId) ?? null)
@@ -299,6 +314,21 @@ export function BallDetailModal({
                         {hasSuccessor ? '次のタスクへトス' : '完了'}
                       </Button>
                     )}
+                    {/* 完了の差し戻し (#89): 完了済みプランを完了直前 (TOSS済み) に戻す */}
+                    {canUndoComplete && (
+                      <Button
+                        variant="outline"
+                        onClick={() => undoCompleteMut.mutate()}
+                        disabled={undoCompleteMut.isPending}
+                      >
+                        {undoCompleteMut.isPending ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <Undo2 className="size-4" />
+                        )}
+                        完了を取り消す
+                      </Button>
+                    )}
                   </div>
                 </SheetFooter>
               </>
@@ -364,6 +394,20 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
+const EVENT_LABEL: Record<BallEvent['eventType'], string> = {
+  tossed: 'TOSS',
+  completed: '完了',
+  toss_undone: '差し戻し',
+  completion_undone: '完了の取り消し',
+};
+
+function EventIcon({ type }: { type: BallEvent['eventType'] }) {
+  if (type === 'tossed') return <Send className="size-3.5 text-sky-600" />;
+  if (type === 'completed') return <CheckCircle2 className="size-3.5 text-emerald-600" />;
+  // toss_undone / completion_undone は差し戻し系
+  return <Undo2 className="size-3.5 text-amber-600" />;
+}
+
 function EventTimeline({ events }: { events: BallEvent[] }) {
   if (events.length === 0) {
     return <p className="text-xs text-muted-foreground">まだイベントはありません。</p>;
@@ -375,14 +419,8 @@ function EventTimeline({ events }: { events: BallEvent[] }) {
           key={e.id}
           className="flex items-center gap-2 rounded-md border border-border px-2 py-1 text-xs"
         >
-          {e.eventType === 'tossed' ? (
-            <Send className="size-3.5 text-sky-600" />
-          ) : (
-            <CheckCircle2 className="size-3.5 text-emerald-600" />
-          )}
-          <span className="font-medium">
-            {e.eventType === 'tossed' ? 'TOSS' : '完了'}
-          </span>
+          <EventIcon type={e.eventType} />
+          <span className="font-medium">{EVENT_LABEL[e.eventType]}</span>
           {e.source === 'auto_chain' && (
             <Badge variant="secondary" className="px-1 py-0 text-[10px]">
               <Zap className="size-3" />

--- a/apps/web/src/features/plans/api.ts
+++ b/apps/web/src/features/plans/api.ts
@@ -30,7 +30,7 @@ export type MemberRef = {
 
 export type BallEvent = {
   id: string;
-  eventType: 'tossed' | 'completed';
+  eventType: 'tossed' | 'completed' | 'toss_undone' | 'completion_undone';
   source: 'human' | 'auto_chain';
   actor: MemberRef | null;
   occurredAt: string;
@@ -150,6 +150,12 @@ export const plansApi = {
     }),
   undoToss: (projectId: string, itemId: string, planId: string) =>
     apiRequest<{ plan: Plan }>(`${basePath(projectId, itemId)}/${planId}/toss-undo`, {
+      method: 'POST',
+      body: {},
+    }),
+  /** 完了の差し戻し (#89)。完了済みプランを完了直前 (TOSS 済み) に戻す。 */
+  undoComplete: (projectId: string, itemId: string, planId: string) =>
+    apiRequest<{ plan: Plan }>(`${basePath(projectId, itemId)}/${planId}/complete-undo`, {
       method: 'POST',
       body: {},
     }),

--- a/packages/db/prisma/migrations/20260620000003_add_completion_undone_event/migration.sql
+++ b/packages/db/prisma/migrations/20260620000003_add_completion_undone_event/migration.sql
@@ -1,0 +1,35 @@
+-- -----------------------------------------------------------------------------
+-- Migration: 20260620000003_add_completion_undone_event
+-- 完了の差し戻し (#89) のため、ball_events.event_type に 'completion_undone' を、
+-- audit_logs.action に 'undo_complete' を追加する。
+--  - completion_undone: 完了 (completed) を取り消し、TOSS 済み状態に戻すイベント。
+--    append-only のため completed 行は削除せず追記で打ち消す (toss_undone と同様)。
+--  - undo_complete: 完了差し戻しの監査アクション。
+-- これらが CHECK 制約に含まれていないと INSERT が CHECK 違反で失敗する。
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE "ball_events" DROP CONSTRAINT "ck_be_event_type";
+
+ALTER TABLE "ball_events"
+  ADD CONSTRAINT "ck_be_event_type"
+  CHECK ("event_type" IN ('tossed', 'completed', 'toss_undone', 'completion_undone'));
+
+ALTER TABLE "audit_logs" DROP CONSTRAINT "ck_al_action";
+
+ALTER TABLE "audit_logs"
+  ADD CONSTRAINT "ck_al_action" CHECK ("action" IN (
+    'login',
+    'logout',
+    'complete_signup',
+    'update_profile',
+    'toss',
+    'untoss',
+    'complete',
+    'undo_complete',
+    'auto_toss',
+    'share_access',
+    'share_create',
+    'share_revoke',
+    'share_toss',
+    'share_complete'
+  ));

--- a/packages/shared/src/domain/ballHolder.test.ts
+++ b/packages/shared/src/domain/ballHolder.test.ts
@@ -40,6 +40,24 @@ describe('deriveBallHolder', () => {
     });
     expect(r.state).toBe('tossed');
   });
+
+  it('returns from member with ready state on toss_undone event', () => {
+    const r = deriveBallHolder(plan, {
+      eventType: 'toss_undone',
+      source: 'human',
+      occurredAt: '2026-06-04T00:00:00Z',
+    });
+    expect(r).toEqual({ memberId: 'from-1', state: 'ready' });
+  });
+
+  it('returns to member with tossed state on completion_undone event (#89)', () => {
+    const r = deriveBallHolder(plan, {
+      eventType: 'completion_undone',
+      source: 'human',
+      occurredAt: '2026-06-05T00:00:00Z',
+    });
+    expect(r).toEqual({ memberId: 'to-1', state: 'tossed' });
+  });
 });
 
 describe('pickLatestBallEvent', () => {

--- a/packages/shared/src/domain/ballHolder.ts
+++ b/packages/shared/src/domain/ballHolder.ts
@@ -5,7 +5,7 @@
 
 export type PlanState = 'ready' | 'tossed' | 'completed';
 
-export type BallEventType = 'tossed' | 'completed' | 'toss_undone';
+export type BallEventType = 'tossed' | 'completed' | 'toss_undone' | 'completion_undone';
 
 export type BallEventLike = {
   eventType: BallEventType;
@@ -32,15 +32,18 @@ export type BallHolderResult = {
  *   - 最新 = tossed: to_member が Ball Holder, state = 'tossed'
  *   - 最新 = completed: to_member が Ball Holder (完了者), state = 'completed'
  *   - 最新 = toss_undone (差し戻し): from_member に戻る, state = 'ready'
+ *   - 最新 = completion_undone (完了の差し戻し): 完了直前 (TOSS 済み) に戻る,
+ *     to_member が Ball Holder, state = 'tossed' (#89)
  *
  * 各イベントは「遷移後の状態」を表すため、最新イベント 1 件で現状態が決まる
- * (toss_undone は直前の tossed を打ち消し ready に戻す)。
+ * (toss_undone は tossed を打ち消し ready に、completion_undone は completed を
+ *  打ち消し tossed に戻す)。
  */
 export function deriveBallHolder(plan: PlanLike, latestEvent?: BallEventLike | null): BallHolderResult {
   if (!latestEvent || latestEvent.eventType === 'toss_undone') {
     return { memberId: plan.fromMemberId, state: 'ready' };
   }
-  if (latestEvent.eventType === 'tossed') {
+  if (latestEvent.eventType === 'tossed' || latestEvent.eventType === 'completion_undone') {
     return { memberId: plan.toMemberId, state: 'tossed' };
   }
   return { memberId: plan.toMemberId, state: 'completed' };


### PR DESCRIPTION
Closes #89

## 概要
完了状態になった予定を、**完了前の状態（TOSS済み）に戻せる**ようにします。

## 設計
既存の TOSS 差し戻し (`toss_undone`) と同じ append-only パターンを踏襲します。
完了 (`completed`) を削除せず、`completion_undone` イベントを追記して打ち消すことで、
履歴を保ったまま **TOSS済み** 状態（ボール保持者＝確認者）に戻します。

## 変更点
- **DB** `20260620000003_add_completion_undone_event`
  - `ball_events.event_type` に `completion_undone` を追加
  - `audit_logs.action` に `undo_complete` を追加
- **shared** `deriveBallHolder` が `completion_undone` を `tossed` 状態として導出
- **BE**
  - `undoCompletePlan` サービス + `POST /:planId/complete-undo` ルート
  - 認可: 完了直前のボール保持者（確認者）またはディレクターのみ
  - 完了時に後続を自動TOSSしていた場合、その auto_chain TOSS も連動して差し戻し。
    後続が既に完了済みなら `409 SUCCESSOR_ALREADY_COMPLETED` でブロック
- **FE**
  - 完了済みモーダルに「完了を取り消す」ボタン
  - 履歴タイムラインに差し戻し系イベント（差し戻し / 完了の取り消し）を表示
    （従来 `toss_undone` が「完了」と誤表示されていた点も修正）

## テスト
- `deriveBallHolder` の `completion_undone` / `toss_undone` ケースを追加
- `complete-undo` ルートの認証境界テストを追加
- ローカルで `type-check` / `lint` / `test`（88件）/ `prisma format` をパス
- 反映には対象DBへの `prisma migrate deploy`（本番は Release）が必要です

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)