### PR TITLE
ci: preview(dev) DB へのマイグレーション専用フローを追加

### DIFF
--- a/.github/workflows/dev-migrate.yml
+++ b/.github/workflows/dev-migrate.yml
@@ -1,0 +1,56 @@
+name: Dev Migrate
+
+# preview(dev) DB へマイグレーションを適用する。Release(本番) とは独立したフロー。
+#   - main へのマージ時 (migrations 変更を含む push) に自動適用
+#   - 手動 (workflow_dispatch) でも実行可
+#
+# 本番への適用は release-deploy.yml (GitHub Release 公開時) が担当し、こちらは
+# preview(dev) DB のみを対象とする。
+#
+# 必要な GitHub Secrets:
+#   DEV_DATABASE_URL  — dev/preview DB の DATABASE_URL (Prisma 接続)
+#   DEV_DIRECT_URL    — dev/preview DB の DIRECT_URL (migrate 用)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/db/prisma/migrations/**'
+  workflow_dispatch:
+
+concurrency:
+  # dev DB へのマイグレーションは同時実行させない (ref に依らずグローバルに直列化)
+  group: dev-migrate
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: prisma migrate deploy (dev)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.19.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm db:generate
+
+      - name: Run database migrations (dev/preview)
+        env:
+          DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
+          DIRECT_URL: ${{ secrets.DEV_DIRECT_URL }}
+        run: pnpm --filter @trakon/db exec prisma migrate deploy


### PR DESCRIPTION
## 背景
現状、`prisma migrate deploy` は **GitHub Release 公開時の `release-deploy.yml` でのみ**実行され、
かつ対象は**本番DB**だけです。preview(dev) 環境のDBにDDLを反映する自動フローが存在せず、
Release を作らないと preview(dev) にマイグレーションが適用されない状態でした。

## 変更
Release とは独立した **preview(dev) 専用のマイグレーションフロー** `dev-migrate.yml` を追加します。

- **トリガー**
  - `push` to `main`（`packages/db/prisma/migrations/**` に変更がある場合のみ）→ マージ時に自動適用
  - `workflow_dispatch` → 手動でも実行可能
- **対象**: `DEV_DATABASE_URL` / `DEV_DIRECT_URL`（preview/dev DB）への `prisma migrate deploy`
- **直列化**: `concurrency: dev-migrate` で dev DB への同時マイグレーションを防止
- 本番への適用は従来どおり `release-deploy.yml`（Release 公開時）が担当します。

## 必要な準備（リポジトリ管理者）
以下の GitHub Secrets の追加が必要です（追加されるまでフローは失敗します）:

- `DEV_DATABASE_URL` … preview/dev DB の DATABASE_URL（Prisma 接続）
- `DEV_DIRECT_URL` … preview/dev DB の DIRECT_URL（migrate 用）

## 補足
- この PR 自体はマイグレーションファイルを含まないため、マージしても `dev-migrate` は走りません
  （パスフィルタ）。次回マイグレーションを含む main マージ時から自動適用されます。
- 既存マイグレーション（#90 / #91 など）を今すぐ dev に反映したい場合は、マージ後に
  Actions から `Dev Migrate` を手動実行してください。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)