### PR TITLE
fix(schedule): 予定シート表示中も横スクロールで全列を見えるようにする (#115)

### DIFF
--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -62,7 +62,12 @@ export function ItemSchedulePage() {
 }
 
 function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
-  const [, setParams] = useSearchParams();
+  const [params, setParams] = useSearchParams();
+  // 予定シート (作成/編集/詳細) が開いている間は、右側パネルに隠れる分だけ
+  // スケジュール右端に余白を確保して全列を横スクロールで見えるようにする (#115)
+  const planSheetOpen = ['create-plan', 'edit-plan', 'ball-detail'].includes(
+    params.get('modal') ?? '',
+  );
   const [rowHeight, setRowHeight] = useState(ROW_HEIGHT_DEFAULT);
   // 表示する制作物: 'all' か特定 itemId。初期は全制作物 (#49)。
   // 単一に絞る場合は画面内セレクタで選択する。
@@ -325,6 +330,7 @@ function Inner({ projectId, itemId }: { projectId: string; itemId: string }) {
           onLink={commitLink}
           onCopy={(plan) => copyMut.mutate(plan)}
           copyingPlanId={copyMut.isPending ? copyMut.variables?.id ?? null : null}
+          sheetOpen={planSheetOpen}
         />
       )}
 
@@ -437,6 +443,7 @@ function ScheduleBoard({
   onLink,
   onCopy,
   copyingPlanId,
+  sheetOpen,
 }: {
   days: Date[];
   items: ProjectItem[];
@@ -450,6 +457,7 @@ function ScheduleBoard({
   onLink: (source: Plan, target: Plan) => void;
   onCopy: (plan: Plan) => void;
   copyingPlanId: string | null;
+  sheetOpen: boolean;
 }) {
   const today = new Date();
   const [drag, setDrag] = useState<DragState | null>(null);
@@ -604,7 +612,7 @@ function ScheduleBoard({
   return (
     <>
     <div className="flex-1 overflow-auto">
-      <div className="flex w-max select-none">
+      <div className={cn('flex w-max select-none', sheetOpen && 'pr-[440px]')}>
         {/* 日付軸 (sticky left) */}
         <div
           className="sticky left-0 z-30 shrink-0 border-r border-border bg-background"


### PR DESCRIPTION
## 概要
予定モーダル（右側パネル）が表示されるとスケジュールが隠れて見えず、横スクロールしても隠れた列を可視領域に出せない問題 (#115) を修正します。

## 原因
予定シート（作成/編集/詳細）は `fixed right-0 w-full max-w-[420px]` の右側パネル。スケジュールのスクロール領域は全幅のままなので、最右端の列がパネル下に入り、最大までスクロールしてもパネルの外へ出せなかった。

## 変更点
- 予定シートが開いているか（URL の `?modal=create-plan|edit-plan|ball-detail`）を判定。
- 開いている間だけ、スケジュール内容（`flex w-max`）の右端にパネル幅分の余白（`pr-[440px]`）を確保。横スクロールで全列を可視領域（パネル左）へ出せるようにした。

シートは `modal={false}` で背面操作が可能なため、余白確保のみで解決する。閉じている間は余白なしで従来どおり。

## 確認
- `pnpm type-check` / `pnpm lint` / `pnpm test`(595 passed) 成功。

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)