### PR TITLE
feat(auth): 退会処理 (アカウント削除) を追加 (#95)

### DIFF
--- a/apps/web/server/middleware/projectAuth.ts
+++ b/apps/web/server/middleware/projectAuth.ts
@@ -27,9 +27,10 @@ export function attachCurrentUserId(): MiddlewareHandler {
     const authUser = c.get('authUser');
     const user = await prisma.user.findUnique({
       where: { authUserId: authUser.authUserId },
-      select: { id: true },
+      select: { id: true, deletedAt: true },
     });
-    if (!user) {
+    // 退会済み (deletedAt) は未存在として扱う (締め出し)。
+    if (!user || user.deletedAt) {
       throw new ApiException(
         'PROFILE_NOT_COMPLETED',
         404,

--- a/apps/web/server/routes/v1/auth.ts
+++ b/apps/web/server/routes/v1/auth.ts
@@ -1,9 +1,14 @@
 import { Hono } from 'hono';
 
 import { requireAuth } from '../../middleware/auth.js';
-import { completeSignupBodySchema, updateProfileBodySchema } from '../../schemas/auth.js';
+import {
+  completeSignupBodySchema,
+  deleteAccountBodySchema,
+  updateProfileBodySchema,
+} from '../../schemas/auth.js';
 import {
   completeSignup,
+  deleteAccount,
   getCurrentUser,
   recordLogin,
   syncUser,
@@ -84,4 +89,17 @@ export const authRoute = new Hono()
       userAgent: c.req.header('user-agent') ?? undefined,
     });
     return c.json({ data: user }, 201);
+  })
+
+  /** 退会 (アカウント削除): 論理削除 + 匿名化 + Supabase Auth 削除 */
+  .delete('/me', async (c) => {
+    const authUser = c.get('authUser');
+    const body = deleteAccountBodySchema.parse(await c.req.json());
+    await deleteAccount({
+      authUserId: authUser.authUserId,
+      reason: body.reason,
+      ip: c.req.header('x-forwarded-for') ?? undefined,
+      userAgent: c.req.header('user-agent') ?? undefined,
+    });
+    return c.json({ data: { ok: true } });
   });

--- a/apps/web/server/schemas/auth.ts
+++ b/apps/web/server/schemas/auth.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { withdrawalReasonSchema } from '@trakon/shared';
 
 export const completeSignupBodySchema = z.object({
   fullName: z.string().trim().min(1).max(100),
@@ -33,3 +34,10 @@ export const updateProfileBodySchema = z
   });
 
 export type UpdateProfileBody = z.infer<typeof updateProfileBodySchema>;
+
+/** 退会 (アカウント削除) リクエスト。退会理由は必須。 */
+export const deleteAccountBodySchema = z.object({
+  reason: withdrawalReasonSchema,
+});
+
+export type DeleteAccountBody = z.infer<typeof deleteAccountBodySchema>;

--- a/apps/web/server/services/auth.test.ts
+++ b/apps/web/server/services/auth.test.ts
@@ -6,6 +6,7 @@ import type {
   updateProfile as UpdateProfileType,
   getCurrentUser as GetCurrentUserType,
   recordLogin as RecordLoginType,
+  deleteAccount as DeleteAccountType,
 } from './auth.js';
 
 // =============================================================================
@@ -42,6 +43,7 @@ type MockAudit = {
   result: string;
   ip?: string | null;
   userAgent?: string | null;
+  extra?: Record<string, unknown>;
 };
 
 let nextId = 1;
@@ -74,6 +76,13 @@ const oauthTx = {
     oauthStore.push(r);
     return r;
   }),
+  deleteMany: vi.fn(async ({ where }: { where: { userId: string } }) => {
+    const before = oauthStore.length;
+    for (let i = oauthStore.length - 1; i >= 0; i--) {
+      if (oauthStore[i]!.userId === where.userId) oauthStore.splice(i, 1);
+    }
+    return { count: before - oauthStore.length };
+  }),
 };
 const auditTx = {
   create: vi.fn(async ({ data }: { data: Omit<MockAudit, 'id'> }) => {
@@ -97,6 +106,7 @@ const prismaMock = {
     create: userTx.create,
     update: userTx.update,
   },
+  oAuthIdentity: { create: oauthTx.create, deleteMany: oauthTx.deleteMany },
   auditLog: { create: auditTx.create },
   // 配列形式 ($transaction([...])) とコールバック形式 ($transaction(fn)) の両対応。
   $transaction: vi.fn(async (arg: unknown) => {
@@ -118,9 +128,21 @@ const updateUserByIdMock = vi.fn(
     error: null,
   }),
 );
+const deleteUserMock = vi.fn(
+  async (): Promise<{ data: { user: object | null }; error: { message: string } | null }> => ({
+    data: { user: {} },
+    error: null,
+  }),
+);
 vi.mock('../lib/supabaseAdmin.js', () => ({
   getSupabaseAdmin: () => ({
-    auth: { admin: { getUserById: getUserByIdMock, updateUserById: updateUserByIdMock } },
+    auth: {
+      admin: {
+        getUserById: getUserByIdMock,
+        updateUserById: updateUserByIdMock,
+        deleteUser: deleteUserMock,
+      },
+    },
   }),
 }));
 
@@ -133,11 +155,11 @@ let completeSignup: typeof CompleteSignupType;
 let updateProfile: typeof UpdateProfileType;
 let getCurrentUser: typeof GetCurrentUserType;
 let recordLogin: typeof RecordLoginType;
+let deleteAccount: typeof DeleteAccountType;
 
 beforeAll(async () => {
-  ({ syncUser, completeSignup, updateProfile, getCurrentUser, recordLogin } = await import(
-    './auth.js'
-  ));
+  ({ syncUser, completeSignup, updateProfile, getCurrentUser, recordLogin, deleteAccount } =
+    await import('./auth.js'));
 });
 
 afterEach(() => {
@@ -162,6 +184,33 @@ describe('syncUser', () => {
     const res = await syncUser('auth-1', 'a@example.com');
     expect(res.status).toBe('ready');
     if (res.status === 'ready') expect(res.user.id).toBe('u-pre');
+  });
+
+  it('does not return ready for a soft-deleted row (falls through to provider sync)', async () => {
+    userStore['auth-del'] = {
+      id: 'u-del',
+      authUserId: 'auth-del',
+      email: 'deleted+u-del@trakon.invalid',
+      fullName: '退会済みユーザー',
+      displayName: '退会済みユーザー',
+      primaryAuthMethod: 'password',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      deletedAt: new Date('2026-03-03T00:00:00Z'),
+    };
+    getUserByIdMock.mockResolvedValueOnce({
+      data: {
+        user: {
+          email: 'new@example.com',
+          app_metadata: { provider: 'email' },
+          user_metadata: {},
+          identities: [],
+        },
+      },
+      error: null,
+    });
+    const res = await syncUser('auth-del', 'new@example.com');
+    // ready ではなく provider 同期フローに流れる (締め出し)
+    expect(res.status).toBe('requires_profile_completion');
   });
 
   it('returns requires_profile_completion for Magic-link provider', async () => {
@@ -430,6 +479,105 @@ describe('getCurrentUser', () => {
 
   it('returns null when the user does not exist', async () => {
     expect(await getCurrentUser('auth-none')).toBeNull();
+  });
+
+  it('returns null for a soft-deleted (withdrawn) user', async () => {
+    userStore['auth-del'] = {
+      id: 'u-del',
+      authUserId: 'auth-del',
+      email: 'deleted+u-del@trakon.invalid',
+      fullName: '退会済みユーザー',
+      displayName: '退会済みユーザー',
+      primaryAuthMethod: 'password',
+      createdAt: new Date('2026-02-02T00:00:00Z'),
+      deletedAt: new Date('2026-03-03T00:00:00Z'),
+    };
+    expect(await getCurrentUser('auth-del')).toBeNull();
+  });
+});
+
+describe('deleteAccount', () => {
+  const seed = (overrides: Partial<MockUser> = {}) => {
+    userStore['auth-del'] = {
+      id: 'u-del',
+      authUserId: 'auth-del',
+      email: 'bye@example.com',
+      fullName: '河津 正和',
+      displayName: 'Kawazu',
+      primaryAuthMethod: 'password',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      deletedAt: null,
+      ...overrides,
+    };
+  };
+
+  it('soft-deletes + anonymizes the user, removes oauth, logs the reason, deletes the Supabase auth user', async () => {
+    seed({ primaryAuthMethod: 'google' });
+    oauthStore.push({
+      id: 'o-1',
+      userId: 'u-del',
+      provider: 'google',
+      providerUserId: 'google-sub',
+      email: 'bye@example.com',
+    });
+
+    await deleteAccount({
+      authUserId: 'auth-del',
+      reason: 'switching_tool',
+      ip: '203.0.113.9',
+      userAgent: 'jest-UA',
+    });
+
+    const stored = userStore['auth-del'];
+    expect(stored?.deletedAt).toBeInstanceOf(Date);
+    expect(stored?.email).toBe('deleted+u-del@trakon.invalid');
+    expect(stored?.fullName).toBe('退会済みユーザー');
+    expect(stored?.displayName).toBe('退会済みユーザー');
+    // oauth_identities は物理削除
+    expect(oauthStore).toHaveLength(0);
+    // 監査ログに退会理由を残す
+    expect(auditStore).toHaveLength(1);
+    expect(auditStore[0]).toMatchObject({
+      actorUserId: 'u-del',
+      action: 'account_delete',
+      resourceType: 'user',
+      resourceId: 'u-del',
+      result: 'success',
+      extra: { reason: 'switching_tool' },
+      ip: '203.0.113.9',
+      userAgent: 'jest-UA',
+    });
+    // Supabase Auth ユーザーも削除
+    expect(deleteUserMock).toHaveBeenCalledWith('auth-del');
+  });
+
+  it('throws 404 PROFILE_NOT_COMPLETED when the user does not exist', async () => {
+    await expect(
+      deleteAccount({ authUserId: 'auth-missing', reason: 'other' }),
+    ).rejects.toMatchObject({ code: 'PROFILE_NOT_COMPLETED', status: 404 });
+    expect(deleteUserMock).not.toHaveBeenCalled();
+  });
+
+  it('throws 404 when the user is already withdrawn (deletedAt set)', async () => {
+    seed({ deletedAt: new Date('2026-02-02T00:00:00Z') });
+    await expect(
+      deleteAccount({ authUserId: 'auth-del', reason: 'other' }),
+    ).rejects.toMatchObject({ code: 'PROFILE_NOT_COMPLETED', status: 404 });
+    expect(deleteUserMock).not.toHaveBeenCalled();
+  });
+
+  it('throws 500 SUPABASE_DELETE_FAILED but keeps the Prisma soft-delete committed', async () => {
+    seed();
+    deleteUserMock.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: 'supabase down' },
+    });
+    await expect(
+      deleteAccount({ authUserId: 'auth-del', reason: 'not_using' }),
+    ).rejects.toMatchObject({ code: 'SUPABASE_DELETE_FAILED', status: 500 });
+    // Prisma は先にコミット済みなので論理削除は残る (締め出し済み)
+    expect(userStore['auth-del']?.deletedAt).toBeInstanceOf(Date);
+    expect(auditStore).toHaveLength(1);
   });
 });
 

--- a/apps/web/server/services/auth.ts
+++ b/apps/web/server/services/auth.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@trakon/db';
+import type { WithdrawalReason } from '@trakon/shared';
 import { uuidv7 } from 'uuidv7';
 
 import { ApiException } from '../lib/errors.js';
@@ -89,7 +90,8 @@ function deriveOAuthNames(meta: Record<string, unknown>, email: string) {
  */
 export async function syncUser(authUserId: string, jwtEmail: string): Promise<SyncResult> {
   const existing = await prisma.user.findUnique({ where: { authUserId } });
-  if (existing) {
+  // 退会済み (deletedAt) は未存在として扱い、ready を返さない (締め出し)。
+  if (existing && !existing.deletedAt) {
     return { status: 'ready', user: toDTO(existing) };
   }
 
@@ -257,7 +259,7 @@ export async function updateProfile(input: {
   newPassword?: string;
 }): Promise<CurrentUserDTO> {
   const existing = await prisma.user.findUnique({ where: { authUserId: input.authUserId } });
-  if (!existing) {
+  if (!existing || existing.deletedAt) {
     throw new ApiException('PROFILE_NOT_COMPLETED', 404, 'User profile not found.');
   }
 
@@ -296,7 +298,79 @@ export async function updateProfile(input: {
 
 export async function getCurrentUser(authUserId: string): Promise<CurrentUserDTO | null> {
   const user = await prisma.user.findUnique({ where: { authUserId } });
-  return user ? toDTO(user) : null;
+  // 退会済み (deletedAt) は未存在として扱う (締め出し)。
+  return user && !user.deletedAt ? toDTO(user) : null;
+}
+
+/**
+ * 退会 (アカウント削除) を行う (issue #95)。物理削除は Project.createdBy の Restrict
+ * 制約で不可なため、論理削除 (deletedAt) + 個人情報の匿名化 + Supabase Auth ユーザー削除
+ * で実現する。
+ * - users: deletedAt をセットし email / fullName / displayName を匿名化
+ *   (email @unique を維持したまま同一メールでの再登録を可能にする)
+ * - oauth_identities: 物理削除 (再登録時の uq_oauth_identities_* 衝突を回避。
+ *   Supabase 側 auth ユーザーも削除するため整合する)
+ * - audit_logs: account_delete を退会理由 (extra.reason) 付きで記録
+ *
+ * 整合性のため Prisma を先にコミットしてから Supabase Auth を削除する。Supabase 削除が
+ * 失敗しても論理削除済みで締め出しガード (getCurrentUser / attachCurrentUserId) が効くため
+ * リカバリ可能。
+ */
+export async function deleteAccount(input: {
+  authUserId: string;
+  reason: WithdrawalReason;
+  ip?: string;
+  userAgent?: string;
+}): Promise<void> {
+  const existing = await withTimeout(
+    prisma.user.findUnique({ where: { authUserId: input.authUserId } }),
+    STEP_TIMEOUT_MS,
+    'findUnique',
+  );
+  if (!existing || existing.deletedAt) {
+    throw new ApiException('PROFILE_NOT_COMPLETED', 404, 'User profile not found.');
+  }
+
+  await withTimeout(
+    prisma.$transaction([
+      prisma.user.update({
+        where: { id: existing.id },
+        data: {
+          deletedAt: new Date(),
+          email: `deleted+${existing.id}@trakon.invalid`,
+          fullName: '退会済みユーザー',
+          displayName: '退会済みユーザー',
+        },
+      }),
+      prisma.oAuthIdentity.deleteMany({ where: { userId: existing.id } }),
+      prisma.auditLog.create({
+        data: {
+          actorUserId: existing.id,
+          action: 'account_delete',
+          resourceType: 'user',
+          resourceId: existing.id,
+          result: 'success',
+          extra: { reason: input.reason },
+          ip: input.ip ?? null,
+          userAgent: input.userAgent ?? null,
+        },
+      }),
+    ]),
+    STEP_TIMEOUT_MS,
+    'transaction',
+  );
+
+  // Supabase Auth ユーザーを削除し、再ログインを物理的に不可にする。
+  // Prisma は既にコミット済みのため、ここで失敗してもデータ整合は保たれる。
+  const supabase = getSupabaseAdmin();
+  const { error } = await withTimeout(
+    supabase.auth.admin.deleteUser(input.authUserId),
+    STEP_TIMEOUT_MS,
+    'supabase.deleteUser',
+  );
+  if (error) {
+    throw new ApiException('SUPABASE_DELETE_FAILED', 500, error.message);
+  }
 }
 
 export async function recordLogin(input: {

--- a/apps/web/src/features/auth/ProfileModal.test.tsx
+++ b/apps/web/src/features/auth/ProfileModal.test.tsx
@@ -179,6 +179,60 @@ describe('ProfileModal', () => {
     expect(body).toEqual({ newPassword: 'abcd1234!' });
   });
 
+  it('退会する → 理由選択＋「退会」入力で DELETE /auth/me を送り onSignOut を呼ぶ', async () => {
+    let body: { reason?: string } | null = null;
+    server.use(
+      http.delete('*/api/v1/auth/me', async ({ request }) => {
+        body = (await request.json()) as { reason?: string };
+        return HttpResponse.json({ data: { ok: true } });
+      }),
+    );
+
+    const onSignOut = vi.fn();
+    const u = userEvent.setup({ pointerEventsCheck: 0 });
+    renderWithProviders(
+      <ProfileModal user={user} open onClose={() => {}} onSignOut={onSignOut} />,
+    );
+
+    await u.click(screen.getByRole('button', { name: '退会する' }));
+    // 理由ラジオを1つ選ぶ
+    await u.click(await screen.findByLabelText('他のツールに移行'));
+    // 「退会」と入力
+    await u.type(screen.getByPlaceholderText('退会'), '退会');
+    // フッターの退会実行ボタン (複数ある「退会する」の最後)
+    const buttons = screen.getAllByRole('button', { name: '退会する' });
+    await u.click(buttons[buttons.length - 1]!);
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('退会が完了しました'));
+    expect(body).toEqual({ reason: 'switching_tool' });
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('退会フォームで理由未選択／「退会」未入力だとバリデーションエラーを出し送信しない', async () => {
+    let called = false;
+    server.use(
+      http.delete('*/api/v1/auth/me', () => {
+        called = true;
+        return HttpResponse.json({ data: { ok: true } });
+      }),
+    );
+
+    const onSignOut = vi.fn();
+    const u = userEvent.setup({ pointerEventsCheck: 0 });
+    renderWithProviders(
+      <ProfileModal user={user} open onClose={() => {}} onSignOut={onSignOut} />,
+    );
+
+    await u.click(screen.getByRole('button', { name: '退会する' }));
+    const buttons = screen.getAllByRole('button', { name: '退会する' });
+    await u.click(buttons[buttons.length - 1]!);
+
+    expect(await screen.findByText('退会理由を選択してください')).toBeInTheDocument();
+    expect(screen.getByText('「退会」と正しく入力してください')).toBeInTheDocument();
+    expect(called).toBe(false);
+    expect(onSignOut).not.toHaveBeenCalled();
+  });
+
   it('OAuth ユーザーにはパスワード変更ボタンを出さない', () => {
     renderWithProviders(
       <ProfileModal

--- a/apps/web/src/features/auth/ProfileModal.tsx
+++ b/apps/web/src/features/auth/ProfileModal.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Loader2, LogOut } from 'lucide-react';
 import { toast } from 'sonner';
+import { WITHDRAWAL_REASONS, type WithdrawalReason } from '@trakon/shared';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -27,7 +28,7 @@ const AUTH_METHOD_LABEL: Record<CurrentUser['primaryAuthMethod'], string> = {
   microsoft: 'Microsoft',
 };
 
-type Mode = 'view' | 'profile' | 'password';
+type Mode = 'view' | 'profile' | 'password' | 'withdraw';
 
 /**
  * プロフィール / 認証情報モーダル (プロトタイプ ProfileModal 準拠)。
@@ -61,7 +62,9 @@ export function ProfileModal({
               ? 'パスワードを変更します。'
               : mode === 'profile'
                 ? 'お名前と表示名を変更します。'
-                : 'プロフィール情報を確認・編集できます。'}
+                : mode === 'withdraw'
+                  ? 'アカウントを退会します。この操作は取り消せません。'
+                  : 'プロフィール情報を確認・編集できます。'}
           </DialogDescription>
         </DialogHeader>
 
@@ -70,12 +73,16 @@ export function ProfileModal({
             user={user}
             onEdit={() => setMode('profile')}
             onChangePassword={() => setMode('password')}
+            onWithdraw={() => setMode('withdraw')}
             onSignOut={onSignOut}
             onClose={close}
           />
         )}
         {mode === 'profile' && <ProfileForm user={user} onDone={() => setMode('view')} />}
         {mode === 'password' && <PasswordForm onDone={() => setMode('view')} />}
+        {mode === 'withdraw' && (
+          <WithdrawForm onCancel={() => setMode('view')} onSignOut={onSignOut} />
+        )}
       </DialogContent>
     </Dialog>
   );
@@ -85,12 +92,14 @@ function ViewMode({
   user,
   onEdit,
   onChangePassword,
+  onWithdraw,
   onSignOut,
   onClose,
 }: {
   user: CurrentUser;
   onEdit: () => void;
   onChangePassword: () => void;
+  onWithdraw: () => void;
   onSignOut: () => void;
   onClose: () => void;
 }) {
@@ -127,14 +136,24 @@ function ViewMode({
         )}
       </div>
 
-      <DialogFooter>
-        <Button variant="ghost" onClick={onClose}>
-          閉じる
+      <DialogFooter className="sm:justify-between">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onWithdraw}
+          className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+        >
+          退会する
         </Button>
-        <Button variant="outline" onClick={onSignOut}>
-          <LogOut className="size-4" />
-          サインアウト
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="ghost" onClick={onClose}>
+            閉じる
+          </Button>
+          <Button variant="outline" onClick={onSignOut}>
+            <LogOut className="size-4" />
+            サインアウト
+          </Button>
+        </div>
       </DialogFooter>
     </>
   );
@@ -230,6 +249,79 @@ function PasswordForm({ onDone }: { onDone: () => void }) {
         <Button type="submit" disabled={mut.isPending}>
           {mut.isPending && <Loader2 className="size-4 animate-spin" />}
           パスワードを変更
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+const withdrawSchema = z.object({
+  reason: z.enum(WITHDRAWAL_REASONS.map((r) => r.value) as [WithdrawalReason, ...WithdrawalReason[]], {
+    errorMap: () => ({ message: '退会理由を選択してください' }),
+  }),
+  confirm: z.literal('退会', {
+    errorMap: () => ({ message: '「退会」と正しく入力してください' }),
+  }),
+});
+type WithdrawValues = z.infer<typeof withdrawSchema>;
+
+/**
+ * 退会 (アカウント削除) フォーム。退会理由のラジオ選択 +「退会」入力を必須にし、
+ * DELETE /auth/me を送る。成功時は onSignOut (ローカルセッション破棄 → /login) を呼ぶ。
+ */
+function WithdrawForm({ onCancel, onSignOut }: { onCancel: () => void; onSignOut: () => void }) {
+  const form = useForm<WithdrawValues>({ resolver: zodResolver(withdrawSchema) });
+
+  const mut = useMutation({
+    mutationFn: (v: WithdrawValues) => authApi.deleteAccount({ reason: v.reason }),
+    onSuccess: () => {
+      toast.success('退会が完了しました');
+      onSignOut();
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '退会に失敗しました'),
+  });
+
+  return (
+    <form onSubmit={form.handleSubmit((v) => mut.mutate(v))} className="space-y-4">
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">退会理由を教えてください</legend>
+        <div className="space-y-1.5">
+          {WITHDRAWAL_REASONS.map((r) => (
+            <label key={r.value} className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                value={r.value}
+                className="size-4 accent-primary"
+                {...form.register('reason')}
+              />
+              {r.label}
+            </label>
+          ))}
+        </div>
+        {form.formState.errors.reason && (
+          <p className="text-xs text-destructive">{form.formState.errors.reason.message}</p>
+        )}
+      </fieldset>
+
+      <FormField
+        label="確認のため「退会」と入力してください"
+        error={form.formState.errors.confirm?.message}
+      >
+        <Input {...form.register('confirm')} autoComplete="off" placeholder="退会" />
+      </FormField>
+
+      <DialogFooter>
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={mut.isPending}>
+          キャンセル
+        </Button>
+        <Button
+          type="submit"
+          disabled={mut.isPending}
+          className="bg-destructive text-white hover:bg-destructive/90"
+        >
+          {mut.isPending && <Loader2 className="size-4 animate-spin" />}
+          退会する
         </Button>
       </DialogFooter>
     </form>

--- a/apps/web/src/features/auth/api.ts
+++ b/apps/web/src/features/auth/api.ts
@@ -1,3 +1,5 @@
+import type { WithdrawalReason } from '@trakon/shared';
+
 import { apiRequest } from '@/lib/api';
 
 export type CurrentUser = {
@@ -25,6 +27,10 @@ export type UpdateProfileInput = {
   newPassword?: string;
 };
 
+export type DeleteAccountInput = {
+  reason: WithdrawalReason;
+};
+
 export const authApi = {
   syncMe: () => apiRequest<SyncResponse>('/auth/me/sync', { method: 'POST' }),
   getMe: () => apiRequest<CurrentUser>('/auth/me'),
@@ -32,4 +38,6 @@ export const authApi = {
     apiRequest<CurrentUser>('/auth/me/complete-signup', { method: 'POST', body }),
   updateProfile: (body: UpdateProfileInput) =>
     apiRequest<CurrentUser>('/auth/me', { method: 'PATCH', body }),
+  deleteAccount: (body: DeleteAccountInput) =>
+    apiRequest<{ ok: true }>('/auth/me', { method: 'DELETE', body }),
 };

--- a/packages/db/prisma/migrations/20260627000001_add_account_delete_action/migration.sql
+++ b/packages/db/prisma/migrations/20260627000001_add_account_delete_action/migration.sql
@@ -1,0 +1,28 @@
+-- -----------------------------------------------------------------------------
+-- Migration: 20260627000001_add_account_delete_action
+-- 退会処理 (#95) のため、audit_logs.action に 'account_delete' を追加する。
+--  - account_delete: ユーザー自身による退会 (論理削除 + 匿名化 + Supabase Auth 削除)
+--    の監査アクション。退会理由は audit_logs.extra.reason に格納する。
+-- この値が ck_al_action CHECK 制約に含まれていないと INSERT が CHECK 違反で失敗する。
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE "audit_logs" DROP CONSTRAINT "ck_al_action";
+
+ALTER TABLE "audit_logs"
+  ADD CONSTRAINT "ck_al_action" CHECK ("action" IN (
+    'login',
+    'logout',
+    'complete_signup',
+    'update_profile',
+    'account_delete',
+    'toss',
+    'untoss',
+    'complete',
+    'undo_complete',
+    'auto_toss',
+    'share_access',
+    'share_create',
+    'share_revoke',
+    'share_toss',
+    'share_complete'
+  ));

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -263,7 +263,7 @@ model AuditLog {
   actorUserId  String?  @map("actor_user_id") @db.Uuid
   /// share_links FK は Sub-Phase 0.5 で実装 (share_links テーブル追加時)
   shareLinkId  String?  @map("share_link_id") @db.Uuid
-  /// Phase 0 許可値: login | logout | toss | complete | share_access | share_create | share_revoke | share_toss | share_complete
+  /// Phase 0 許可値: login | logout | complete_signup | update_profile | account_delete | toss | untoss | complete | undo_complete | auto_toss | share_access | share_create | share_revoke | share_toss | share_complete
   action       String
   resourceType String   @map("resource_type")
   resourceId   String?  @map("resource_id") @db.Uuid

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,3 +1,19 @@
 export const APP_NAME = 'TRAKON' as const;
 export const API_VERSION = 'v1' as const;
 export const API_BASE_PATH = `/api/${API_VERSION}` as const;
+
+/**
+ * 退会理由 (issue #95)。退会 Confirm 画面のラジオボタン選択肢として FE で描画し、
+ * value を DELETE /auth/me の body で受けて audit_logs.extra.reason に保存する。
+ * FE/BE で値定義を一元化するため shared に置く。
+ */
+export const WITHDRAWAL_REASONS = [
+  { value: 'not_using', label: '使わなくなった' },
+  { value: 'missing_features', label: '機能が不足している' },
+  { value: 'hard_to_use', label: '操作が難しい' },
+  { value: 'switching_tool', label: '他のツールに移行' },
+  { value: 'temporary_break', label: '一時的に利用を停止' },
+  { value: 'other', label: 'その他' },
+] as const;
+
+export type WithdrawalReason = (typeof WITHDRAWAL_REASONS)[number]['value'];

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { WITHDRAWAL_REASONS, type WithdrawalReason } from '../constants/index.js';
+
 export const healthSchema = z.object({
   status: z.literal('ok'),
   uptime: z.number(),
@@ -7,3 +9,8 @@ export const healthSchema = z.object({
 });
 
 export type Health = z.infer<typeof healthSchema>;
+
+/** 退会理由 (issue #95)。WITHDRAWAL_REASONS の value 集合に限定する。 */
+export const withdrawalReasonSchema = z.enum(
+  WITHDRAWAL_REASONS.map((r) => r.value) as [WithdrawalReason, ...WithdrawalReason[]],
+);


### PR DESCRIPTION
## 概要
[issue #95](https://github.com/OSA-OSAMARU/trakon-app/issues/95) の退会処理（アカウント削除）を実装します。アカウント画面に「退会する」導線を追加し、退会理由のラジオ選択＋「退会」確認入力を経て退会できます。

## 方式の判断
- **論理削除＋匿名化**: `Project.createdBy → User` が `onDelete: Restrict` のため物理削除は不可。`User.deletedAt` をセットし `email`/氏名を匿名化、Supabase Auth ユーザーは `admin.deleteUser` で削除（再ログイン不可）。
- **email 匿名化**で `@unique` を維持したまま同一メールでの再登録を可能に。
- 退会理由は `audit_logs.extra.reason` に記録。

## 変更点
**共有層**
- `WITHDRAWAL_REASONS` 定数（6択）と `withdrawalReasonSchema` を `packages/shared` に追加（FE/BE 共有）

**DB**
- `ck_al_action` CHECK 制約に `account_delete` を追加するマイグレーション（`20260627000001_add_account_delete_action`）

**バックエンド**
- `services/auth.ts`: `deleteAccount()` を新規追加（論理削除＋匿名化＋oauth物理削除＋監査ログ → Supabase Auth 削除）
- 退会済みユーザーの締め出しガードを `getCurrentUser` / `updateProfile` / `syncUser` / `attachCurrentUserId` に追加（二重防御）
- `DELETE /auth/me` ルートと `deleteAccountBodySchema` を追加

**フロントエンド**
- `authApi.deleteAccount` を追加
- `ProfileModal` に「退会する」ボタンと `withdraw` モード（`WithdrawForm`）を追加。成功で `signOut` → `/login`

## テスト
- `deleteAccount` 正常系 / 404 / 退会済み再呼び出し / Supabase 失敗時の整合
- 締め出しガード（`getCurrentUser` / `syncUser`）
- ProfileModal の退会フロー UI とバリデーション
- `pnpm type-check` / `pnpm lint` / `pnpm test`（全 600+ 件）グリーン

## スコープ外（別 issue 推奨）
- プロジェクト作成者の退会時に残存するプロジェクトの所有権移譲（退会自体はブロックしない方針）

## デプロイ時の注意
本番反映時は CHECK 制約拡張マイグレーション（`prisma migrate deploy`）が必要です。

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)