### PR TITLE
fix(auth): Microsoft OAuth ログインで email スコープを明示しコールバックエラーを可視化

### DIFF
--- a/apps/web/src/app/AuthCallbackPage.test.tsx
+++ b/apps/web/src/app/AuthCallbackPage.test.tsx
@@ -92,6 +92,21 @@ describe('AuthCallbackPage', () => {
     );
   });
 
+  it('プロバイダエラー (?error=...) は遷移せずエラーメッセージを表示する', async () => {
+    auth.getSession.mockResolvedValue({ data: { session: null } });
+    renderWithProviders(<AuthCallbackPage />, {
+      route:
+        '/auth/callback?error=server_error&error_description=Error+getting+user+email+from+external+provider',
+    });
+    expect(
+      await screen.findByText(/メールアドレスを取得できなかった/),
+    ).toBeInTheDocument();
+    // 詳細 (元の error_description) も併記して再発調査を容易にする。
+    expect(screen.getByText(/Error getting user email from external provider/)).toBeInTheDocument();
+    // 無言リダイレクトは行わない。
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
   it('sync がエラーなら /login へ遷移する', async () => {
     auth.getSession.mockResolvedValue({ data: { session: makeSession() } });
     server.use(

--- a/apps/web/src/app/AuthCallbackPage.tsx
+++ b/apps/web/src/app/AuthCallbackPage.tsx
@@ -1,9 +1,22 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 
 import { supabase } from '@/lib/supabase';
 import { useCurrentUser } from '@/features/auth/useCurrentUser';
+
+/**
+ * OAuth プロバイダ (Supabase) が email 取得に失敗したときのエラー文言。
+ * Azure (Microsoft) が email クレームを返さないと Supabase が
+ * "Error getting user email from external provider" を返す (設計 §6.6.1)。
+ */
+function friendlyProviderError(errorDescription: string | null): string {
+  const desc = errorDescription ?? '';
+  if (/email/i.test(desc)) {
+    return 'メールアドレスを取得できなかったため、ログインを完了できませんでした。ご利用のアカウントでメールアドレスが公開されているかご確認のうえ、別の方法でログインしてください。';
+  }
+  return 'ログインを完了できませんでした。お手数ですが、もう一度お試しください。';
+}
 
 /**
  * Supabase Auth の Magic-link / OAuth コールバック着地点。
@@ -12,11 +25,18 @@ import { useCurrentUser } from '@/features/auth/useCurrentUser';
  */
 export function AuthCallbackPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { session, sessionLoading, data, isLoading, error } = useCurrentUser();
   // 後方互換: 旧リセットメールは /auth/callback に着地する。PASSWORD_RECOVERY を
   // 検出したら専用のパスワード再設定ページへ振り替える (detectSessionInUrl が
   // hash を消費するため type=recovery は直接読めず、イベントで判定する)。
   const [isRecovery, setIsRecovery] = useState(false);
+
+  // OAuth プロバイダ (Supabase) がコールバックに付けるエラー。email 取得失敗などで
+  // ?error=...&error_description=... が付く。従来は無視して無言で /login に戻していたため
+  // 原因が UI から一切分からなかった。ここで検出して画面に表示する。
+  const providerError = searchParams.get('error');
+  const providerErrorDescription = searchParams.get('error_description');
 
   useEffect(() => {
     const { data: sub } = supabase.auth.onAuthStateChange((event) => {
@@ -26,6 +46,8 @@ export function AuthCallbackPage() {
   }, []);
 
   useEffect(() => {
+    // プロバイダエラー時は遷移せずエラーを表示する (無言リダイレクトの抑止)。
+    if (providerError) return;
     if (isRecovery) {
       navigate('/auth/reset-password', { replace: true });
       return;
@@ -46,7 +68,21 @@ export function AuthCallbackPage() {
     if (data && !data.requiresProfileCompletion) {
       navigate('/dashboard', { replace: true });
     }
-  }, [session, sessionLoading, data, isLoading, error, navigate, isRecovery]);
+  }, [session, sessionLoading, data, isLoading, error, navigate, isRecovery, providerError]);
+
+  if (providerError) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4 text-center">
+        <p className="text-sm text-destructive">{friendlyProviderError(providerErrorDescription)}</p>
+        {providerErrorDescription && (
+          <p className="text-xs text-muted-foreground">詳細: {providerErrorDescription}</p>
+        )}
+        <Link to="/login" replace className="text-sm text-foreground underline underline-offset-2">
+          ログイン画面に戻る
+        </Link>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center gap-2 text-sm text-muted-foreground">

--- a/apps/web/src/features/auth/OAuthButtons.test.tsx
+++ b/apps/web/src/features/auth/OAuthButtons.test.tsx
@@ -30,7 +30,7 @@ describe('OAuthButtons', () => {
     expect(arg.options.redirectTo).toContain('/auth/callback');
   });
 
-  it('Microsoft ボタンで signInWithOAuth(provider=azure) を queryParams なしで呼ぶ', async () => {
+  it('Microsoft ボタンで signInWithOAuth(provider=azure) を email スコープ付き・queryParams なしで呼ぶ', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     renderWithProviders(<OAuthButtons />);
 
@@ -40,6 +40,8 @@ describe('OAuthButtons', () => {
     const arg = signInWithOAuth.mock.calls[0]![0];
     expect(arg.provider).toBe('azure');
     expect(arg.options.queryParams).toBeUndefined();
+    // email クレーム取得のため scope を明示する (Supabase の email 取得失敗を防ぐ)。
+    expect(arg.options.scopes).toContain('email');
   });
 
   it('エラー時はエラーメッセージを表示しボタンを再活性化する', async () => {

--- a/apps/web/src/features/auth/OAuthButtons.tsx
+++ b/apps/web/src/features/auth/OAuthButtons.tsx
@@ -26,6 +26,10 @@ export function OAuthButtons() {
       options: {
         redirectTo: `${window.location.origin}/auth/callback`,
         queryParams: provider === 'google' ? { prompt: 'select_account' } : undefined,
+        // Azure (Microsoft) はスコープを明示しないと email クレームが返らず、Supabase 側が
+        // "Error getting user email from external provider" で認証中断する。設計 §6.6.1 の
+        // Graph 権限 (openid/email/profile/User.Read) と揃えて email を確実に要求する。
+        scopes: provider === 'azure' ? 'openid profile email User.Read' : undefined,
       },
     });
     if (err) {


### PR DESCRIPTION
## 背景

Microsoft (Supabase 上では `azure` provider) でログインすると、MS 側の認証は成功するのにダッシュボードへ遷移せずログイン画面のまま止まる不具合があった。

失敗時のコールバック URL:
```
/auth/callback?error=server_error&error_code=unexpected_failure&error_description=Error+getting+user+email+from+external+provider
```

`Error getting user email from external provider` は **Supabase (GoTrue) が OAuth コールバック処理中に、Microsoft からメールアドレスを取得できず認証を中断している**エラー。アプリのバックエンド (`/auth/me/sync`) に到達する前段で失敗しており、セッションは確立されない。加えて `AuthCallbackPage` が URL の `error` を参照していなかったため、無言で `/login` に戻り「原因不明でログイン画面に止まる」状態になっていた。

## 変更内容

- **`OAuthButtons.tsx`**: azure の `signInWithOAuth` に `scopes: 'openid profile email User.Read'` を明示付与。Supabase のデフォルト任せにせず email クレームを確実に要求する（設計 §6.6.1 の Graph 権限と整合）。
- **`AuthCallbackPage.tsx`**: コールバックの `error` / `error_description` を検出し、無言リダイレクトせずエラーメッセージ（分かりやすい日本語＋技術詳細＋ログインへ戻るリンク）を表示。今後の OAuth 失敗が可視化され再発調査が容易になる。
- テスト更新（`OAuthButtons.test.tsx` / `AuthCallbackPage.test.tsx`）。

> 実際にログインを通す主因は **Azure Entra ID + Supabase の設定**（Graph 権限付与＋管理者同意、Token configuration で optional claim `email` 追加）であり、その設定は本 PR とは別に実施済み。本 PR のコード変更（scopes 明示・エラー可視化）は設定と整合させ、再発を防ぐもの。

## 検証

- `pnpm --filter @trakon/web test OAuthButtons AuthCallbackPage` — 9 件パス
- `pnpm --filter @trakon/web type-check` / `lint`（zero-warnings）通過
- 手動: Azure/Supabase 設定後、実 Microsoft アカウントでログイン → `/dashboard` へ遷移することを確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)