### PR TITLE
fix(auth): 退会後の再ログインで sync 401/projects 404 無限ループを解消

### DIFF
--- a/apps/web/src/features/auth/ProfileModal.test.tsx
+++ b/apps/web/src/features/auth/ProfileModal.test.tsx
@@ -4,8 +4,17 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 
 // supabase は apiRequest の Authorization 注入で getSession を呼ぶためモックする。
+// 退会成功時の signOut({ scope: 'local' }) も捕捉する。
+const { signOutMock } = vi.hoisted(() => ({
+  signOutMock: vi.fn().mockResolvedValue({ error: null }),
+}));
 vi.mock('@/lib/supabase', () => ({
-  supabase: { auth: { getSession: vi.fn().mockResolvedValue({ data: { session: null } }) } },
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+      signOut: signOutMock,
+    },
+  },
 }));
 
 // sonner の toast を捕捉する。
@@ -179,7 +188,7 @@ describe('ProfileModal', () => {
     expect(body).toEqual({ newPassword: 'abcd1234!' });
   });
 
-  it('退会する → 理由選択＋「退会」入力で DELETE /auth/me を送り onSignOut を呼ぶ', async () => {
+  it('退会する → 理由選択＋「退会」入力で DELETE /auth/me を送り local signOut する', async () => {
     let body: { reason?: string } | null = null;
     server.use(
       http.delete('*/api/v1/auth/me', async ({ request }) => {
@@ -188,10 +197,10 @@ describe('ProfileModal', () => {
       }),
     );
 
-    const onSignOut = vi.fn();
+    signOutMock.mockClear();
     const u = userEvent.setup({ pointerEventsCheck: 0 });
     renderWithProviders(
-      <ProfileModal user={user} open onClose={() => {}} onSignOut={onSignOut} />,
+      <ProfileModal user={user} open onClose={() => {}} onSignOut={() => {}} />,
     );
 
     await u.click(screen.getByRole('button', { name: '退会する' }));
@@ -205,7 +214,8 @@ describe('ProfileModal', () => {
 
     await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('退会が完了しました'));
     expect(body).toEqual({ reason: 'switching_tool' });
-    expect(onSignOut).toHaveBeenCalledTimes(1);
+    // stale セッションを残さないよう local scope で signOut する
+    await waitFor(() => expect(signOutMock).toHaveBeenCalledWith({ scope: 'local' }));
   });
 
   it('退会フォームで理由未選択／「退会」未入力だとバリデーションエラーを出し送信しない', async () => {
@@ -217,10 +227,10 @@ describe('ProfileModal', () => {
       }),
     );
 
-    const onSignOut = vi.fn();
+    signOutMock.mockClear();
     const u = userEvent.setup({ pointerEventsCheck: 0 });
     renderWithProviders(
-      <ProfileModal user={user} open onClose={() => {}} onSignOut={onSignOut} />,
+      <ProfileModal user={user} open onClose={() => {}} onSignOut={() => {}} />,
     );
 
     await u.click(screen.getByRole('button', { name: '退会する' }));
@@ -230,7 +240,7 @@ describe('ProfileModal', () => {
     expect(await screen.findByText('退会理由を選択してください')).toBeInTheDocument();
     expect(screen.getByText('「退会」と正しく入力してください')).toBeInTheDocument();
     expect(called).toBe(false);
-    expect(onSignOut).not.toHaveBeenCalled();
+    expect(signOutMock).not.toHaveBeenCalled();
   });
 
   it('OAuth ユーザーにはパスワード変更ボタンを出さない', () => {

--- a/apps/web/src/features/auth/ProfileModal.tsx
+++ b/apps/web/src/features/auth/ProfileModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -7,6 +8,7 @@ import { Loader2, LogOut } from 'lucide-react';
 import { toast } from 'sonner';
 import { WITHDRAWAL_REASONS, type WithdrawalReason } from '@trakon/shared';
 
+import { supabase } from '@/lib/supabase';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -80,9 +82,7 @@ export function ProfileModal({
         )}
         {mode === 'profile' && <ProfileForm user={user} onDone={() => setMode('view')} />}
         {mode === 'password' && <PasswordForm onDone={() => setMode('view')} />}
-        {mode === 'withdraw' && (
-          <WithdrawForm onCancel={() => setMode('view')} onSignOut={onSignOut} />
-        )}
+        {mode === 'withdraw' && <WithdrawForm onCancel={() => setMode('view')} />}
       </DialogContent>
     </Dialog>
   );
@@ -267,16 +267,24 @@ type WithdrawValues = z.infer<typeof withdrawSchema>;
 
 /**
  * 退会 (アカウント削除) フォーム。退会理由のラジオ選択 +「退会」入力を必須にし、
- * DELETE /auth/me を送る。成功時は onSignOut (ローカルセッション破棄 → /login) を呼ぶ。
+ * DELETE /auth/me を送る。
+ *
+ * 成功時は `signOut({ scope: 'local' })` でローカルセッションのみ破棄してから /login へ。
+ * この時点でサーバー側の Supabase ユーザーは既に削除済みのため、通常の global signOut は
+ * `/logout` が無効トークンで失敗し localStorage を消し残す → stale セッションが残り、
+ * 再ログイン/再登録時に sync(401) + projects(404) の無限ループを誘発する。local scope なら
+ * サーバーを呼ばず確実にローカルを消せる。
  */
-function WithdrawForm({ onCancel, onSignOut }: { onCancel: () => void; onSignOut: () => void }) {
+function WithdrawForm({ onCancel }: { onCancel: () => void }) {
+  const navigate = useNavigate();
   const form = useForm<WithdrawValues>({ resolver: zodResolver(withdrawSchema) });
 
   const mut = useMutation({
     mutationFn: (v: WithdrawValues) => authApi.deleteAccount({ reason: v.reason }),
-    onSuccess: () => {
+    onSuccess: async () => {
       toast.success('退会が完了しました');
-      onSignOut();
+      await supabase.auth.signOut({ scope: 'local' });
+      navigate('/login', { replace: true });
     },
     onError: (e) =>
       toast.error(e instanceof ApiClientError ? e.message : '退会に失敗しました'),

--- a/apps/web/src/features/auth/useCurrentUser.test.ts
+++ b/apps/web/src/features/auth/useCurrentUser.test.ts
@@ -9,17 +9,19 @@ import { createElement } from 'react';
 import { server } from '@/test/handlers';
 import { createTestQueryClient } from '@/test/render';
 
-// supabase をモックして getSession / onAuthStateChange を制御する。
+// supabase をモックして getSession / onAuthStateChange / signOut を制御する。
 const getSession = vi.fn();
 const onAuthStateChange = vi.fn(() => ({
   data: { subscription: { unsubscribe() {} } },
 }));
+const signOut = vi.fn().mockResolvedValue({ error: null });
 
 vi.mock('@/lib/supabase', () => ({
   supabase: {
     auth: {
       getSession: (...args: unknown[]) => getSession(...args),
       onAuthStateChange: (...args: unknown[]) => onAuthStateChange(...(args as [])),
+      signOut: (...args: unknown[]) => signOut(...args),
     },
   },
 }));
@@ -103,5 +105,23 @@ describe('useCurrentUser', () => {
 
     await waitFor(() => expect(result.current.error).toBeTruthy());
     expect(result.current.data).toBeUndefined();
+    // 401 以外 (500) では stale セッション破棄を行わない
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
+  it('sync が 401 を返すと stale セッションを local scope で破棄する', async () => {
+    server.use(
+      http.post('*/api/v1/auth/me/sync', () =>
+        HttpResponse.json(
+          { error: { code: 'AUTH_INVALID', message: 'Supabase auth user not found.' } },
+          { status: 401 },
+        ),
+      ),
+    );
+
+    const { result } = renderHook(() => useCurrentUser(), { wrapper });
+
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    await waitFor(() => expect(signOut).toHaveBeenCalledWith({ scope: 'local' }));
   });
 });

--- a/apps/web/src/features/auth/useCurrentUser.ts
+++ b/apps/web/src/features/auth/useCurrentUser.ts
@@ -1,5 +1,8 @@
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
+import { supabase } from '@/lib/supabase';
+import { ApiClientError } from '@/lib/api';
 import { authApi, type SyncResponse } from './api';
 import { useAuthSession } from './useAuthSession';
 
@@ -17,6 +20,17 @@ export function useCurrentUser() {
     staleTime: 60_000,
     retry: 0,
   });
+
+  // stale セッションの自己回復: sync が 401 (AUTH_MISSING/AUTH_INVALID) を返したら
+  // その JWT はサーバー側で無効 (退会済み・削除済み等) なのでローカルセッションを破棄する。
+  // これにより RequireAuth / AuthCallbackPage は !session 分岐で /login へ収束し、
+  // sync(401) + 404 の無限ループを断ち切る。signOut で query は無効化され再 fetch しない。
+  const error = query.error;
+  useEffect(() => {
+    if (error instanceof ApiClientError && error.status === 401) {
+      void supabase.auth.signOut({ scope: 'local' });
+    }
+  }, [error]);
 
   return {
     session,


### PR DESCRIPTION
## 概要
退会 → 同一メールで再登録 → マジックリンククリック後、本来は create-account（プロフィール/パスワード登録）へ進むはずが、`POST /auth/me/sync 401` + `GET /projects 404` を無限に繰り返す不具合を修正します。

## 根本原因
1. **stale セッションの残存（主因）**: 退会成功時、`WithdrawForm` は global `supabase.auth.signOut()` を呼ぶが、この時点で `deleteAccount` により **Supabase ユーザーは既に削除済み**。global signOut はサーバーの `/logout` を無効トークンで叩いて失敗し、**localStorage のセッションを消し残す**。暗号的には有効な stale JWT がブラウザに残る。
2. **stale JWT が sync を 401 にする**: `syncUser` は当該 authUserId の Supabase ユーザーが `getUserById` で見つからないと `AUTH_INVALID 401` を返す（削除済みなので必ず 401）。
3. **ブートストラップがループを増幅**: `SC01LoginPage` は認証済みなら無条件で `/dashboard` へ、`RequireAuth` は sync の `error` を未処理で保護下を描画（→ `GET /projects` が `deletedAt` ガードで 404、`retry:1` で2回）。結果 `/login`↔`/dashboard` を往復し続け、再登録セッションも stale セッションに覆われ create-account に到達できない。

## 修正（FE のみ）
- **`WithdrawForm`**: 退会成功時に **`signOut({ scope: 'local' })`** でローカルセッションのみ確実に破棄 → `/login` へ。`local` scope はサーバー `/logout` を呼ばないため、削除済みユーザーでも失敗せず消せる。
- **`useCurrentUser`**: sync が **401**（`ApiClientError.status === 401`）を返したら stale セッションとみなし `signOut({ scope: 'local' })`。`session` が null になり `RequireAuth`/`AuthCallbackPage` は `/login` へ収束、ループを根本から断つ（多重防御。管理者削除・期限切れ等の stale セッションにも有効）。
- 通常の「サインアウト」（生存ユーザー）は global signOut のまま据え置き。

## テスト
- `useCurrentUser.test.ts`: sync 401 で `signOut({ scope:'local' })` が呼ばれる／500 では呼ばれないことを検証。
- `ProfileModal.test.tsx`: 退会成功で `signOut({ scope:'local' })` が呼ばれることを検証。
- `pnpm type-check` / `pnpm lint` / `pnpm --filter @trakon/web test`（589 件）グリーン。

## 手動確認（Vercel Preview 推奨）
1. 退会 → localStorage の `trakon.auth` が消えること。
2. 同一メールで再登録 → リンククリック → create-account 画面に到達し登録できること。
3. stale セッションを残した状態でも、401 を1回出した後 `/login` に収束しループしないこと。

## スコープ外
Supabase 削除が失敗（`deleteAccount` 500）した場合に旧 authUserId で `completeSignup` が 409 になる退会失敗エッジは本 PR の対象外（別 issue）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)