### PR TITLE
feat(projects): 制作物と参加者をD&Dで並び替え可能にする (#111)

### DIFF
--- a/apps/web/server/routes/v1/items.integration.test.ts
+++ b/apps/web/server/routes/v1/items.integration.test.ts
@@ -75,6 +75,38 @@ describe('items routes (integration)', () => {
       expect(res.body.data.name).toBe('new');
     });
 
+    it('POST /items/reorder はディレクターが並び替えでき、新しい順序を返す (#111)', async () => {
+      const a = await createItem({ projectId: ctx.project.id, name: 'A', sortOrder: 0 });
+      const b = await createItem({ projectId: ctx.project.id, name: 'B', sortOrder: 1 });
+      const c = await createItem({ projectId: ctx.project.id, name: 'C', sortOrder: 2 });
+
+      const res = await api<{ data: ItemDTO[] }>(`${base}/reorder`, {
+        method: 'POST',
+        token: ctx.token,
+        body: { orderedIds: [c.id, a.id, b.id] },
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((i) => i.id)).toEqual([c.id, a.id, b.id]);
+      expect(res.body.data.map((i) => i.sortOrder)).toEqual([0, 1, 2]);
+
+      // 永続化を GET で確認 (/reorder が /:itemId より優先されている確認も兼ねる)
+      const after = await api<{ data: ItemDTO[] }>(base, { token: ctx.token });
+      expect(after.body.data.map((i) => i.name)).toEqual(['C', 'A', 'B']);
+    });
+
+    it('POST /items/reorder は id が過不足あると 422 INVALID_REORDER', async () => {
+      const a = await createItem({ projectId: ctx.project.id, name: 'A', sortOrder: 0 });
+      await createItem({ projectId: ctx.project.id, name: 'B', sortOrder: 1 });
+
+      const res = await api<{ error: { code: string } }>(`${base}/reorder`, {
+        method: 'POST',
+        token: ctx.token,
+        body: { orderedIds: [a.id] }, // B が欠けている
+      });
+      expect(res.status).toBe(422);
+      expect(res.body.error.code).toBe('INVALID_REORDER');
+    });
+
     it('DELETE /items/:itemId は 2 件以上ある場合にディレクターが削除でき 204 を返す', async () => {
       const a = await createItem({ projectId: ctx.project.id, name: 'A', sortOrder: 0 });
       await createItem({ projectId: ctx.project.id, name: 'B', sortOrder: 1 });

--- a/apps/web/server/routes/v1/members.integration.test.ts
+++ b/apps/web/server/routes/v1/members.integration.test.ts
@@ -86,6 +86,40 @@ describe('members routes (integration)', () => {
       expect(res.body.data[0]!.email).toBeNull();
     });
 
+    it('POST /members/reorder はディレクターが並び替えでき、新しい順序を返す (#111)', async () => {
+      const { token, project, member } = await setupProjectWithDirector();
+      const b = await createMember({ projectId: project.id, userId: null, memberType: 'client' });
+      const c = await createMember({ projectId: project.id, userId: null, memberType: 'client' });
+
+      const res = await api<{ data: Array<{ id: string; sortOrder: number }> }>(
+        `/api/v1/projects/${project.id}/members/reorder`,
+        {
+          method: 'POST',
+          token,
+          body: { orderedIds: [c.id, member.id, b.id] },
+        },
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((m) => m.id)).toEqual([c.id, member.id, b.id]);
+      expect(res.body.data.map((m) => m.sortOrder)).toEqual([0, 1, 2]);
+    });
+
+    it('POST /members/reorder は id が過不足あると 422 INVALID_REORDER', async () => {
+      const { token, project, member } = await setupProjectWithDirector();
+      await createMember({ projectId: project.id, userId: null, memberType: 'client' });
+
+      const res = await api<{ error: { code: string } }>(
+        `/api/v1/projects/${project.id}/members/reorder`,
+        {
+          method: 'POST',
+          token,
+          body: { orderedIds: [member.id] }, // 追加メンバーが欠けている
+        },
+      );
+      expect(res.status).toBe(422);
+      expect(res.body.error.code).toBe('INVALID_REORDER');
+    });
+
     it('PATCH /members/:memberId はディレクターがメンバーを更新できる', async () => {
       const { token, project } = await setupProjectWithDirector();
       const target = await createMember({

--- a/apps/web/server/routes/v1/members.ts
+++ b/apps/web/server/routes/v1/members.ts
@@ -7,12 +7,14 @@ import {
 import { ApiException } from '../../lib/errors.js';
 import {
   addMembersBodySchema,
+  reorderMembersBodySchema,
   updateMemberBodySchema,
 } from '../../schemas/members.js';
 import {
   addMembers,
   deleteMember,
   listMembers,
+  reorderMembers,
   updateMember,
 } from '../../services/members.js';
 
@@ -33,6 +35,17 @@ export const membersRoute = new Hono()
     const body = addMembersBodySchema.parse(await c.req.json());
     const created = await addMembers({ projectId: project.projectId, body });
     return c.json({ data: created }, 201);
+  })
+
+  // 並び替え (#111)。静的セグメント /reorder は :memberId より優先される。
+  .post('/reorder', requireProjectMember(), requireProjectDirector(), async (c) => {
+    const project = c.get('project');
+    const body = reorderMembersBodySchema.parse(await c.req.json());
+    const members = await reorderMembers({
+      projectId: project.projectId,
+      orderedIds: body.orderedIds,
+    });
+    return c.json({ data: members });
   })
 
   .patch(

--- a/apps/web/server/routes/v1/projects.ts
+++ b/apps/web/server/routes/v1/projects.ts
@@ -10,6 +10,7 @@ import {
   createItemBodySchema,
   createProjectBodySchema,
   listProjectsQuerySchema,
+  reorderItemsBodySchema,
   updateItemBodySchema,
   updateProjectBodySchema,
 } from '../../schemas/projects.js';
@@ -26,6 +27,7 @@ import {
   deleteItem,
   getItem,
   listItems,
+  reorderItems,
   updateItem,
 } from '../../services/items.js';
 import { listProjectPlans } from '../../services/plans.js';
@@ -125,6 +127,22 @@ export const projectsRoute = new Hono()
       const body = createItemBodySchema.parse(await c.req.json());
       const item = await createItem({ projectId: project.projectId, body });
       return c.json({ data: item }, 201);
+    },
+  )
+
+  // 並び替え (#111)。静的セグメント /reorder は :itemId より優先されるよう先に定義する。
+  .post(
+    '/:projectId/items/reorder',
+    requireProjectMember(),
+    requireProjectDirector(),
+    async (c) => {
+      const project = c.get('project');
+      const body = reorderItemsBodySchema.parse(await c.req.json());
+      const items = await reorderItems({
+        projectId: project.projectId,
+        orderedIds: body.orderedIds,
+      });
+      return c.json({ data: items });
     },
   )
 

--- a/apps/web/server/schemas/members.ts
+++ b/apps/web/server/schemas/members.ts
@@ -26,3 +26,9 @@ export const updateMemberBodySchema = z.object({
   sortOrder: z.number().int().min(0).max(10_000).optional(),
 });
 export type UpdateMemberBody = z.infer<typeof updateMemberBodySchema>;
+
+/** 参加者の一括並び替え (#111)。並び順どおりの id 配列。 */
+export const reorderMembersBodySchema = z.object({
+  orderedIds: z.array(z.string().uuid()).min(1).max(200),
+});
+export type ReorderMembersBody = z.infer<typeof reorderMembersBodySchema>;

--- a/apps/web/server/schemas/projects.ts
+++ b/apps/web/server/schemas/projects.ts
@@ -95,3 +95,9 @@ export const updateItemBodySchema = z.object({
   sortOrder: z.number().int().min(0).max(10_000).optional(),
 });
 export type UpdateItemBody = z.infer<typeof updateItemBodySchema>;
+
+/** 制作物の一括並び替え (#111)。並び順どおりの id 配列。 */
+export const reorderItemsBodySchema = z.object({
+  orderedIds: z.array(z.string().uuid()).min(1).max(200),
+});
+export type ReorderItemsBody = z.infer<typeof reorderItemsBodySchema>;

--- a/apps/web/server/services/items.ts
+++ b/apps/web/server/services/items.ts
@@ -125,6 +125,45 @@ export async function deleteItem(input: { itemId: string; projectId: string }): 
   await prisma.projectItem.delete({ where: { id: input.itemId } });
 }
 
+/**
+ * 制作物の並び替え (#111)。orderedIds は現存する制作物 (アクティブ) と過不足なく
+ * 一致している必要がある。並び順に sortOrder = 0..n-1 を振り直す。
+ */
+export async function reorderItems(input: {
+  projectId: string;
+  orderedIds: string[];
+}): Promise<ProjectItemDTO[]> {
+  const existing = await prisma.projectItem.findMany({
+    where: { projectId: input.projectId, deletedAt: null },
+    select: { id: true },
+  });
+  assertExactIdSet(input.orderedIds, existing.map((i) => i.id));
+
+  await prisma.$transaction(
+    input.orderedIds.map((id, idx) =>
+      prisma.projectItem.update({ where: { id }, data: { sortOrder: idx } }),
+    ),
+  );
+  return listItems(input.projectId);
+}
+
+/** orderedIds が対象集合と「重複なく・過不足なく」一致することを検証する。 */
+export function assertExactIdSet(orderedIds: string[], currentIds: string[]): void {
+  const current = new Set(currentIds);
+  const unique = new Set(orderedIds);
+  if (
+    unique.size !== orderedIds.length ||
+    orderedIds.length !== current.size ||
+    orderedIds.some((id) => !current.has(id))
+  ) {
+    throw new ApiException(
+      'INVALID_REORDER',
+      422,
+      'orderedIds must match the current items exactly (no missing, extra, or duplicate ids).',
+    );
+  }
+}
+
 async function nextSortOrder(projectId: string): Promise<number> {
   const last = await prisma.projectItem.findFirst({
     where: { projectId, deletedAt: null },

--- a/apps/web/server/services/members.ts
+++ b/apps/web/server/services/members.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@trakon/db';
 
 import { ApiException } from '../lib/errors.js';
+import { assertExactIdSet } from './items.js';
 import type { AddMembersBody, UpdateMemberBody } from '../schemas/members.js';
 
 export type MemberDTO = {
@@ -103,6 +104,28 @@ export async function addMembers(input: {
     return result;
   });
   return created;
+}
+
+/**
+ * 参加者の並び替え (#111)。orderedIds は現存する参加者と過不足なく一致している
+ * 必要がある。並び順に sortOrder = 0..n-1 を振り直す。
+ */
+export async function reorderMembers(input: {
+  projectId: string;
+  orderedIds: string[];
+}): Promise<MemberDTO[]> {
+  const existing = await prisma.projectMember.findMany({
+    where: { projectId: input.projectId, deletedAt: null },
+    select: { id: true },
+  });
+  assertExactIdSet(input.orderedIds, existing.map((m) => m.id));
+
+  await prisma.$transaction(
+    input.orderedIds.map((id, idx) =>
+      prisma.projectMember.update({ where: { id }, data: { sortOrder: idx } }),
+    ),
+  );
+  return listMembers(input.projectId);
 }
 
 export async function updateMember(input: {

--- a/apps/web/src/features/projects/MembersPage.tsx
+++ b/apps/web/src/features/projects/MembersPage.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Loader2, Plus, Trash2, UsersRound, ArrowLeft, KanbanSquare } from 'lucide-react';
+import { Loader2, Plus, Trash2, UsersRound, ArrowLeft, KanbanSquare, GripVertical } from 'lucide-react';
 import { MemberKanbanTab } from '@/features/plans/MemberKanbanTab';
 import { toast } from 'sonner';
 
@@ -48,6 +48,8 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { ApiClientError } from '@/lib/api';
+import { cn } from '@/components/ui/utils';
+import { moveItem, useDragReorder } from '@/lib/reorder';
 import { PageContainer } from '@/components/layout/PageContainer';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { membersApi, membersQueryKey, type ProjectMember } from './membersApi';
@@ -147,6 +149,33 @@ function ManageTab({ projectId }: { projectId: string }) {
       toast.error(e instanceof ApiClientError ? e.message : '削除に失敗しました'),
   });
 
+  // 並び替え (#111)。楽観更新でリストを即時入れ替え、失敗時はロールバック。
+  const members = query.data ?? [];
+  const reorderMut = useMutation({
+    mutationFn: (orderedIds: string[]) => membersApi.reorder(projectId, orderedIds),
+    onMutate: async (orderedIds) => {
+      await qc.cancelQueries({ queryKey: membersQueryKey.list(projectId) });
+      const prev = qc.getQueryData<ProjectMember[]>(membersQueryKey.list(projectId));
+      if (prev) {
+        const byId = new Map(prev.map((m) => [m.id, m]));
+        const next = orderedIds
+          .map((id) => byId.get(id))
+          .filter((m): m is ProjectMember => !!m);
+        qc.setQueryData(membersQueryKey.list(projectId), next);
+      }
+      return { prev };
+    },
+    onError: (e, _vars, ctx) => {
+      if (ctx?.prev) qc.setQueryData(membersQueryKey.list(projectId), ctx.prev);
+      toast.error(e instanceof ApiClientError ? e.message : '並び替えに失敗しました');
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: membersQueryKey.list(projectId) }),
+  });
+
+  const drag = useDragReorder((from, to) => {
+    reorderMut.mutate(moveItem(members, from, to).map((m) => m.id));
+  });
+
   return (
     <Card>
       <CardHeader>
@@ -167,6 +196,7 @@ function ManageTab({ projectId }: { projectId: string }) {
           <Table>
             <TableHeader>
               <TableRow>
+                <TableHead className="w-8" />
                 <TableHead>氏名</TableHead>
                 <TableHead>所属</TableHead>
                 <TableHead>メール</TableHead>
@@ -175,9 +205,26 @@ function ManageTab({ projectId }: { projectId: string }) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {query.data.map((m) => {
+              {members.map((m, idx) => {
                 return (
-                  <TableRow key={m.id}>
+                  <TableRow
+                    key={m.id}
+                    {...drag.rowProps(idx)}
+                    className={cn(
+                      drag.fromIndex === idx && 'opacity-50',
+                      drag.overIndex === idx && drag.fromIndex !== idx && 'border-t-2 border-t-primary',
+                    )}
+                  >
+                    <TableCell className="pr-0">
+                      <span
+                        {...drag.handleProps(idx)}
+                        className="inline-flex cursor-grab text-muted-foreground hover:text-foreground active:cursor-grabbing"
+                        aria-label="ドラッグして並び替え"
+                        title="ドラッグして並び替え"
+                      >
+                        <GripVertical className="size-4" />
+                      </span>
+                    </TableCell>
                     <TableCell className="font-medium">{m.name}</TableCell>
                     <TableCell className="text-muted-foreground">
                       {m.organizationName || '—'}

--- a/apps/web/src/features/projects/ProjectEditPage.tsx
+++ b/apps/web/src/features/projects/ProjectEditPage.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Loader2, Pencil, Plus, Trash2, Users, ArrowLeft, AlertCircle, CalendarDays, Link2, Archive, ArchiveRestore } from 'lucide-react';
+import { Loader2, Pencil, Plus, Trash2, Users, ArrowLeft, AlertCircle, CalendarDays, Link2, Archive, ArchiveRestore, GripVertical } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -26,6 +26,8 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { ApiClientError } from '@/lib/api';
+import { cn } from '@/components/ui/utils';
+import { moveItem, useDragReorder } from '@/lib/reorder';
 import { projectsApi, projectsQueryKey, type ProjectItem } from './api';
 
 const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD 形式で入力してください');
@@ -334,6 +336,30 @@ function ItemsSection({
       toast.error(e instanceof ApiClientError ? e.message : '削除に失敗しました'),
   });
 
+  // 並び替え (#111)。楽観更新でリストを即時入れ替え、失敗時はロールバック。
+  const reorderMut = useMutation({
+    mutationFn: (orderedIds: string[]) => projectsApi.reorderItems(projectId, orderedIds),
+    onMutate: async (orderedIds) => {
+      await qc.cancelQueries({ queryKey: projectsQueryKey.items(projectId) });
+      const prev = qc.getQueryData<ProjectItem[]>(projectsQueryKey.items(projectId));
+      if (prev) {
+        const byId = new Map(prev.map((i) => [i.id, i]));
+        const next = orderedIds.map((id) => byId.get(id)).filter((i): i is ProjectItem => !!i);
+        qc.setQueryData(projectsQueryKey.items(projectId), next);
+      }
+      return { prev };
+    },
+    onError: (e, _vars, ctx) => {
+      if (ctx?.prev) qc.setQueryData(projectsQueryKey.items(projectId), ctx.prev);
+      toast.error(e instanceof ApiClientError ? e.message : '並び替えに失敗しました');
+    },
+    onSettled: () => invalidate(),
+  });
+
+  const drag = useDragReorder((from, to) => {
+    reorderMut.mutate(moveItem(items, from, to).map((i) => i.id));
+  });
+
   return (
     <Card>
       <CardHeader>
@@ -356,9 +382,27 @@ function ItemsSection({
           <p className="text-sm text-muted-foreground">まだ制作物がありません。</p>
         )}
         <ul className="divide-y divide-border">
-          {items.map((it) => (
-            <li key={it.id} className="flex items-center justify-between gap-2 py-2">
-              <div className="text-sm">{it.name}</div>
+          {items.map((it, idx) => (
+            <li
+              key={it.id}
+              {...drag.rowProps(idx)}
+              className={cn(
+                'flex items-center justify-between gap-2 py-2',
+                drag.fromIndex === idx && 'opacity-50',
+                drag.overIndex === idx && drag.fromIndex !== idx && 'border-t-2 border-t-primary',
+              )}
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <span
+                  {...drag.handleProps(idx)}
+                  className="cursor-grab text-muted-foreground hover:text-foreground active:cursor-grabbing"
+                  aria-label="ドラッグして並び替え"
+                  title="ドラッグして並び替え"
+                >
+                  <GripVertical className="size-4" />
+                </span>
+                <div className="truncate text-sm">{it.name}</div>
+              </div>
               <div className="flex gap-1">
                 <Button variant="ghost" size="sm" asChild>
                   <Link to={`/projects/${projectId}/items/${it.id}`}>

--- a/apps/web/src/features/projects/api.ts
+++ b/apps/web/src/features/projects/api.ts
@@ -80,6 +80,11 @@ export const projectsApi = {
     }),
   deleteItem: (projectId: string, itemId: string) =>
     apiRequest<void>(`/projects/${projectId}/items/${itemId}`, { method: 'DELETE' }),
+  reorderItems: (projectId: string, orderedIds: string[]) =>
+    apiRequest<ProjectItem[]>(`/projects/${projectId}/items/reorder`, {
+      method: 'POST',
+      body: { orderedIds },
+    }),
 };
 
 export const projectsQueryKey = {

--- a/apps/web/src/features/projects/membersApi.ts
+++ b/apps/web/src/features/projects/membersApi.ts
@@ -45,6 +45,11 @@ export const membersApi = {
     apiRequest<void>(`/projects/${projectId}/members/${memberId}`, {
       method: 'DELETE',
     }),
+  reorder: (projectId: string, orderedIds: string[]) =>
+    apiRequest<ProjectMember[]>(`/projects/${projectId}/members/reorder`, {
+      method: 'POST',
+      body: { orderedIds },
+    }),
 };
 
 export const membersQueryKey = {

--- a/apps/web/src/lib/reorder.test.ts
+++ b/apps/web/src/lib/reorder.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { moveItem } from './reorder';
+
+describe('moveItem', () => {
+  it('前方へ移動する', () => {
+    expect(moveItem(['a', 'b', 'c', 'd'], 2, 0)).toEqual(['c', 'a', 'b', 'd']);
+  });
+
+  it('後方へ移動する', () => {
+    expect(moveItem(['a', 'b', 'c', 'd'], 0, 2)).toEqual(['b', 'c', 'a', 'd']);
+  });
+
+  it('末尾へ移動する', () => {
+    expect(moveItem(['a', 'b', 'c'], 0, 2)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('from === to は元の配列をそのまま返す', () => {
+    const list = ['a', 'b', 'c'];
+    expect(moveItem(list, 1, 1)).toBe(list);
+  });
+
+  it('範囲外インデックスは元の配列をそのまま返す', () => {
+    const list = ['a', 'b'];
+    expect(moveItem(list, 0, 5)).toBe(list);
+    expect(moveItem(list, -1, 0)).toBe(list);
+  });
+
+  it('元の配列を変更しない', () => {
+    const list = ['a', 'b', 'c'];
+    moveItem(list, 0, 2);
+    expect(list).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/apps/web/src/lib/reorder.ts
+++ b/apps/web/src/lib/reorder.ts
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+
+/** list の from 番目を to 番目へ移動した新しい配列を返す (元配列は変更しない)。 */
+export function moveItem<T>(list: T[], from: number, to: number): T[] {
+  if (
+    from === to ||
+    from < 0 ||
+    to < 0 ||
+    from >= list.length ||
+    to >= list.length
+  ) {
+    return list;
+  }
+  const next = list.slice();
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved!);
+  return next;
+}
+
+/**
+ * ネイティブ HTML5 ドラッグ&ドロップによる縦リストの並び替えフック (#111)。
+ * - `handleProps(index)`: ドラッグの起点となるグリップ要素に付与する。
+ * - `rowProps(index)`: ドロップ対象となる各行に付与する。
+ * onReorder(from, to) はドロップ時に一度だけ呼ばれる。
+ */
+export function useDragReorder(onReorder: (from: number, to: number) => void) {
+  const [fromIndex, setFromIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
+
+  const reset = () => {
+    setFromIndex(null);
+    setOverIndex(null);
+  };
+
+  return {
+    fromIndex,
+    overIndex,
+    isDragging: fromIndex !== null,
+    handleProps: (index: number) => ({
+      draggable: true,
+      onDragStart: (e: React.DragEvent) => {
+        setFromIndex(index);
+        e.dataTransfer.effectAllowed = 'move';
+        // Firefox はドラッグ開始に setData が必須。
+        e.dataTransfer.setData('text/plain', String(index));
+      },
+      onDragEnd: reset,
+    }),
+    rowProps: (index: number) => ({
+      onDragOver: (e: React.DragEvent) => {
+        if (fromIndex === null) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        if (overIndex !== index) setOverIndex(index);
+      },
+      onDrop: (e: React.DragEvent) => {
+        e.preventDefault();
+        if (fromIndex !== null && fromIndex !== index) onReorder(fromIndex, index);
+        reset();
+      },
+    }),
+  };
+}


### PR DESCRIPTION
## 概要
制作物（プロジェクト編集）と参加者（参加者管理）をマウスのドラッグ&ドロップで並び替えられるようにします (#111)。

## バックエンド
- 一括並び替えエンドポイントを追加：
  - `POST /projects/:projectId/items/reorder`
  - `POST /projects/:projectId/members/reorder`
  - 静的セグメント `/reorder` が `:itemId` / `:memberId` より優先されるよう定義（統合テストで実証）。
- `reorderItems` / `reorderMembers` サービス：`orderedIds` が現存レコードと**過不足・重複なく一致**することを検証（`assertExactIdSet`）し、トランザクションで `sortOrder = 0..n-1` を振り直す。不一致は `422 INVALID_REORDER`。ディレクター限定。

## フロントエンド
- ネイティブ HTML5 DnD のユーティリティ/フックを追加（`moveItem`, `useDragReorder`）— 外部依存なし。
- 制作物リスト・参加者テーブルにグリップハンドル（⋮⋮）とドロップ処理を追加。楽観更新で即時反映し、失敗時はロールバック。

## 確認
- `pnpm type-check` / `pnpm lint` / `pnpm test`(603 passed) 成功。
- `moveItem` の単体テスト、reorder エンドポイントの実DB統合テスト（正常系＋過不足時 422）を追加。

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)