### PR TITLE
feat(auth): OAuth 新規登録に規約みなし同意の導線を追加

### DIFF
--- a/apps/web/src/features/auth/OAuthButtons.tsx
+++ b/apps/web/src/features/auth/OAuthButtons.tsx
@@ -9,8 +9,12 @@ type TrakonProvider = 'google' | 'azure';
  * Google / Microsoft の OAuth ログインボタン。
  * Supabase SDK の signInWithOAuth が PKCE / state を内部処理し、
  * /auth/callback にリダイレクトしてくる (AuthCallbackPage が sync を呼ぶ)。
+ *
+ * OAuth はボタン押下＝即プロバイダ遷移のため、押下前にチェックさせるのが難しい。
+ * 新規ユーザーはそのままプロフィールが自動生成されるため、規約同意はボタン下部の
+ * 「みなし同意」文言で担保する (login / signup 両画面に表示される)。
  */
-export function OAuthButtons({ disabled = false }: { disabled?: boolean }) {
+export function OAuthButtons() {
   const [busy, setBusy] = useState<TrakonProvider | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -37,7 +41,7 @@ export function OAuthButtons({ disabled = false }: { disabled?: boolean }) {
         type="button"
         variant="outline"
         className="w-full"
-        disabled={disabled || busy !== null}
+        disabled={busy !== null}
         onClick={() => start('google')}
       >
         <GoogleMark />
@@ -47,13 +51,34 @@ export function OAuthButtons({ disabled = false }: { disabled?: boolean }) {
         type="button"
         variant="outline"
         className="w-full"
-        disabled={disabled || busy !== null}
+        disabled={busy !== null}
         onClick={() => start('azure')}
       >
         <MicrosoftMark />
         Microsoft で続ける
       </Button>
       {error && <p className="text-xs text-destructive">{error}</p>}
+      <p className="text-[11px] leading-relaxed text-muted-foreground">
+        Google・Microsoft で続けると、
+        <a
+          href="/terms"
+          target="_blank"
+          rel="noreferrer"
+          className="text-foreground underline underline-offset-2"
+        >
+          利用規約
+        </a>
+        および
+        <a
+          href="/privacy"
+          target="_blank"
+          rel="noreferrer"
+          className="text-foreground underline underline-offset-2"
+        >
+          プライバシーポリシー
+        </a>
+        に同意したものとみなされます。
+      </p>
     </div>
   );
 }

--- a/apps/web/src/features/auth/SC01LoginPage.test.tsx
+++ b/apps/web/src/features/auth/SC01LoginPage.test.tsx
@@ -117,6 +117,18 @@ describe('SC01LoginPage — login 画面', () => {
     expect(cb).not.toBeChecked();
   });
 
+  it('OAuth ボタン下に「みなし同意」文言と規約リンクを表示する', async () => {
+    renderWithProviders(<SC01LoginPage />, { route: '/login' });
+    expect(
+      await screen.findByText(/同意したものとみなされます/),
+    ).toBeInTheDocument();
+    // みなし同意文言内の利用規約リンクが /terms を指す。
+    const termsLinks = screen
+      .getAllByRole('link', { name: '利用規約' })
+      .filter((a) => a.getAttribute('href') === '/terms');
+    expect(termsLinks.length).toBeGreaterThan(0);
+  });
+
   it('認証済みかつ create-account 以外なら /dashboard へリダイレクトする', async () => {
     auth.getSession.mockResolvedValue({ data: { session: makeSession() } });
     renderWithProviders(<SC01LoginPage />, { route: '/login' });
@@ -154,7 +166,7 @@ describe('SC01LoginPage — signup 画面', () => {
     expect(await screen.findByText(/メールの送信に失敗しました/)).toBeInTheDocument();
   });
 
-  it('規約に未同意だと送信ボタンが無効で signInWithOtp を呼ばない', async () => {
+  it('規約未同意ではメール送信ボタンのみ無効、OAuth はみなし同意で常時有効', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     renderWithProviders(<SC01LoginPage />, { route: '/login?screen=signup' });
 
@@ -162,11 +174,11 @@ describe('SC01LoginPage — signup 画面', () => {
       await screen.findByLabelText('メールアドレス'),
       'new@example.com',
     );
-    // 未チェックの状態ではメール送信ボタンも OAuth ボタンも無効。
+    // 未チェックではメール送信ボタンは無効。OAuth は「みなし同意」文言で担保するため常時有効。
     expect(screen.getByRole('button', { name: /認証メールを送る/ })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /Google で続ける/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Google で続ける/ })).toBeEnabled();
 
-    // チェックすると解放される。
+    // チェックするとメール送信ボタンも解放される。
     await user.click(screen.getByRole('checkbox'));
     expect(screen.getByRole('button', { name: /認証メールを送る/ })).toBeEnabled();
     expect(screen.getByRole('button', { name: /Google で続ける/ })).toBeEnabled();

--- a/apps/web/src/features/auth/SC01LoginPage.tsx
+++ b/apps/web/src/features/auth/SC01LoginPage.tsx
@@ -268,7 +268,9 @@ function SignupForm({
           </Button>
         </form>
         <div className="mt-6">
-          <OAuthButtons disabled={!agreed} />
+          {/* OAuth は「みなし同意」文言 (OAuthButtons 内) で担保するため、規約チェック
+              未完でも押下可能。チェックボックスはメール登録ボタン専用。 */}
+          <OAuthButtons />
         </div>
         <p className="mt-5 text-center text-[11px] leading-relaxed text-muted-foreground">
           <a href="/terms" target="_blank" rel="noreferrer" className="underline underline-offset-2">


### PR DESCRIPTION
## 背景 / 課題
PR #105 で新規登録に規約同意チェックボックスを追加したが、これはメール(Magic-link)登録と signup 画面の OAuth ボタンにしか効いていなかった。

Google / Microsoft はボタン押下＝即プロバイダ画面へ遷移する性質上「押す前にチェック」させにくく、especially **login 画面の OAuth ボタンには同意導線が一切なかった**。新規ユーザーが Google/Microsoft を押すとサーバ側 `syncUser()` がプロフィールを自動生成し、そのままダッシュボードに着地して規約同意の導線が存在しない、という不具合報告への対応。

## 対応方針（みなし同意）
OAuth ボタン付近に「**Google・Microsoft で続けると、利用規約およびプライバシーポリシーに同意したものとみなされます**」という文言（規約/プラポリへのリンク付き）を表示する。チェックボックス・新画面・DB 変更なしのフロントのみ最小変更。

- `OAuthButtons.tsx`: ボタン下部にみなし同意の注記を追加（login/signup 両画面に自動表示）。`disabled` prop を撤去。
- `SC01LoginPage.tsx` (SignupForm): OAuth をみなし同意に統一するため `<OAuthButtons disabled={!agreed} />` → `<OAuthButtons />`。同意チェックボックスは**メール登録ボタン専用**として存置。

## テスト
- `SC01LoginPage.test.tsx`: 「未同意ではメール送信ボタンのみ無効・OAuth は常時有効」に更新。login 画面にみなし同意文言＋/terms リンクが出る新規テストを追加。
- lint / type-check / 全ユニット(594 pass) / coverage(91.05% ≥ 88%) / build すべてグリーン（ローカル確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)