### PR TITLE
fix(schedule): 後続矢印がスケジュールヘッダにかぶらないようにする (#116)

### DIFF
--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -701,7 +701,9 @@ function ScheduleBoard({
               <div
                 data-item-id={item.id}
                 className={cn(
-                  'relative',
+                  // isolate で本体を独立した stacking context にし、内部の後続矢印 (SVG z-20)
+                  // が列ヘッダー (sticky z-20) の上に描画されるのを防ぐ (#116)
+                  'relative isolate',
                   // 別制作物からの D&D 移動ターゲットをハイライト (#52)
                   drag?.mode === 'move' &&
                     drag.targetItemId === item.id &&


### PR DESCRIPTION
## 概要
後続予定を繋ぐ矢印が、スクロール時に sticky な列ヘッダー（制作物名・ボール保持者の行）へはみ出して重なる不具合 (#116) を修正します。

![before](https://github.com/user-attachments/assets/d8b182f8-2f60-45bf-9ebd-be314c5ef377)

## 原因
矢印を描く `LinkLayer` の SVG は `absolute inset-0 z-20`。一方、列ヘッダーは `sticky top-0 z-20`。両者は同じ列内の兄弟だが、本体 div が `relative`（`z-index: auto`）で **stacking context を作らない**ため、SVG(`z-20`) が列の stacking context に浮上し、ヘッダー(`z-20`) と同レベル・DOM 後方となって前面に描画されていた。

## 変更点
- スケジュール本体 div に `isolate`（`isolation: isolate`）を付与。本体を独立した stacking context にすることで、内部の矢印 SVG を本体内へ閉じ込め、`z-20` の positioned 要素であるヘッダーが本体より前面に描画されるようにした。

矢印とチップ／リサイズハンドル間の相対的な重なり順は本体内で保たれるため、既存の見た目・操作性には影響しない。

## 確認
- `pnpm type-check` / `pnpm lint` / `pnpm test`(595 passed) 成功。
- className のみの変更。※ローカルにフルスタック(DB/認証)未起動のため画面での目視確認は未実施だが、stacking context の解析に基づく修正。

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)