### PR TITLE
fix(profile): ユーザープロフィールのカーソル/ボタン配置を改善 (#98)

### DIFF
--- a/apps/web/src/app/SidebarLayout.tsx
+++ b/apps/web/src/app/SidebarLayout.tsx
@@ -115,7 +115,7 @@ export function SidebarLayout() {
             <button
               type="button"
               onClick={() => setProfileOpen(true)}
-              className="flex w-full items-center gap-2 px-4 py-3 text-left hover:bg-accent/40"
+              className="flex w-full cursor-pointer items-center gap-2 px-4 py-3 text-left hover:bg-accent/40"
             >
               <Avatar name={user.displayName || user.email} className="size-8 text-xs" />
               <span className="min-w-0">

--- a/apps/web/src/features/auth/ProfileModal.tsx
+++ b/apps/web/src/features/auth/ProfileModal.tsx
@@ -127,13 +127,13 @@ function ViewMode({
         )}
       </div>
 
-      <DialogFooter>
-        <Button variant="ghost" onClick={onClose}>
-          閉じる
-        </Button>
-        <Button variant="outline" onClick={onSignOut}>
+      <DialogFooter className="sm:justify-between">
+        <Button variant="ghost" size="sm" onClick={onSignOut}>
           <LogOut className="size-4" />
           サインアウト
+        </Button>
+        <Button variant="outline" size="sm" onClick={onClose}>
+          閉じる
         </Button>
       </DialogFooter>
     </>


### PR DESCRIPTION
## 概要

[Issue #98](https://github.com/OSA-OSAMARU/trakon-app/issues/98) の2点を修正します。

1. **カーソルがクリッカブルでない** — 左下のプロフィール表示はクリックでモーダルが開くが、ホバーしてもカーソルが矢印のままだった。Tailwind v4 のプリフライトが `<button>` のカーソルを `default` にリセットするのが原因。トリガーに `cursor-pointer` を追加。
2. **モーダルのボタン配置の崩れ** — 表示モードのフッターを `sm:justify-between` で **サインアウト(左) / 閉じる(右)** に整理し、ボタンサイズを `size="sm"` に統一して整然と並べた。

## 変更点

- `apps/web/src/app/SidebarLayout.tsx`: プロフィールトリガーに `cursor-pointer` 付与
- `apps/web/src/features/auth/ProfileModal.tsx`: 表示モードフッターのレイアウト/サイズ整理

共有 UI（dialog.tsx / button.tsx）は変更せず、スタイル/レイアウトのみの最小変更。文言・機能・API の変更なし。

## 検証

- `pnpm lint` / `pnpm type-check` パス
- 左下トリガーのホバーでポインター表示、モーダルのボタン整列を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)