### PR TITLE
fix(auth): 退会フォームのラジオボタンの黒塗り表示を修正

### DIFF
--- a/apps/web/src/features/auth/ProfileModal.tsx
+++ b/apps/web/src/features/auth/ProfileModal.tsx
@@ -292,7 +292,7 @@ function WithdrawForm({ onCancel, onSignOut }: { onCancel: () => void; onSignOut
               <input
                 type="radio"
                 value={r.value}
-                className="size-4 accent-primary"
+                className="size-4 shrink-0 appearance-none rounded-full border border-input bg-background checked:border-[5px] checked:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 {...form.register('reason')}
               />
               {r.label}


### PR DESCRIPTION
## 概要
退会フォーム（`ProfileModal` の `WithdrawForm`）のラジオボタンが黒い塗りつぶし円で表示される不具合を修正します。

| Before | After |
|---|---|
| 黒塗りの円（違和感あり） | 未選択=薄グレー輪郭 / 選択時=primary リング |

## 原因
ラジオに付与していた `accent-primary` が、テーマの `--primary: #2b2b2b`（ほぼ黒）を `accent-color` に適用し、ネイティブラジオが黒く描画されていました。

## 対応
`appearance-none` ベースの明示スタイルに置換：
- 未選択: `border-input`（#d4d4d4）の細い輪郭＋白背景
- 選択時: `checked:border-[5px] checked:border-primary` で primary のリング表示
- フォーカス: 既存 Input と同じ `ring` トークン

既存の `border-input` / `border-primary` / `ring` / `bg-background` トークンを再利用し、ダーク／ライト両対応を維持。新規依存は追加していません。

## テスト
- `pnpm --filter @trakon/web test src/features/auth/ProfileModal.test.tsx` ✅（選択・バリデーションは従来どおり）
- `pnpm type-check` / `pnpm lint` ✅
- 表示確認は本 PR の Vercel Preview を参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)