### PR TITLE
fix(schedule): 単日・短期の予定でも期間をドラッグで伸ばせるようにする (#113)

### DIFF
--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -1038,11 +1038,12 @@ function BallChip({
         width: laneWidth - 12,
       }}
     >
-      {/* リサイズハンドル (上) */}
-      {editable && tier !== 'mini' && (
+      {/* リサイズハンドル (上)。単日/短期の予定 (mini) でも掴んで期間変更できるよう
+          tier に依らず表示する (#113)。 */}
+      {editable && (
         <div
           onPointerDown={(e) => onPointerDownBall(e, 'resize-top')}
-          className="absolute inset-x-0 top-0 h-1.5 cursor-ns-resize"
+          className="absolute inset-x-0 top-0 z-10 h-1.5 cursor-ns-resize"
           aria-hidden
         />
       )}
@@ -1104,11 +1105,12 @@ function BallChip({
         </div>
       )}
 
-      {/* リサイズハンドル (下) */}
-      {editable && tier !== 'mini' && (
+      {/* リサイズハンドル (下)。単日/短期の予定 (mini) でも掴んで期間変更できるよう
+          tier に依らず表示する (#113)。後続紐づけハンドル (z-20) より下に置く。 */}
+      {editable && (
         <div
           onPointerDown={(e) => onPointerDownBall(e, 'resize-bottom')}
-          className="absolute inset-x-0 bottom-0 h-1.5 cursor-ns-resize"
+          className="absolute inset-x-0 bottom-0 z-10 h-1.5 cursor-ns-resize"
           aria-hidden
         />
       )}


### PR DESCRIPTION
## 概要
日付が1日のみ（または短期）の予定を、マウスドラッグで期間延長できない不具合 (#113) を修正します。

## 原因
予定カードのリサイズハンドル（上下端）が `editable && tier !== 'mini'` 条件で描画されていた。`ballTier()` は高さ80px未満を `'mini'` と判定するため、単日予定（既定 rowHeight で約36px）や2日程度の短期予定ではハンドルが一切表示されず、端を掴んで伸ばせなかった。

## 変更点
- リサイズハンドル（上・下）の表示条件を `tier !== 'mini'` 依存から外し、`editable` なら常に表示。
- ハンドルを掴みやすいよう `z-10` を付与（下端中央の後続紐づけハンドル `z-20` より下に配置し、既存のリンク作成操作を維持）。

`commitResize` 側は元々 `end = start`（単日）からの延長に対応済みのため、ハンドル表示のみで期間延長が機能します。

## 確認
- `pnpm type-check` / `pnpm lint` / `pnpm test`(595 passed) 成功。
- `ballTier` のロジックは未変更（他カードの見た目・段組みに影響なし）。

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)