### PR TITLE
fix(auth): パスワード再設定リンクで再設定画面に遷移するよう修正

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { AuthCallbackPage } from './app/AuthCallbackPage';
 import { DashboardPage } from './app/DashboardPage';
+import { ResetPasswordPage } from './app/ResetPasswordPage';
 import { SidebarLayout } from './app/SidebarLayout';
 import { RequireAuth } from './features/auth/RequireAuth';
 import { SC01LoginPage } from './features/auth/SC01LoginPage';
@@ -24,6 +25,7 @@ export function App() {
     <Routes>
       <Route path="/login" element={<SC01LoginPage />} />
       <Route path="/auth/callback" element={<AuthCallbackPage />} />
+      <Route path="/auth/reset-password" element={<ResetPasswordPage />} />
       <Route path="/invitations/:token" element={<InvitationAcceptPage />} />
       <Route path="/share/:token" element={<SharePage />} />
 

--- a/apps/web/src/app/AuthCallbackPage.tsx
+++ b/apps/web/src/app/AuthCallbackPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 
+import { supabase } from '@/lib/supabase';
 import { useCurrentUser } from '@/features/auth/useCurrentUser';
 
 /**
@@ -12,8 +13,23 @@ import { useCurrentUser } from '@/features/auth/useCurrentUser';
 export function AuthCallbackPage() {
   const navigate = useNavigate();
   const { session, sessionLoading, data, isLoading, error } = useCurrentUser();
+  // 後方互換: 旧リセットメールは /auth/callback に着地する。PASSWORD_RECOVERY を
+  // 検出したら専用のパスワード再設定ページへ振り替える (detectSessionInUrl が
+  // hash を消費するため type=recovery は直接読めず、イベントで判定する)。
+  const [isRecovery, setIsRecovery] = useState(false);
 
   useEffect(() => {
+    const { data: sub } = supabase.auth.onAuthStateChange((event) => {
+      if (event === 'PASSWORD_RECOVERY') setIsRecovery(true);
+    });
+    return () => sub.subscription.unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    if (isRecovery) {
+      navigate('/auth/reset-password', { replace: true });
+      return;
+    }
     if (sessionLoading || isLoading) return;
     if (!session) {
       navigate('/login', { replace: true });
@@ -30,7 +46,7 @@ export function AuthCallbackPage() {
     if (data && !data.requiresProfileCompletion) {
       navigate('/dashboard', { replace: true });
     }
-  }, [session, sessionLoading, data, isLoading, error, navigate]);
+  }, [session, sessionLoading, data, isLoading, error, navigate, isRecovery]);
 
   return (
     <div className="flex min-h-screen items-center justify-center gap-2 text-sm text-muted-foreground">

--- a/apps/web/src/app/ResetPasswordPage.tsx
+++ b/apps/web/src/app/ResetPasswordPage.tsx
@@ -1,0 +1,231 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { ArrowLeft, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { supabase } from '@/lib/supabase';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+
+/**
+ * パスワード再設定 (recovery) 専用の着地ページ。
+ *
+ * `resetPasswordForEmail` の redirectTo からここへ着地する。Supabase SDK は
+ * detectSessionInUrl により recovery トークンを消費して一時セッションを確立する。
+ * このページは RequireAuth / SC01LoginPage の外にあるため、セッションが確立されても
+ * ダッシュボードへ自動遷移せず、新パスワードの入力を促す (§9.1 SR-AUTH)。
+ */
+export function ResetPasswordPage() {
+  const { session, isLoading } = useAuthSession();
+
+  if (isLoading) {
+    return (
+      <Centered>
+        <Loader2 className="size-4 animate-spin" />
+        リンクを確認しています…
+      </Centered>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-start justify-center bg-background px-4 pt-24">
+      <div className="w-full max-w-sm">
+        <h1 className="mb-8 text-center text-3xl font-extrabold tracking-[0.2em]">TRAKON</h1>
+        {session ? <NewPasswordForm /> : <InvalidLink />}
+      </div>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// 新パスワード入力フォーム
+// -----------------------------------------------------------------------------
+const resetSchema = z
+  .object({
+    newPassword: z
+      .string()
+      .min(8, 'パスワードは8文字以上で入力してください')
+      .max(128)
+      .refine((v) => /[A-Za-z]/.test(v) && /\d/.test(v) && /[^\w\s]/.test(v), {
+        message: '英字・数字・記号をそれぞれ1文字以上含めてください',
+      }),
+    confirm: z.string(),
+  })
+  .refine((v) => v.newPassword === v.confirm, {
+    path: ['confirm'],
+    message: 'パスワードが一致しません',
+  });
+type ResetInput = z.infer<typeof resetSchema>;
+
+function NewPasswordForm() {
+  const navigate = useNavigate();
+  const [serverError, setServerError] = useState<string | null>(null);
+  const form = useForm<ResetInput>({ resolver: zodResolver(resetSchema) });
+
+  const onSubmit = async (values: ResetInput) => {
+    setServerError(null);
+    const { error } = await supabase.auth.updateUser({ password: values.newPassword });
+    if (error) {
+      setServerError('パスワードの変更に失敗しました。時間をおいて再度お試しください。');
+      return;
+    }
+    // 再設定完了後はサインアウトし、新パスワードでの明示的なログインを促す。
+    await supabase.auth.signOut();
+    toast.success('パスワードを変更しました。新しいパスワードでログインしてください。');
+    navigate('/login', { replace: true });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">新しいパスワードの設定</CardTitle>
+        <CardDescription>
+          新しいパスワードを入力してください。
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <Field
+            id="newPassword"
+            label="新しいパスワード"
+            hint="8文字以上、英字・数字・記号を含む"
+            error={form.formState.errors.newPassword?.message}
+          >
+            <Input
+              id="newPassword"
+              type="password"
+              autoComplete="new-password"
+              {...form.register('newPassword')}
+            />
+            <PasswordStrength value={form.watch('newPassword') ?? ''} />
+          </Field>
+          <Field
+            id="confirm"
+            label="新しいパスワード（確認）"
+            error={form.formState.errors.confirm?.message}
+          >
+            <Input
+              id="confirm"
+              type="password"
+              autoComplete="new-password"
+              {...form.register('confirm')}
+            />
+          </Field>
+          {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+          <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
+            {form.formState.isSubmitting && <Loader2 className="size-4 animate-spin" />}
+            パスワードを変更する
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// リンク無効／期限切れ
+// -----------------------------------------------------------------------------
+function InvalidLink() {
+  const navigate = useNavigate();
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">リンクが無効です</CardTitle>
+        <CardDescription>
+          パスワード再設定リンクの有効期限が切れているか、既に使用済みです。
+          お手数ですが、もう一度リセットメールを送信してください。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Button
+          type="button"
+          className="w-full"
+          onClick={() => navigate('/login?screen=password-reset-request', { replace: true })}
+        >
+          リセットメールを再送する
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          className="w-full"
+          onClick={() => navigate('/login', { replace: true })}
+        >
+          <ArrowLeft className="size-4" />
+          ログインに戻る
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Shared (SC01LoginPage と同一の見た目)
+// -----------------------------------------------------------------------------
+function Field({
+  id,
+  label,
+  hint,
+  error,
+  children,
+}: {
+  id: string;
+  label: string;
+  hint?: string;
+  error?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      {children}
+      {hint && !error && <p className="text-xs text-muted-foreground">{hint}</p>}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+function PasswordStrength({ value }: { value: string }) {
+  if (!value) return null;
+  let score = 0;
+  if (value.length >= 8) score++;
+  if (/[A-Za-z]/.test(value)) score++;
+  if (/\d/.test(value)) score++;
+  if (/[^\w\s]/.test(value)) score++;
+
+  const meta =
+    score <= 1
+      ? { label: '弱い', color: 'bg-red-500' }
+      : score === 2
+        ? { label: '普通', color: 'bg-amber-500' }
+        : score === 3
+          ? { label: 'やや強い', color: 'bg-lime-500' }
+          : { label: '強い', color: 'bg-emerald-500' };
+
+  return (
+    <div className="mt-1.5 space-y-1" aria-live="polite">
+      <div className="flex gap-1">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className={`h-1 flex-1 rounded-full ${i < score ? meta.color : 'bg-muted'}`}
+          />
+        ))}
+      </div>
+      <p className="text-[11px] text-muted-foreground">強度：{meta.label}</p>
+    </div>
+  );
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center gap-2 text-sm text-muted-foreground">
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/features/auth/SC01LoginPage.test.tsx
+++ b/apps/web/src/features/auth/SC01LoginPage.test.tsx
@@ -201,7 +201,7 @@ describe('SC01LoginPage — password-reset-request 画面', () => {
     await waitFor(() =>
       expect(auth.resetPasswordForEmail).toHaveBeenCalledWith(
         'reset@example.com',
-        expect.objectContaining({ redirectTo: expect.stringContaining('/auth/callback') }),
+        expect.objectContaining({ redirectTo: expect.stringContaining('/auth/reset-password') }),
       ),
     );
     expect(

--- a/apps/web/src/features/auth/SC01LoginPage.tsx
+++ b/apps/web/src/features/auth/SC01LoginPage.tsx
@@ -522,7 +522,7 @@ function PasswordResetRequest({
   const onSubmit = async (values: SignupInput) => {
     setServerError(null);
     const { error } = await supabase.auth.resetPasswordForEmail(values.email, {
-      redirectTo: `${window.location.origin}/auth/callback`,
+      redirectTo: `${window.location.origin}/auth/reset-password`,
     });
     if (error) {
       // 機密第一: 存在判定を漏らさないため成功扱いに統一


### PR DESCRIPTION
## 概要

「パスワードを忘れた方」からリセットメールを送り、届いたリンクをクリックしても**新しいパスワードを設定する画面にならず**、ログイン状態でダッシュボードへ遷移したり、時々ログイン画面へ飛ばされる不具合を修正します。

## 原因

パスワード再設定の専用画面が存在せず、リセットメールの `redirectTo` が `/auth/callback` を指していた。

1. リンク（`/auth/callback#access_token=...&type=recovery`）をクリック
2. `detectSessionInUrl: true` が recovery トークンを消費し**セッションを確立**
3. `AuthCallbackPage` は recovery を区別せず、プロフィール完了済みユーザーを `/dashboard` へ遷移
4. トークンが事前フェッチ（メールのセキュリティスキャナ等）・期限切れ・使用済みの場合はセッションが確立されず `/login` へ

## 変更内容

- **`SC01LoginPage`**: `resetPasswordForEmail` の `redirectTo` を `/auth/callback` → `/auth/reset-password` に変更（magic-link の `/auth/callback` は維持）
- **`ResetPasswordPage`（新規）**: recovery 専用の着地ページ。`RequireAuth`／`SC01LoginPage` の外にあるため自動でダッシュボードへ遷移しない
  - セッションあり → 新パスワード入力 → `updateUser` で更新 → サインアウト → ログイン画面へ案内
  - セッションなし（無効/期限切れ/事前フェッチ済み）→ 「リンクが無効です」＋リセットメール再送導線
- **`App`**: `/auth/reset-password` ルートを追加
- **`AuthCallbackPage`**: 後方互換。既に送信済みの旧リンクが `/auth/callback` に着地しても `PASSWORD_RECOVERY` を検出して再設定ページへ振り替え

## ⚠️ コード外の必須設定

Supabase の **Auth → URL Configuration → Redirect URLs** に `/auth/reset-password` が許可対象として含まれている必要があります（未許可だと Site URL にフォールバックしリンクが壊れる）。ワイルドカード（`https://<本番ドメイン>/**` 等）登録済みなら追加対応不要。

## テスト

- `pnpm --filter @trakon/web type-check` / `lint` / `test`（61 tests）通過を確認済み

## 動作確認手順

1. ログイン →「パスワードを忘れた場合」→ メール送信
2. リンク先が `/auth/reset-password` になっていること、クリックで新パスワード入力画面が出ること（ダッシュボード/ログインに飛ばない）
3. 設定後にログイン画面へ戻り、新パスワードでログインできること
4. 使用済みリンク再訪で「リンクが無効です」表示＋再送導線が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)