### PR TITLE
fix(plans): 予定の担当者(FROM/TO)を未設定に戻せるようにする (#114)

### DIFF
--- a/apps/web/server/routes/v1/plans.integration.test.ts
+++ b/apps/web/server/routes/v1/plans.integration.test.ts
@@ -56,6 +56,29 @@ describe('plans routes (integration)', () => {
       expect(res.body.data.ballState).toBe('ready');
     });
 
+    it('PATCH で fromMemberId=null を送ると担当者を未設定に戻せる (#114)', async () => {
+      const created = await createPlanViaApi({
+        title: 'Design',
+        category: 'design',
+        scheduledDate: '2026-06-01',
+        fromMemberId: fromId,
+        toMemberId: toId,
+      });
+      const planId = created.body.data.id;
+
+      const res = await api<{
+        data: { fromMember: { id: string } | null; toMember: { id: string } | null };
+      }>(`${base}/${planId}`, {
+        method: 'PATCH',
+        token: ctx.token,
+        body: { fromMemberId: null },
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.data.fromMember).toBeNull();
+      // TO は未指定なので維持される
+      expect(res.body.data.toMember?.id).toBe(toId);
+    });
+
     it('TOSS すると ballState=tossed・最新イベントが tossed になる', async () => {
       const created = await createPlanViaApi({
         title: 'Design',

--- a/apps/web/server/schemas/plans.test.ts
+++ b/apps/web/server/schemas/plans.test.ts
@@ -86,6 +86,14 @@ describe('updatePlanBodySchema', () => {
     expect(updatePlanBodySchema.safeParse({ toMemberId: toId }).success).toBe(true);
   });
 
+  it('accepts fromMemberId / toMemberId = null (clears assignee) (#114)', () => {
+    expect(updatePlanBodySchema.safeParse({ fromMemberId: null }).success).toBe(true);
+    expect(updatePlanBodySchema.safeParse({ toMemberId: null }).success).toBe(true);
+    expect(
+      updatePlanBodySchema.safeParse({ fromMemberId: null, toMemberId: null }).success,
+    ).toBe(true);
+  });
+
   it('accepts successorPlanId set and null (clear)', () => {
     expect(updatePlanBodySchema.safeParse({ successorPlanId: fromId }).success).toBe(true);
     expect(updatePlanBodySchema.safeParse({ successorPlanId: null }).success).toBe(true);

--- a/apps/web/server/schemas/plans.ts
+++ b/apps/web/server/schemas/plans.ts
@@ -45,8 +45,9 @@ export const updatePlanBodySchema = z
     category: planCategorySchema.optional(),
     scheduledDate: isoDate.optional(),
     dueDate: isoDate.nullable().optional(),
-    fromMemberId: uuid.optional(),
-    toMemberId: uuid.optional(),
+    // null を送ると担当者を未設定に戻せる (#114)。undefined は変更なし。
+    fromMemberId: uuid.nullable().optional(),
+    toMemberId: uuid.nullable().optional(),
     // 別制作物への移動 (#52)。同一プロジェクト内の item への付け替え。
     itemId: uuid.optional(),
     successorPlanId: uuid.nullable().optional(),

--- a/apps/web/server/services/plans.ts
+++ b/apps/web/server/services/plans.ts
@@ -415,18 +415,22 @@ export async function updatePlan(input: {
         'FROM/TO cannot be changed after the ball has been tossed.',
       );
     }
-    const nextFrom = input.body.fromMemberId ?? existing.fromMemberId;
-    const nextTo = input.body.toMemberId ?? existing.toMemberId;
-    if (nextFrom === nextTo) {
+    // undefined は変更なし (既存値を維持)、null は未設定へクリア (#114)
+    const nextFrom =
+      input.body.fromMemberId !== undefined ? input.body.fromMemberId : existing.fromMemberId;
+    const nextTo =
+      input.body.toMemberId !== undefined ? input.body.toMemberId : existing.toMemberId;
+    if (nextFrom && nextTo && nextFrom === nextTo) {
       throw new ApiException(
         'INVALID_MEMBER',
         422,
         'fromMemberId and toMemberId must differ.',
       );
     }
+    // 実在検証は非 null の新規指定のみ (クリア=null は検証不要)
     const changedMemberIds: string[] = [];
-    if (input.body.fromMemberId !== undefined) changedMemberIds.push(input.body.fromMemberId);
-    if (input.body.toMemberId !== undefined) changedMemberIds.push(input.body.toMemberId);
+    if (input.body.fromMemberId) changedMemberIds.push(input.body.fromMemberId);
+    if (input.body.toMemberId) changedMemberIds.push(input.body.toMemberId);
     await assertMembersBelongToProject({
       projectId: input.projectId,
       memberIds: changedMemberIds,

--- a/apps/web/src/features/plans/CreatePlanModal.tsx
+++ b/apps/web/src/features/plans/CreatePlanModal.tsx
@@ -156,9 +156,10 @@ export function CreatePlanModal({
         dueDate: v.dueDate || null,
         memo: v.memo ?? null,
         ...(moving ? { itemId: v.itemId } : { successorPlanId: v.successorPlanId || null }),
-        // FROM/TO は TOSS 前のみ送信 (ロック中はサーバ側でも拒否される)
+        // FROM/TO は TOSS 前のみ送信 (ロック中はサーバ側でも拒否される)。
+        // 空選択は null を送って担当者を未設定に戻す (#114)。
         ...(fromToEditable
-          ? { fromMemberId: v.fromMemberId || undefined, toMemberId: v.toMemberId || undefined }
+          ? { fromMemberId: v.fromMemberId || null, toMemberId: v.toMemberId || null }
           : {}),
       });
     },
@@ -249,19 +250,25 @@ export function CreatePlanModal({
               error={form.formState.errors.fromMemberId?.message}
             >
               <SelectField
-                value={form.watch('fromMemberId') || undefined}
-                onChange={(v) => form.setValue('fromMemberId', v)}
+                value={form.watch('fromMemberId') || '__none__'}
+                onChange={(v) => form.setValue('fromMemberId', v === '__none__' ? '' : v)}
                 disabled={!fromToEditable}
-                options={members.map((m) => ({ value: m.id, label: `${m.name} (${m.organizationName || '—'})` }))}
+                options={[
+                  { value: '__none__', label: '未設定' },
+                  ...members.map((m) => ({ value: m.id, label: `${m.name} (${m.organizationName || '—'})` })),
+                ]}
                 placeholder="選択"
               />
             </Field>
             <Field label="確認者(TO)（任意）" error={form.formState.errors.toMemberId?.message}>
               <SelectField
-                value={form.watch('toMemberId') || undefined}
-                onChange={(v) => form.setValue('toMemberId', v)}
+                value={form.watch('toMemberId') || '__none__'}
+                onChange={(v) => form.setValue('toMemberId', v === '__none__' ? '' : v)}
                 disabled={!fromToEditable}
-                options={members.map((m) => ({ value: m.id, label: `${m.name} (${m.organizationName || '—'})` }))}
+                options={[
+                  { value: '__none__', label: '未設定' },
+                  ...members.map((m) => ({ value: m.id, label: `${m.name} (${m.organizationName || '—'})` })),
+                ]}
                 placeholder="選択"
               />
             </Field>

--- a/apps/web/src/features/plans/api.ts
+++ b/apps/web/src/features/plans/api.ts
@@ -85,8 +85,8 @@ export type UpdatePlanInput = Partial<{
   category: PlanCategory;
   scheduledDate: string;
   dueDate: string | null;
-  fromMemberId: string;
-  toMemberId: string;
+  fromMemberId: string | null;
+  toMemberId: string | null;
   // 別制作物へ移動 (#52)
   itemId: string;
   successorPlanId: string | null;


### PR DESCRIPTION
## 概要
一度設定した実施者(FROM)/確認者(TO)を外して「担当者無し」に戻せない不具合 (#114) を修正します。

## 原因
- 更新スキーマ `updatePlanBodySchema` の `fromMemberId`/`toMemberId` が `uuid.optional()` で **null を受け付けず**、クリアを送る手段がなかった。
- `updatePlan` サービスも `nextFrom = body.fromMemberId ?? existing.fromMemberId` としており、**null を送っても既存値へフォールバック**していた。

## 変更点
- **スキーマ**: `fromMemberId`/`toMemberId` を `uuid.nullable().optional()` に（DB 列は元々 nullable）。
- **サービス** (`updatePlan`): `null`(クリア) と `undefined`(変更なし) を区別。FROM≠TO 検証は両方が非 null のときのみ。実在チェックも非 null の新規指定のみ対象。
- **フロント** (`CreatePlanModal`): FROM/TO 選択に「未設定」項目を追加。編集時は空選択を `null` として送信。`UpdatePlanInput` の型を `string | null` に。

## 確認
- `pnpm type-check` / `pnpm lint` / `pnpm test`(595 passed) すべて成功。
- スキーマテストに null 許可ケース、実DB統合テストに「PATCH fromMemberId=null で担当者クリア」を追加。

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)