### PR TITLE
ci(deploy): Release Deploy を特定タグ指定で手動実行できるよう対応

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -13,22 +13,31 @@ name: Release Deploy
 on:
   release:
     types: [published]
+  # 特定タグを指定して手動で Production デプロイする (ロールバックや再デプロイ用)。
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'デプロイ対象の Git タグ (例: v1.2.3)'
+        required: true
+        type: string
 
 concurrency:
-  group: release-deploy-${{ github.ref }}
+  # タグ単位で直列化する (release / 手動どちらの経路でも同じ group にする)。
+  group: release-deploy-${{ github.event.inputs.tag || github.event.release.tag_name }}
   cancel-in-progress: false
 
 jobs:
   deploy:
     name: prisma migrate deploy + vercel deploy --prod
     runs-on: ubuntu-latest
-    if: ${{ !github.event.release.prerelease }}
+    # release 経由の prerelease はスキップ。手動 (workflow_dispatch) は常に実行する。
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## 概要

Release Deploy ワークフローに `workflow_dispatch` トリガーを追加し、特定のタグを指定して手動で Production デプロイできるようにしました。ロールバックや再デプロイの用途で使えます。

## 変更内容

- **`workflow_dispatch` トリガー追加** — `tag` 入力（必須）を受け取り、Actions の「Run workflow」から任意のタグを指定して手動デプロイ可能に
- **Checkout の `ref`** — `github.event.inputs.tag || github.event.release.tag_name` にし、手動なら入力タグ、Release 経由なら従来通り
- **`if` 条件** — 手動実行は常に実行、Release 経由は従来通り prerelease をスキップ（手動時に prerelease が空で誤スキップされる問題も回避）
- **`concurrency` group** — タグ単位に変更し、Release / 手動が同じタグなら直列化

## 使い方

Actions → 「Release Deploy」→ **Run workflow** でデプロイ対象タグ（例: `v1.2.3`）を入力して実行。

> [!NOTE]
> Run workflow ボタンはこのワークフローがデフォルトブランチ (`main`) に存在して初めて表示されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)