### PR TITLE
feat(legal): 会社概要ページ追加＋公開ページ共通ヘッダー/フッター (#118, #112)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,7 @@ import { RequireAuth } from './features/auth/RequireAuth';
 import { SC01LoginPage } from './features/auth/SC01LoginPage';
 import { InvitationAcceptPage } from './features/invitations/InvitationAcceptPage';
 import { CommercePage } from './features/legal/CommercePage';
+import { CompanyPage } from './features/legal/CompanyPage';
 import { PrivacyPage } from './features/legal/PrivacyPage';
 import { TermsPage } from './features/legal/TermsPage';
 import { ItemSchedulePage } from './features/plans/ItemSchedulePage';
@@ -29,7 +30,8 @@ export function App() {
       <Route path="/invitations/:token" element={<InvitationAcceptPage />} />
       <Route path="/share/:token" element={<SharePage />} />
 
-      {/* 未ログインでも閲覧可能な法務ページ */}
+      {/* 未ログインでも閲覧可能な会社情報・法務ページ */}
+      <Route path="/company" element={<CompanyPage />} />
       <Route path="/terms" element={<TermsPage />} />
       <Route path="/privacy" element={<PrivacyPage />} />
       <Route path="/commerce" element={<CommercePage />} />

--- a/apps/web/src/app/SidebarLayout.tsx
+++ b/apps/web/src/app/SidebarLayout.tsx
@@ -11,6 +11,7 @@ import { supabase } from '@/lib/supabase';
 import { useCurrentUser } from '@/features/auth/useCurrentUser';
 import { ProfileModal } from '@/features/auth/ProfileModal';
 import { projectsApi, projectsQueryKey } from '@/features/projects/api';
+import { LEGAL_NAV } from '@/features/legal/companyInfo';
 
 const DOT_PALETTE = [
   'bg-violet-500',
@@ -108,6 +109,23 @@ export function SidebarLayout() {
             全て →
           </NavLink>
         </div>
+
+        {/* 会社情報・法務ページへの導線 (公開ページ)。別タブで開きアプリ操作を妨げない。 */}
+        <nav className="shrink-0 border-t border-border px-4 py-2">
+          <div className="flex flex-wrap gap-x-3 gap-y-1">
+            {LEGAL_NAV.map((item) => (
+              <a
+                key={item.to}
+                href={item.to}
+                target="_blank"
+                rel="noreferrer"
+                className="text-[11px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+              >
+                {item.label}
+              </a>
+            ))}
+          </div>
+        </nav>
 
         {/* ユーザー情報フッター: 全ページ共通で常時表示 (読込中は Skeleton) */}
         <div className="shrink-0 border-t border-border">

--- a/apps/web/src/features/legal/CommercePage.tsx
+++ b/apps/web/src/features/legal/CommercePage.tsx
@@ -1,4 +1,5 @@
 import { LegalDefList, LegalPageLayout } from './LegalPageLayout';
+import { COMPANY, COMPANY_ADDRESS_FULL } from './companyInfo';
 
 // 特定商取引法に基づく表記 — 出典 https://trakon-test.vercel.app/commerce.html の本文をそのまま掲載。
 export function CommercePage() {
@@ -6,9 +7,9 @@ export function CommercePage() {
     <LegalPageLayout title="特定商取引法に基づく表記">
       <LegalDefList
         rows={[
-          { label: '販売事業者', value: '株式会社おさまるカンパニー' },
-          { label: '運営責任者', value: '宮丸 長（Osa MIYAMARU）' },
-          { label: '所在地', value: '埼玉県児玉郡神川町原新田21-20' },
+          { label: '販売事業者', value: COMPANY.name },
+          { label: '運営責任者', value: COMPANY.representative },
+          { label: '所在地', value: COMPANY_ADDRESS_FULL },
           {
             label: 'お問い合わせ先',
             value: (
@@ -26,7 +27,7 @@ export function CommercePage() {
               </>
             ),
           },
-          { label: '電話番号', value: '請求があった場合、遅滞なく開示いたします。' },
+          { label: '電話番号', value: COMPANY.phone },
           {
             label: '販売価格',
             value: '各プランごとに、申込ページまたは料金ページに表示する金額とします。',

--- a/apps/web/src/features/legal/CompanyPage.tsx
+++ b/apps/web/src/features/legal/CompanyPage.tsx
@@ -1,0 +1,31 @@
+import { LegalDefList, LegalPageLayout } from './LegalPageLayout';
+import { COMPANY, COMPANY_ADDRESS_FULL } from './companyInfo';
+
+// 会社概要 — 出典 https://trakon-test.vercel.app/company。
+// 所在地・電話番号は #112 で指定されたものを掲載する。
+export function CompanyPage() {
+  return (
+    <LegalPageLayout title="会社概要">
+      <LegalDefList
+        rows={[
+          { label: '会社名', value: COMPANY.name },
+          { label: '代表取締役', value: COMPANY.representative },
+          { label: '所在地', value: COMPANY_ADDRESS_FULL },
+          { label: '電話番号', value: COMPANY.phone },
+          {
+            label: '事業内容',
+            value: (
+              <>
+                {COMPANY.business.map((b) => (
+                  <span key={b} className="block">
+                    {b}
+                  </span>
+                ))}
+              </>
+            ),
+          },
+        ]}
+      />
+    </LegalPageLayout>
+  );
+}

--- a/apps/web/src/features/legal/LegalPageLayout.tsx
+++ b/apps/web/src/features/legal/LegalPageLayout.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import type { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
+
+import { LEGAL_NAV } from './companyInfo';
 
 // =============================================================================
 // 法務ページ (利用規約 / プライバシーポリシー / 特定商取引法に基づく表記) 共通レイアウト。
@@ -28,13 +30,28 @@ export function LegalPageLayout({
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-10 border-b border-border bg-card/80 backdrop-blur">
-        <div className="mx-auto flex h-14 max-w-3xl items-center justify-between px-6">
+        <div className="mx-auto flex max-w-3xl flex-wrap items-center gap-x-5 gap-y-2 px-6 py-3">
           <Link to="/login" className="text-lg font-extrabold tracking-[0.2em]">
             TRAKON
           </Link>
+          <nav className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+            {LEGAL_NAV.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  isActive
+                    ? 'font-medium text-foreground'
+                    : 'text-muted-foreground underline-offset-4 hover:text-foreground hover:underline'
+                }
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
           <Link
             to="/login"
-            className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+            className="ml-auto text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
           >
             <span aria-hidden>←</span> ログインに戻る
           </Link>
@@ -55,15 +72,15 @@ function LegalFooter() {
   return (
     <footer className="mt-12 border-t border-border pt-6">
       <nav className="flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground">
-        <Link to="/terms" className="underline-offset-4 hover:text-foreground hover:underline">
-          利用規約
-        </Link>
-        <Link to="/privacy" className="underline-offset-4 hover:text-foreground hover:underline">
-          プライバシーポリシー
-        </Link>
-        <Link to="/commerce" className="underline-offset-4 hover:text-foreground hover:underline">
-          特定商取引法に基づく表記
-        </Link>
+        {LEGAL_NAV.map((item) => (
+          <Link
+            key={item.to}
+            to={item.to}
+            className="underline-offset-4 hover:text-foreground hover:underline"
+          >
+            {item.label}
+          </Link>
+        ))}
       </nav>
       <p className="mt-4 text-xs text-muted-foreground">© 2026 株式会社おさまるカンパニー</p>
     </footer>

--- a/apps/web/src/features/legal/LegalPages.test.tsx
+++ b/apps/web/src/features/legal/LegalPages.test.tsx
@@ -1,13 +1,39 @@
 import { describe, expect, it } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 
 import { renderWithProviders } from '@/test/render';
 import { TermsPage } from './TermsPage';
 import { PrivacyPage } from './PrivacyPage';
 import { CommercePage } from './CommercePage';
+import { CompanyPage } from './CompanyPage';
+import { COMPANY, COMPANY_ADDRESS_FULL } from './companyInfo';
 
-describe('法務ページ', () => {
-  it('利用規約: 見出し・条項・附則・相互リンクを描画する', () => {
+describe('法務・会社情報ページ', () => {
+  it('会社概要: 見出しと会社情報 (#112 の住所・電話) を描画する', () => {
+    renderWithProviders(<CompanyPage />, { route: '/company' });
+
+    expect(screen.getByRole('heading', { level: 1, name: '会社概要' })).toBeInTheDocument();
+    expect(screen.getByText(COMPANY.name)).toBeInTheDocument();
+    expect(screen.getByText(COMPANY.representative)).toBeInTheDocument();
+    expect(screen.getByText(COMPANY_ADDRESS_FULL)).toBeInTheDocument();
+    expect(screen.getByText(COMPANY.phone)).toBeInTheDocument();
+  });
+
+  it('共通ヘッダー: 会社概要を含む4ページへの相互リンクを描画する', () => {
+    renderWithProviders(<TermsPage />, { route: '/terms' });
+
+    const header = screen.getByRole('banner');
+    for (const [name, href] of [
+      ['会社概要', '/company'],
+      ['利用規約', '/terms'],
+      ['プライバシーポリシー', '/privacy'],
+      ['特定商取引法に基づく表記', '/commerce'],
+    ] as const) {
+      expect(within(header).getByRole('link', { name })).toHaveAttribute('href', href);
+    }
+  });
+
+  it('利用規約: 見出し・条項・附則を描画する', () => {
     renderWithProviders(<TermsPage />, { route: '/terms' });
 
     expect(screen.getByRole('heading', { level: 1, name: '利用規約' })).toBeInTheDocument();
@@ -18,11 +44,10 @@ describe('法務ページ', () => {
     ).toBeInTheDocument();
     // 箇条書き (LegalList) の項目が描画されている
     expect(screen.getByText(/リバースエンジニアリング/)).toBeInTheDocument();
-    // フッターの相互リンク
-    expect(screen.getByRole('link', { name: 'プライバシーポリシー' })).toHaveAttribute(
-      'href',
-      '/privacy',
-    );
+    // フッターの相互リンク (ヘッダーにも同名リンクがあるため getAllByRole で確認)
+    expect(
+      screen.getAllByRole('link', { name: 'プライバシーポリシー' })[0],
+    ).toHaveAttribute('href', '/privacy');
     expect(screen.getByText(/© 2026 株式会社おさまるカンパニー/)).toBeInTheDocument();
   });
 
@@ -38,12 +63,8 @@ describe('法務ページ', () => {
     expect(
       screen.getByRole('heading', { level: 2, name: '第14条（お問い合わせ窓口）' }),
     ).toBeInTheDocument();
-    // 定義リスト (LegalDefList) の問い合わせ窓口の住所が描画されている
-    expect(screen.getByText('埼玉県児玉郡神川町原新田21-20')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: '特定商取引法に基づく表記' })).toHaveAttribute(
-      'href',
-      '/commerce',
-    );
+    // 定義リスト (LegalDefList) の問い合わせ窓口の住所は #112 の新住所に統一されている
+    expect(screen.getByText(COMPANY_ADDRESS_FULL)).toBeInTheDocument();
   });
 
   it('特定商取引法: 販売事業者と問い合わせメールを描画する', () => {

--- a/apps/web/src/features/legal/PrivacyPage.tsx
+++ b/apps/web/src/features/legal/PrivacyPage.tsx
@@ -5,6 +5,7 @@ import {
   LegalP,
   LegalPageLayout,
 } from './LegalPageLayout';
+import { COMPANY, COMPANY_ADDRESS_FULL } from './companyInfo';
 
 // プライバシーポリシー — 出典 https://trakon-test.vercel.app/privacy.html の本文をそのまま掲載。
 export function PrivacyPage() {
@@ -183,8 +184,8 @@ export function PrivacyPage() {
         </LegalP>
         <LegalDefList
           rows={[
-            { label: '会社名', value: '株式会社おさまるカンパニー' },
-            { label: '住所', value: '埼玉県児玉郡神川町原新田21-20' },
+            { label: '会社名', value: COMPANY.name },
+            { label: '住所', value: COMPANY_ADDRESS_FULL },
             { label: 'お問い合わせ', value: 'お問い合わせフォームよりご連絡ください。' },
           ]}
         />

--- a/apps/web/src/features/legal/companyInfo.ts
+++ b/apps/web/src/features/legal/companyInfo.ts
@@ -1,0 +1,29 @@
+// =============================================================================
+// 会社情報の共有定数。会社概要 / 特定商取引法 / プライバシーポリシー間で表記を統一する。
+// 住所・電話番号は #112 で指定されたものを正とする。
+// =============================================================================
+
+export const COMPANY = {
+  name: '株式会社おさまるカンパニー',
+  representative: '宮丸 長（Osa MIYAMARU）',
+  postalCode: '〒330-9501',
+  address: '埼玉県さいたま市大宮区桜木町2丁目3番地 大宮マルイ7階',
+  phone: '03-6110-0597',
+  contactEmail: 'trakon_contact@osamaru.com',
+  business: [
+    'プロジェクト進行支援サービスの企画・開発・運営',
+    'Web に関する企画・制作・運用支援',
+  ],
+} as const;
+
+/** 郵便番号付きの完全な所在地表記。 */
+export const COMPANY_ADDRESS_FULL = `${COMPANY.postalCode} ${COMPANY.address}`;
+
+// 公開ページ (会社概要 / 利用規約 / プライバシーポリシー / 特定商取引法に基づく表記)。
+// 公開ページ間の共通ヘッダー・フッター、およびアプリ内サイドバーの導線で共有する。
+export const LEGAL_NAV: { to: string; label: string }[] = [
+  { to: '/company', label: '会社概要' },
+  { to: '/terms', label: '利用規約' },
+  { to: '/privacy', label: 'プライバシーポリシー' },
+  { to: '/commerce', label: '特定商取引法に基づく表記' },
+];


### PR DESCRIPTION
## 概要
会社概要ページを追加し、公開ページ（会社概要・利用規約・プライバシーポリシー・特定商取引法に基づく表記）を相互に行き来できる共通ヘッダー/フッターを設けます (#118)。あわせて住所を #112 の新住所に統一します (#112)。

## 変更点
### 会社概要ページ (`/company`)
- 出典 https://trakon-test.vercel.app/company の内容をもとに新規作成。所在地・電話番号は #112 で指定されたものを掲載：
  - 所在地: 〒330-9501 埼玉県さいたま市大宮区桜木町2丁目3番地 大宮マルイ7階
  - 電話番号: 03-6110-0597
- 未ログインでも閲覧可能な公開ルートとして登録。

### 共通ヘッダー/フッター（公開ページ）
- `LegalPageLayout` のヘッダーに4ページへの相互ナビリンクを追加。フッターにも会社概要を追加。4ページとも同レイアウトを使うため一括で反映。

### アプリ内導線
- 認証済みアプリのサイドバー下部に4ページへのリンクを追加（別タブで開き、アプリ操作を妨げない）。※ユーザー確認のうえ「共通ヘッダー/フッター」ではなくサイドバー導線とした。

### 住所の統一 (#112)
- 会社情報を `companyInfo.ts` に集約。特定商取引法ページ・プライバシーポリシーの住所を旧住所（埼玉県児玉郡神川町原新田21-20）から #112 の新住所に統一。特商法の電話番号も実番号を記載。

## 確認
- `pnpm type-check` / `pnpm lint` / `pnpm test`(597 passed) 成功。
- 会社概要ページの描画・共通ヘッダーの4リンク・住所統一をテストで検証。

Closes #118
Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)