### PR TITLE
fix(schedule): ボール保持者をライン(後続チェーン)単位で導出する (#117)

### DIFF
--- a/apps/web/src/features/plans/ItemSchedulePage.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.tsx
@@ -21,7 +21,8 @@ import {
 import { cn } from '@/components/ui/utils';
 import { projectsApi, projectsQueryKey, type ProjectItem } from '@/features/projects/api';
 import { membersApi, membersQueryKey } from '@/features/projects/membersApi';
-import { plansApi, plansQueryKey, type Plan } from './api';
+import { deriveLineBallHolders } from '@trakon/shared';
+import { plansApi, plansQueryKey, type Plan, type MemberRef } from './api';
 import { CATEGORY_STYLE } from './categoryColor';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { PlanModalsHost } from './PlanModalsHost';
@@ -430,6 +431,31 @@ function computeChain(
   return { chainIds, linkSourceIds };
 }
 
+/**
+ * ライン単位の現在のボール保持者 (member) を解決する (#117)。
+ * deriveLineBallHolders が返す member_id を、予定に紐づく MemberRef へ解決する。
+ */
+function resolveHolders(itemPlans: Plan[]): MemberRef[] {
+  const holderIds = deriveLineBallHolders(
+    itemPlans.map((p) => ({
+      id: p.id,
+      successorPlanId: p.successorPlanId,
+      status: p.status,
+      ballState: p.ballState,
+      fromMemberId: p.fromMember?.id ?? null,
+      toMemberId: p.toMember?.id ?? null,
+    })),
+  );
+  const refById = new Map<string, MemberRef>();
+  for (const p of itemPlans) {
+    if (p.fromMember) refById.set(p.fromMember.id, p.fromMember);
+    if (p.toMember) refById.set(p.toMember.id, p.toMember);
+  }
+  return holderIds
+    .map((id) => refById.get(id))
+    .filter((m): m is MemberRef => m !== undefined);
+}
+
 function ScheduleBoard({
   days,
   items,
@@ -660,11 +686,9 @@ function ScheduleBoard({
           const { laneOf, laneCount } = assignLanes(itemPlans);
           const colWidth = Math.max(minColumnWidth, laneCount * laneWidth);
           const color = itemColor(item.id);
-          // 代表ボール = 最新の active プラン。その現ホルダーを列上部に表示
-          const activePlans = itemPlans.filter((p) => p.status === 'active');
-          const repHolder = activePlans.length
-            ? activePlans[activePlans.length - 1]!.ballHolder
-            : null;
+          // 代表ボール保持者 = ライン (後続チェーン) 単位で現在の保持者を導出 (#117)。
+          // 後続で繋がっていない予定は別ライン扱いなので、保持者が複数になりうる。
+          const repHolders = resolveHolders(itemPlans);
           // コネクト印用: 先行 (誰かの後続として指されている) plan の id 集合
           const predecessorTargetIds = new Set(
             itemPlans
@@ -693,11 +717,11 @@ function ScheduleBoard({
                 </div>
                 <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
                   <span className="shrink-0">ボール保持:</span>
-                  {repHolder ? (
+                  {repHolders.length > 0 ? (
                     <span className="truncate font-medium text-foreground">
-                      {repHolder.organizationName
-                        ? `${repHolder.organizationName} ${repHolder.name}`
-                        : repHolder.name}
+                      {repHolders
+                        .map((h) => (h.organizationName ? `${h.organizationName} ${h.name}` : h.name))
+                        .join('、')}
                     </span>
                   ) : (
                     <span>—</span>

--- a/packages/shared/src/domain/ballHolder.test.ts
+++ b/packages/shared/src/domain/ballHolder.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { deriveBallHolder, pickLatestBallEvent } from './ballHolder.js';
+import {
+  deriveBallHolder,
+  deriveLineBallHolders,
+  pickLatestBallEvent,
+  type LinePlanLike,
+} from './ballHolder.js';
 
 describe('deriveBallHolder', () => {
   const plan = {
@@ -70,5 +75,79 @@ describe('pickLatestBallEvent', () => {
     const b = { eventType: 'completed' as const, source: 'human' as const, occurredAt: '2026-06-02T00:00:00Z' };
     const c = { eventType: 'tossed' as const, source: 'auto_chain' as const, occurredAt: '2026-06-01T12:00:00Z' };
     expect(pickLatestBallEvent([a, b, c])).toBe(b);
+  });
+});
+
+describe('deriveLineBallHolders (#117)', () => {
+  // 前提A: ワイヤー作成 → デザイン作成 が後続で繋がっている
+  //   ワイヤー: FROM=田中 TO=佐藤 / デザイン: FROM=山田 TO=高橋
+  const lineA = (
+    wire: { status: LinePlanLike['status']; ballState: LinePlanLike['ballState'] },
+    design: { status: LinePlanLike['status']; ballState: LinePlanLike['ballState'] },
+  ): LinePlanLike[] => [
+    { id: 'wire', successorPlanId: 'design', fromMemberId: 'tanaka', toMemberId: 'sato', ...wire },
+    { id: 'design', successorPlanId: null, fromMemberId: 'yamada', toMemberId: 'takahashi', ...design },
+  ];
+
+  const READY = { status: 'active' as const, ballState: 'ready' as const };
+  const TOSSED = { status: 'active' as const, ballState: 'tossed' as const };
+  const DONE = { status: 'completed' as const, ballState: 'completed' as const };
+
+  it('ケース1/5: ワイヤー未TOSS → 田中 (FROM)', () => {
+    expect(deriveLineBallHolders(lineA(READY, READY))).toEqual(['tanaka']);
+  });
+
+  it('ケース2/6: ワイヤーTOSS済・未完了 → 佐藤 (TO)', () => {
+    expect(deriveLineBallHolders(lineA(TOSSED, READY))).toEqual(['sato']);
+  });
+
+  it('ケース3/7: ワイヤー完了・デザイン未TOSS → 山田 (後続のFROM)', () => {
+    expect(deriveLineBallHolders(lineA(DONE, READY))).toEqual(['yamada']);
+  });
+
+  it('ケース4/8: ワイヤー完了・デザインTOSS済未完了 → 高橋 (後続のTO)', () => {
+    expect(deriveLineBallHolders(lineA(DONE, TOSSED))).toEqual(['takahashi']);
+  });
+
+  it('ケース9: ワイヤー・デザインとも完了 → 保持者なし', () => {
+    expect(deriveLineBallHolders(lineA(DONE, DONE))).toEqual([]);
+  });
+
+  // 前提B: 後続で繋がっていない2予定は別ラインとして扱い、保持者は2名になる
+  const lineB = (
+    wire: { status: LinePlanLike['status']; ballState: LinePlanLike['ballState'] },
+    flyer: { status: LinePlanLike['status']; ballState: LinePlanLike['ballState'] },
+  ): LinePlanLike[] => [
+    { id: 'wire', successorPlanId: null, fromMemberId: 'tanaka', toMemberId: 'sato', ...wire },
+    { id: 'flyer', successorPlanId: null, fromMemberId: 'yamada', toMemberId: 'takahashi', ...flyer },
+  ];
+
+  it('前提B: 独立した2ライン → 保持者は2名 (それぞれの状態で決まる)', () => {
+    expect(deriveLineBallHolders(lineB(READY, READY))).toEqual(['tanaka', 'yamada']);
+    expect(deriveLineBallHolders(lineB(TOSSED, TOSSED))).toEqual(['sato', 'takahashi']);
+    expect(deriveLineBallHolders(lineB(DONE, READY))).toEqual(['yamada']);
+  });
+
+  it('同一人物が複数ラインを持つ場合は重複を除く', () => {
+    const plans: LinePlanLike[] = [
+      { id: 'a', successorPlanId: null, fromMemberId: 'tanaka', toMemberId: 'sato', ...READY },
+      { id: 'b', successorPlanId: null, fromMemberId: 'tanaka', toMemberId: 'x', ...READY },
+    ];
+    expect(deriveLineBallHolders(plans)).toEqual(['tanaka']);
+  });
+
+  it('canceled の予定は無視する', () => {
+    const plans: LinePlanLike[] = [
+      { id: 'a', successorPlanId: null, fromMemberId: 'tanaka', toMemberId: 'sato', status: 'canceled', ballState: 'ready' },
+      { id: 'b', successorPlanId: null, fromMemberId: 'yamada', toMemberId: 'takahashi', ...READY },
+    ];
+    expect(deriveLineBallHolders(plans)).toEqual(['yamada']);
+  });
+
+  it('保持者が空/未設定なら詰めて返す', () => {
+    const plans: LinePlanLike[] = [
+      { id: 'a', successorPlanId: null, fromMemberId: null, toMemberId: null, ...READY },
+    ];
+    expect(deriveLineBallHolders(plans)).toEqual([]);
   });
 });

--- a/packages/shared/src/domain/ballHolder.ts
+++ b/packages/shared/src/domain/ballHolder.ts
@@ -49,6 +49,62 @@ export function deriveBallHolder(plan: PlanLike, latestEvent?: BallEventLike | n
   return { memberId: plan.toMemberId, state: 'completed' };
 }
 
+/** ライン (後続チェーン) 単位のボール保持者導出に使う plan 形状。 */
+export type LinePlanLike = {
+  id: string;
+  /** この予定の「後続の予定」。予定同士を 1 本のラインに繋ぐ。 */
+  successorPlanId: string | null;
+  status: 'active' | 'completed' | 'canceled';
+  /** 予定単体のボール状態 (deriveBallHolder 由来)。 */
+  ballState: PlanState;
+  fromMemberId: string | null;
+  toMemberId: string | null;
+};
+
+/**
+ * 「ライン」単位で現在のボール保持者を導出する (#117)。
+ *
+ * ライン = 後続 (successorPlanId) で連結された予定のまとまり。後続で繋がっていない
+ * 予定は、期間が重なっていてもそれぞれ独立したラインとして扱う。
+ *
+ * 各ラインの保持者は、ラインの先頭から辿って最初に見つかる「未完了の予定」で決まる:
+ *   - その予定が TOSS されていなければ FROM (実施者)
+ *   - TOSS 済みで未完了なら TO (確認者)
+ * ラインの予定がすべて完了していれば、そのラインに保持者はいない (後続が無いため)。
+ *
+ * 独立したラインが複数あれば保持者も複数になりうる。同一人物が複数ラインを持つ
+ * 場合は重複を除いた distinct な member_id 配列を、入力順を保って返す。
+ * canceled の予定は無視する。
+ */
+export function deriveLineBallHolders(plans: LinePlanLike[]): string[] {
+  const active = plans.filter((p) => p.status !== 'canceled');
+  const byId = new Map(active.map((p) => [p.id, p]));
+  // 誰かの後続として指されている予定はラインの先頭ではない。
+  const successorIds = new Set(
+    active
+      .map((p) => p.successorPlanId)
+      .filter((id): id is string => id !== null),
+  );
+  const heads = active.filter((p) => !successorIds.has(p.id));
+
+  const holders: string[] = [];
+  for (const head of heads) {
+    let cur: LinePlanLike | undefined = head;
+    const visited = new Set<string>();
+    while (cur && !visited.has(cur.id)) {
+      visited.add(cur.id);
+      if (cur.status !== 'completed') {
+        const holderId = cur.ballState === 'tossed' ? cur.toMemberId : cur.fromMemberId;
+        if (holderId) holders.push(holderId);
+        break;
+      }
+      // 完了済みなら後続へ。後続が無ければ (= 全完了) このラインに保持者はいない。
+      cur = cur.successorPlanId ? byId.get(cur.successorPlanId) : undefined;
+    }
+  }
+  return [...new Set(holders)];
+}
+
 /**
  * `ball_events` の配列から「最新のイベント」を取り出す。
  * occurredAt の降順ソートを前提としない (呼び出し側でソートしていない可能性に備え)。


### PR DESCRIPTION
## 概要
スケジュール列ヘッダーの代表ボール保持者のロジックを、issue のケース定義に沿って修正します (#117)。

## 原因
従来は `activePlans[activePlans.length - 1].ballHolder`（＝最新の active 予定の保持者）1名のみを表示しており、後続チェーンの進行状態や独立ライン（複数保持者）を反映できていなかった。

## 変更点
`packages/shared` に純関数 `deriveLineBallHolders` を追加：
- **ライン** = `successorPlanId` で連結された予定のまとまり。後続で繋がっていない予定は、期間が重なっていてもそれぞれ独立したラインとして扱う。
- 各ラインの保持者は、先頭から辿って**最初の未完了予定**で決まる（未TOSS→FROM実施者／TOSS済未完了→TO確認者）。ラインが全完了なら保持者なし。
- 独立ラインが複数あれば保持者も複数（distinct）。

スケジュール列ヘッダーの「ボール保持:」を複数保持者対応（`、`区切り）に変更。

## 確認
- `pnpm type-check` / `pnpm lint` / `pnpm test`（web 603 + shared 17 passed）成功。
- issue のケース1〜9・前提A/B・重複除去・canceled 無視を網羅する単体テストを追加。

### スコープ補足
本 issue のケースが指す「スケジュール上の代表ボール保持者」を対象としています。ダッシュボードの「担当タスク」集計（予定単体の保持者ベース）は別概念のため本 PR では変更していません。必要であれば別途対応します。

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)