### PR TITLE
fix(ci): 招待メール件名のテスト期待値を実装に追従させCI失敗を解消

### DIFF
--- a/apps/web/server/lib/mailer.test.ts
+++ b/apps/web/server/lib/mailer.test.ts
@@ -122,7 +122,7 @@ describe('getMailer (resend)', () => {
     };
     expect(payload.from).toBe('noreply@trakon.test');
     expect(payload.to).toBe(invitation.to);
-    expect(payload.subject).toBe('[TRAKON] プロジェクト<X> への招待');
+    expect(payload.subject).toBe('「プロジェクト<X>」への参加のご案内 | TRAKON');
     // HTML 本文には受諾 URL とエスケープ済みのプロジェクト名が含まれる
     expect(payload.html).toContain(invitation.acceptUrl);
     expect(payload.html).toContain('プロジェクト&lt;X&gt;');


### PR DESCRIPTION
## 背景

最新 main (`a870da5` "feat(mail): …メール文面の改善") の CI が失敗していました。
- 失敗 run: https://github.com/OSA-OSAMARU/trakon-app/actions/runs/28319778375/job/83899547130

`a870da5` で招待メールの件名を改善（変更）した際、ユニットテストの期待値が旧文面のまま残り、`@trakon/web` の `test:coverage` が 1 件失敗していました（lint / type-check は通過、test のみ失敗）。

```
AssertionError: expected '「プロジェクト<X>」への参加のご案内 | TRAKON' to be '[TRAKON] プロジェクト<X> への招待'
 ❯ server/lib/mailer.test.ts:125:29
```

## 変更内容

実装側の新件名（`apps/web/server/lib/mailer.ts:64`）が意図された正しい文面のため、テストを実装に追従させます。

`apps/web/server/lib/mailer.test.ts:125` の期待値を 1 行修正:
- Before: `'[TRAKON] プロジェクト<X> への招待'`
- After: `'「プロジェクト<X>」への参加のご案内 | TRAKON'`

## 確認

- `pnpm --filter @trakon/web test server/lib/mailer.test.ts` → 9 tests 全 pass
- `pnpm --filter @trakon/web lint` / `type-check` → クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)