### PR TITLE
feat(mail): 認証メールの Resend Custom SMTP 化手順整備とメール文面改善

### DIFF
--- a/apps/web/server/lib/mailer.ts
+++ b/apps/web/server/lib/mailer.ts
@@ -61,7 +61,7 @@ function createResendMailer(apiKey: string, fromEmail: string): Mailer {
       const { error } = await client.emails.send({
         from: fromEmail,
         to: input.to,
-        subject: `[TRAKON] ${input.projectName} への招待`,
+        subject: `「${input.projectName}」への参加のご案内 | TRAKON`,
         html,
         text,
       });
@@ -81,15 +81,17 @@ function renderInvitationText(input: {
   expiresHuman: string;
 }): string {
   return [
-    `TRAKON のプロジェクト「${input.projectName}」への招待が届きました。`,
+    `${input.inviterName} さんが、TRAKON のプロジェクト「${input.projectName}」にあなたを招待しました。`,
     '',
-    `招待者: ${input.inviterName}`,
-    `期限  : ${input.expiresHuman}`,
+    'TRAKON は、いま誰が次の対応を持っているか（ボール）を可視化し、制作の進行をスムーズにするツールです。',
     '',
-    '以下の URL からアカウント作成・招待受諾を行ってください。',
+    '▼ 参加する（アカウント作成・招待の受諾）',
     input.acceptUrl,
     '',
-    '本メールに心当たりがない場合は無視してください。',
+    `このリンクの有効期限は ${input.expiresHuman} です。`,
+    '期限を過ぎた場合は、お手数ですが招待した方にご連絡ください。',
+    '',
+    'お心当たりがない場合は、このメールを破棄していただいて問題ありません。',
     '— TRAKON',
   ].join('\n');
 }
@@ -101,16 +103,21 @@ function renderInvitationHtml(input: {
   expiresHuman: string;
 }): string {
   // シンプルな HTML テンプレート。Phase 1 で React Email に移行候補
-  return `<!doctype html><html lang="ja"><body style="font-family:-apple-system,'Hiragino Kaku Gothic ProN','Yu Gothic',sans-serif;color:#0f172a;line-height:1.6">
-  <div style="max-width:560px;margin:0 auto;padding:24px">
-    <h1 style="font-size:18px;margin:0 0 12px">TRAKON プロジェクトへの招待</h1>
-    <p>「<strong>${escapeHtml(input.projectName)}</strong>」への招待が届きました。</p>
-    <p style="margin:8px 0"><strong>招待者:</strong> ${escapeHtml(input.inviterName)}<br/><strong>期限:</strong> ${escapeHtml(input.expiresHuman)}</p>
-    <p style="margin:24px 0">
-      <a href="${input.acceptUrl}" style="display:inline-block;padding:10px 16px;background:#030213;color:#fff;border-radius:6px;text-decoration:none">招待を受諾する</a>
+  // 認証メール（Supabase Email Templates）と同一トーン: docs/email-templates.md
+  return `<!doctype html><html lang="ja"><body style="font-family:-apple-system,'Hiragino Kaku Gothic ProN','Yu Gothic',sans-serif;color:#0f172a;line-height:1.7;background:#f8fafc;margin:0;padding:24px">
+  <div style="max-width:560px;margin:0 auto;background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:32px">
+    <p style="font-size:13px;letter-spacing:.08em;color:#64748b;margin:0 0 16px">TRAKON</p>
+    <h1 style="font-size:18px;margin:0 0 16px">「${escapeHtml(input.projectName)}」への参加のご案内</h1>
+    <p style="margin:0 0 12px"><strong>${escapeHtml(input.inviterName)}</strong> さんが、あなたをプロジェクトに招待しました。</p>
+    <p style="margin:0 0 24px;color:#475569;font-size:14px">TRAKON は、いま誰が次の対応を持っているか（ボール）を可視化し、制作の進行をスムーズにするツールです。</p>
+    <p style="margin:0 0 24px">
+      <a href="${input.acceptUrl}" style="display:inline-block;padding:12px 20px;background:#030213;color:#fff;border-radius:8px;text-decoration:none;font-weight:600">参加する</a>
     </p>
-    <p style="font-size:12px;color:#64748b">ボタンが動かない場合は次の URL を直接開いてください:<br/>${input.acceptUrl}</p>
-    <p style="font-size:12px;color:#64748b;margin-top:32px">本メールに心当たりがない場合は無視してください。 — TRAKON</p>
+    <p style="font-size:13px;color:#64748b;margin:0 0 4px">このリンクの有効期限は <strong>${escapeHtml(input.expiresHuman)}</strong> です。</p>
+    <p style="font-size:13px;color:#64748b;margin:0 0 24px">期限を過ぎた場合は、お手数ですが招待した方にご連絡ください。</p>
+    <p style="font-size:12px;color:#94a3b8;margin:0 0 8px">ボタンが開けない場合は、次の URL をブラウザに貼り付けてください:<br/>${input.acceptUrl}</p>
+    <hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0"/>
+    <p style="font-size:12px;color:#94a3b8;margin:0">お心当たりがない場合は、このメールを破棄していただいて問題ありません。<br/>— TRAKON</p>
   </div></body></html>`;
 }
 

--- a/docs/design/implementation-notes.md
+++ b/docs/design/implementation-notes.md
@@ -17,6 +17,7 @@ Sub-Phase 0.0〜0.6 の実装過程で、基本設計書 v1.1 から意図的に
 | **Resend 送信失敗時のリトライ** | Phase 1 で Inngest 非同期化 | **同期送信 + 失敗で transaction rollback** | Phase 0 は単純さ優先 | Inngest で非同期化、再送ジョブ追加 |
 | **マイグレーション diff の自動生成** | `prisma migrate dev` 推奨 | **手書き SQL** で CHECK 制約・トリガを明示 | `prisma migrate dev` だけでは CHECK / トリガ / 部分インデックスを自動生成できない | 設計書 §6.9 に追記想定 |
 | **Supabase キー新方式移行（Phase 1 直前）** | 設計書 §6 は Legacy API keys（`anon` JWT / `service_role` JWT）前提 | **新方式 `sb_publishable_*` / `sb_secret_*` へ移行**。BE 側 env は `SUPABASE_SECRET_KEY` 優先 / `SUPABASE_SERVICE_ROLE_KEY` フォールバック、FE 側は `VITE_SUPABASE_PUBLISHABLE_KEY` に完全切替。JWT 署名キーとは独立管理になったため、`server/middleware/auth.ts` の iss/aud/JWKS 検証ロジックは不変 | Supabase Legacy API keys は 2026 年末でサポート終了予定。商用デプロイ前に新方式へ寄せて将来負債を回避。supabase-js は ^2.106.2 へ更新（新キー形式は apikey ヘッダーに渡すだけで透過対応） | 設計書 v1.2 § 6 環境変数表を新方式に書き換え |
+| **認証メールのブランド統制（§5.3.2）** | Supabase 標準メールを OFF にし **auth Webhook 経由で Resend 送信**、テンプレは `server/lib/mail/` でコード管理 | **Supabase Custom SMTP に Resend を設定**し、件名/本文は Supabase Email Templates、from は SMTP 送信者設定で管理 | Webhook + Send Email Hook 実装より大幅に軽量。レート制限解消（デフォルト共有 SMTP 脱却）とブランド文言変更を設定作業のみで両立。手順は `operations.md §2.4.2` | 文言をコード/i18n で一元管理したくなれば Send Email Hook 方式へ移行 |
 
 ## 設計書 v1.2 で追加・改訂すべき項目（提案）
 

--- a/docs/email-templates.md
+++ b/docs/email-templates.md
@@ -1,0 +1,163 @@
+# TRAKON メールテンプレート集
+
+TRAKON が送るメールの **件名・本文** を一元管理する。トーンは PRD UXR-05「煽らず濁さず逃げない」に従い、落ち着いた・明確・正直な言葉づかいにする。
+
+- **招待メール**はコードで送信（`apps/web/server/lib/mailer.ts`）。本ファイルは設計の正本ではなく、トーン統一のための参照。
+- **認証メール**（サインアップ確認 / Magic Link / パスワード再設定 / メール変更）は **Supabase Dashboard → Authentication → Email Templates** に貼り付ける。設定手順は [operations.md §2.4.2](operations.md#242-supabase-custom-smtp認証メールを-resend-経由にする)。
+
+> Supabase テンプレートの変数（Go template）：`{{ .ConfirmationURL }}`（アクションリンク）、`{{ .Token }}`（6 桁 OTP）、`{{ .SiteURL }}`、`{{ .Email }}`。
+> 共通デザイン：最大幅 560px / 本文色 `#0f172a` / ボタン背景 `#030213`・角丸 8px。招待メール（`mailer.ts`）と揃える。
+
+---
+
+## 共通の送信者（from）
+
+Supabase → Authentication → Emails → SMTP Settings → Sender に設定（認証メール共通）：
+
+```
+表示名: TRAKON
+メール: noreply@trakon.example.com   ← 実ドメインに置換
+```
+
+招待メール（アプリ独自）は Vercel Env `RESEND_FROM_EMAIL` で設定：
+
+```
+RESEND_FROM_EMAIL=TRAKON <noreply@trakon.example.com>
+```
+
+> ドメインは Resend で **SPF / DKIM 検証済み**であること（未検証だと迷惑メール判定・送信失敗）。
+
+---
+
+## 1. サインアップ確認（Confirm signup）
+
+**件名:**
+
+```
+TRAKON へのご登録を完了してください
+```
+
+**本文（HTML）:**
+
+```html
+<!doctype html>
+<html lang="ja">
+  <body style="font-family:-apple-system,'Hiragino Kaku Gothic ProN','Yu Gothic',sans-serif;color:#0f172a;line-height:1.7;background:#f8fafc;margin:0;padding:24px">
+    <div style="max-width:560px;margin:0 auto;background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:32px">
+      <p style="font-size:13px;letter-spacing:.08em;color:#64748b;margin:0 0 16px">TRAKON</p>
+      <h1 style="font-size:18px;margin:0 0 16px">ご登録ありがとうございます</h1>
+      <p style="margin:0 0 24px;color:#475569;font-size:14px">下のボタンからメールアドレスを確認し、登録を完了してください。</p>
+      <p style="margin:0 0 24px">
+        <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:12px 20px;background:#030213;color:#fff;border-radius:8px;text-decoration:none;font-weight:600">メールアドレスを確認する</a>
+      </p>
+      <p style="font-size:12px;color:#94a3b8;margin:0 0 8px">ボタンが開けない場合は、次の URL をブラウザに貼り付けてください:<br/>{{ .ConfirmationURL }}</p>
+      <hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0"/>
+      <p style="font-size:12px;color:#94a3b8;margin:0">お心当たりがない場合は、このメールを破棄していただいて問題ありません。<br/>— TRAKON</p>
+    </div>
+  </body>
+</html>
+```
+
+---
+
+## 2. ログインリンク（Magic Link）
+
+**件名:**
+
+```
+TRAKON へのログインリンク
+```
+
+**本文（HTML）:**
+
+```html
+<!doctype html>
+<html lang="ja">
+  <body style="font-family:-apple-system,'Hiragino Kaku Gothic ProN','Yu Gothic',sans-serif;color:#0f172a;line-height:1.7;background:#f8fafc;margin:0;padding:24px">
+    <div style="max-width:560px;margin:0 auto;background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:32px">
+      <p style="font-size:13px;letter-spacing:.08em;color:#64748b;margin:0 0 16px">TRAKON</p>
+      <h1 style="font-size:18px;margin:0 0 16px">ログインリンクをお送りします</h1>
+      <p style="margin:0 0 24px;color:#475569;font-size:14px">下のボタンから TRAKON にログインできます。このリンクは一定時間で無効になります。</p>
+      <p style="margin:0 0 24px">
+        <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:12px 20px;background:#030213;color:#fff;border-radius:8px;text-decoration:none;font-weight:600">ログインする</a>
+      </p>
+      <p style="font-size:12px;color:#94a3b8;margin:0 0 8px">ボタンが開けない場合は、次の URL をブラウザに貼り付けてください:<br/>{{ .ConfirmationURL }}</p>
+      <hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0"/>
+      <p style="font-size:12px;color:#94a3b8;margin:0">心当たりがない場合は、このメールを破棄してください。第三者があなたのメールアドレスを入力した可能性があります。<br/>— TRAKON</p>
+    </div>
+  </body>
+</html>
+```
+
+---
+
+## 3. パスワード再設定（Reset Password）
+
+**件名:**
+
+```
+TRAKON のパスワード再設定
+```
+
+**本文（HTML）:**
+
+```html
+<!doctype html>
+<html lang="ja">
+  <body style="font-family:-apple-system,'Hiragino Kaku Gothic ProN','Yu Gothic',sans-serif;color:#0f172a;line-height:1.7;background:#f8fafc;margin:0;padding:24px">
+    <div style="max-width:560px;margin:0 auto;background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:32px">
+      <p style="font-size:13px;letter-spacing:.08em;color:#64748b;margin:0 0 16px">TRAKON</p>
+      <h1 style="font-size:18px;margin:0 0 16px">パスワードを再設定します</h1>
+      <p style="margin:0 0 24px;color:#475569;font-size:14px">下のボタンから新しいパスワードを設定してください。このリンクは一定時間で無効になります。</p>
+      <p style="margin:0 0 24px">
+        <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:12px 20px;background:#030213;color:#fff;border-radius:8px;text-decoration:none;font-weight:600">パスワードを再設定する</a>
+      </p>
+      <p style="font-size:12px;color:#94a3b8;margin:0 0 8px">ボタンが開けない場合は、次の URL をブラウザに貼り付けてください:<br/>{{ .ConfirmationURL }}</p>
+      <hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0"/>
+      <p style="font-size:12px;color:#94a3b8;margin:0">再設定をご依頼していない場合は、このメールを破棄してください。パスワードは変更されません。<br/>— TRAKON</p>
+    </div>
+  </body>
+</html>
+```
+
+---
+
+## 4. メールアドレス変更の確認（Change Email Address）
+
+`config.toml` で `double_confirm_changes = true` のため、新旧アドレス両方に確認メールが届く。
+
+**件名:**
+
+```
+TRAKON のメールアドレス変更の確認
+```
+
+**本文（HTML）:**
+
+```html
+<!doctype html>
+<html lang="ja">
+  <body style="font-family:-apple-system,'Hiragino Kaku Gothic ProN','Yu Gothic',sans-serif;color:#0f172a;line-height:1.7;background:#f8fafc;margin:0;padding:24px">
+    <div style="max-width:560px;margin:0 auto;background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:32px">
+      <p style="font-size:13px;letter-spacing:.08em;color:#64748b;margin:0 0 16px">TRAKON</p>
+      <h1 style="font-size:18px;margin:0 0 16px">メールアドレスの変更を確認します</h1>
+      <p style="margin:0 0 24px;color:#475569;font-size:14px">下のボタンからメールアドレスの変更を確定してください。</p>
+      <p style="margin:0 0 24px">
+        <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:12px 20px;background:#030213;color:#fff;border-radius:8px;text-decoration:none;font-weight:600">変更を確定する</a>
+      </p>
+      <p style="font-size:12px;color:#94a3b8;margin:0 0 8px">ボタンが開けない場合は、次の URL をブラウザに貼り付けてください:<br/>{{ .ConfirmationURL }}</p>
+      <hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0"/>
+      <p style="font-size:12px;color:#94a3b8;margin:0">お心当たりがない場合は、このメールを破棄し、アカウントのパスワード変更をご検討ください。<br/>— TRAKON</p>
+    </div>
+  </body>
+</html>
+```
+
+---
+
+## 招待メール（参考 / 実体はコード）
+
+実体は `apps/web/server/lib/mailer.ts`。件名・本文を変更する場合はコードを編集する。
+
+- 件名: `「{プロジェクト名}」への参加のご案内 | TRAKON`
+- 差出人: `RESEND_FROM_EMAIL`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -45,17 +45,42 @@ Phase 0 商用リリースに必要な **外部サービスのセットアップ
 
 [apps/web/README.md §「OAuth プロバイダ設定」](../apps/web/README.md) を参照。dev / prod で別 OAuth App を作成。
 
-### 2.4 Resend（招待メール）
+### 2.4 Resend（メール送信）
+
+TRAKON のメールは **2 系統** あり、いずれも Resend に集約する：
+
+| 系統 | 送信経路 | 対象メール | from / 文面の管理 |
+|---|---|---|---|
+| **アプリ独自** | Resend SDK（`server/lib/mailer.ts`） | プロジェクト招待 | コードで制御（`RESEND_FROM_EMAIL` / `mailer.ts`） |
+| **認証系** | **Supabase Auth → Resend Custom SMTP** | サインアップ確認 / Magic Link / パスワード再設定 | Supabase の Email Templates / SMTP 送信者設定 |
+
+> **重要（レート制限）**：Supabase の認証メールは、Custom SMTP を設定しないと **Supabase 共有のデフォルト SMTP**（1 時間あたり数通の極めて厳しい制限）で送られる。複数人が一斉にサインアップすると即詰まる。**下記 2.4.2 の Custom SMTP 設定でこの制限を解消する**こと。
+
+#### 2.4.1 Resend セットアップ（共通）
 
 1. <https://resend.com/signup>
-2. Domains で送信元ドメイン（例 `trakon.example.com`）を追加し、表示される **SPF / DKIM / DMARC** の DNS レコードを設定
+2. Domains で送信元ドメイン（例 `trakon.example.com`）を追加し、表示される **SPF / DKIM / DMARC** の DNS レコードを設定（**検証完了**まで待つ。未検証だと迷惑メール判定・送信失敗の原因）
 3. API Keys から API キーを発行
-4. Vercel Env に投入：
+4. Vercel Env に投入（招待メール = アプリ独自送信用）：
    - `RESEND_API_KEY=<key>`
    - `RESEND_FROM_EMAIL=TRAKON <noreply@trakon.example.com>`
 5. `APP_ENV=prod` のとき必須。未設定だと起動時に例外
 
 > dev / local では `RESEND_API_KEY` を空のままでも `console.log` ダミー送信にフォールバックする。
+
+#### 2.4.2 Supabase Custom SMTP（認証メールを Resend 経由にする）
+
+prod の Supabase プロジェクトで設定する（dev も同様に設定推奨）。
+
+1. Resend の SMTP 接続情報を用意：
+   - Host: `smtp.resend.com` / Port: `465`（または `587`）
+   - Username: `resend` / Password: **Resend API キー**（2.4.1 で発行したもの）
+2. Supabase Dashboard → **Authentication → Emails → SMTP Settings** を有効化し、上記を入力
+3. **Sender**（送信者）に `noreply@trakon.example.com` / 表示名 `TRAKON` を設定 → これが認証メールの `from` になる
+4. **Authentication → Rate Limits → Email sending** を運用想定に合わせて引き上げる（Custom SMTP 設定後はここが実質の上限。デフォルトの 30 通/時などでは一斉登録で不足する場合あり）
+5. **Authentication → Email Templates** で Confirm signup / Magic Link / Reset Password / Change Email の **件名・本文** を編集。**貼り付け用テンプレートは [email-templates.md](email-templates.md) に用意済み**（PRD UXR-05「煽らず濁さず逃げない」。招待メール `mailer.ts` とトーン統一）
+
+> ローカル（`supabase start`）は `[inbucket]` でメールを受けるため Custom SMTP 設定は不要。
 
 ### 2.5 DB ロール分離
 
@@ -93,7 +118,7 @@ psql "$DIRECT_URL" \
 
 - **PITR**: 有効化（任意の時点へリストア可能）
 - **Daily backups**: 7 日間保持
-- **Custom SMTP**: 不要（Resend を使うため）
+- **Custom SMTP**: **必須**（Resend を Custom SMTP として設定する。手順は [2.4.2 節](#242-supabase-custom-smtp認証メールを-resend-経由にする)）。未設定だと認証メールが Supabase デフォルト SMTP の厳しいレート制限に当たり、一斉サインアップで失敗する
 
 ### 2.9 GitHub Actions Secrets
 
@@ -127,11 +152,19 @@ psql "$DIRECT_URL" \
 - **DB マイグレーション**：**前進的修正リリース**で対応（後方互換のあるカラム追加/データ移行で巻き戻す）
 - 緊急時：Supabase PITR で本番 DB を直前の時点に巻き戻し（要 Pro プラン）
 
-### 3.3 招待メール送信失敗時の対応
+### 3.3 メール送信失敗時の対応
+
+**招待メール（アプリ独自送信）**
 
 1. Sentry でエラー詳細を確認
 2. Resend Dashboard で送信ログを確認（バウンス / SPF / DKIM）
 3. ユーザーには手動で再送（管理画面の参加者管理タブから削除→再追加）
+
+**認証メール（サインアップ / Magic Link / パスワード再設定）**
+
+1. **「メールが届かない・一斉登録で失敗する」場合、まず Custom SMTP（[2.4.2](#242-supabase-custom-smtp認証メールを-resend-経由にする)）が設定済みか確認**。未設定だと Supabase デフォルト SMTP の数通/時の制限に当たる
+2. Resend Dashboard の送信ログに認証メールが出ているか確認（出ていなければ Supabase 側で Custom SMTP が効いていない）
+3. Supabase Dashboard → Authentication → Rate Limits の上限と、ドメインの SPF/DKIM 検証状態を確認
 
 ---
 


### PR DESCRIPTION
## 背景・目的

メール送信に関する2つの課題への対応:

1. **複数人が一斉に新規登録するとメール送信制限に引っかかる**
2. **メールの文面・タイトル・from を変更したい**

調査の結果、原因は **Resend ではなく Supabase 側**にあると判明した。認証メール（サインアップ確認 / Magic Link / パスワード再設定）は、Custom SMTP 未設定だと **Supabase の共有デフォルト SMTP**（1時間あたり数通という極めて厳しい制限）で送られており、一斉登録で詰まる。Resend はアプリ独自の招待メールにしか使われていなかった。

→ **Resend をそのまま継続**し、Supabase の Custom SMTP として設定することで、制限解消とブランド文面の変更を最小コストで両立する方針に確定（ユーザー確認済み）。

## 変更内容

このPRは **ドキュメント整備＋招待メール文面の改善**が中心。実際の Resend / Supabase Dashboard 設定は別途手動作業（手順は本PRのドキュメントに記載）。

- **`docs/operations.md`**
  - §2.4 を「招待＝Resend SDK / 認証＝Supabase Custom SMTP(Resend)」の2系統に再構成し、**§2.4.2 に Custom SMTP 設定手順**（SMTP 認証情報・送信者・レート制限・テンプレ編集）を新設
  - §2.8 の「Custom SMTP: 不要」という**誤記を「必須」へ訂正**
  - §3.3 を認証メール失敗時の切り分け手順を含めて拡張
- **`docs/email-templates.md`（新規）** — Supabase にそのまま貼り付け可能な認証メールテンプレート集（Confirm signup / Magic Link / Reset Password / Change Email の件名＋HTML）
- **`apps/web/server/lib/mailer.ts`** — 招待メールの件名・本文・HTML をブランドトーンに合わせて改善（from は `RESEND_FROM_EMAIL` のまま）
- **`docs/design/implementation-notes.md`** — 設計書 §5.3.2 の Webhook 方式 → Custom SMTP 方式への変更を記録

## テスト

- `pnpm --filter @trakon/web test mailer` … 9件パス
- `pnpm --filter @trakon/web type-check` … パス
- 招待メールのテストはモック方式で文面に依存しないため影響なし

## マージ後に必要な手動作業（コード外）

`docs/operations.md §2.4.2` の手順に従う:
1. Resend アカウント作成 → ドメインの SPF/DKIM 認証 → API キー発行
2. Vercel 環境変数に `RESEND_API_KEY` / `RESEND_FROM_EMAIL` を設定（招待メール用）
3. Supabase Dashboard に Custom SMTP（Resend）・送信者・レート制限を設定
4. Supabase Email Templates に `docs/email-templates.md` の内容を貼り付け

🤖 Generated with [Claude Code](https://claude.com/claude-code)