### PR TITLE
test(schedule): #117 ボール保持者ロジックの回帰テスト (実DB統合＋フロント描画)

### DIFF
--- a/apps/web/server/routes/v1/plans.integration.test.ts
+++ b/apps/web/server/routes/v1/plans.integration.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { deriveLineBallHolders } from '@trakon/shared';
+
 import { api } from '../../test/request.js';
 import {
   createItem,
@@ -142,6 +144,72 @@ describe('plans routes (integration)', () => {
       expect(res.status).toBe(200);
       expect(res.body.data.autoTossed?.id).toBe(successor.body.data.id);
       expect(res.body.data.autoTossed?.latestEvent?.source).toBe('auto_chain');
+    });
+  });
+
+  // #117: ライン単位の代表ボール保持者 (deriveLineBallHolders) を実データで検証する。
+  describe('#117 ボール保持者 (ライン単位)', () => {
+    type FullPlan = {
+      id: string;
+      status: 'active' | 'completed' | 'canceled';
+      ballState: 'ready' | 'tossed' | 'completed';
+      successorPlanId: string | null;
+      fromMember: { id: string } | null;
+      toMember: { id: string } | null;
+    };
+
+    async function holdersNow(): Promise<string[]> {
+      const list = await api<{ data: FullPlan[] }>(base, { token: ctx.token });
+      return deriveLineBallHolders(
+        list.body.data.map((p) => ({
+          id: p.id,
+          successorPlanId: p.successorPlanId,
+          status: p.status,
+          ballState: p.ballState,
+          fromMemberId: p.fromMember?.id ?? null,
+          toMemberId: p.toMember?.id ?? null,
+        })),
+      );
+    }
+
+    // ワイヤー(FROM=fromId TO=toId) → デザイン(FROM=dzFrom TO=dzTo) を後続で連結し、
+    // ワイヤーを TOSS→完了 する (完了時にデザインが auto-toss される)。
+    async function setupLinkedChain() {
+      const dzFrom = await createMember({ projectId: ctx.project.id, memberType: 'production' });
+      const dzTo = await createMember({ projectId: ctx.project.id, memberType: 'production' });
+      const design = await createPlanViaApi({
+        title: 'デザイン作成',
+        category: 'design',
+        scheduledDate: '2026-07-19',
+        dueDate: '2026-07-26',
+        fromMemberId: dzFrom.id,
+        toMemberId: dzTo.id,
+      });
+      const wire = await createPlanViaApi({
+        title: 'ワイヤー作成',
+        category: 'wireframe',
+        scheduledDate: '2026-07-11',
+        dueDate: '2026-07-18',
+        fromMemberId: fromId,
+        toMemberId: toId,
+        successorPlanId: design.body.data.id,
+      });
+      await api(`${base}/${wire.body.data.id}/toss`, { method: 'POST', token: ctx.token, body: {} });
+      await api(`${base}/${wire.body.data.id}/complete`, { method: 'POST', token: ctx.token });
+      return { wire: wire.body.data, design: design.body.data, dzFrom: dzFrom.id, dzTo: dzTo.id };
+    }
+
+    it('ケース3: ワイヤー完了・デザイン未TOSS → デザインの FROM', async () => {
+      const { design, dzFrom } = await setupLinkedChain();
+      // 完了時に auto-toss されたデザインを差し戻して「未TOSS」に戻す
+      await api(`${base}/${design.id}/toss-undo`, { method: 'POST', token: ctx.token, body: {} });
+      expect(await holdersNow()).toEqual([dzFrom]);
+    });
+
+    it('ケース4: ワイヤー完了・デザインTOSS済 → デザインの TO', async () => {
+      const { dzTo } = await setupLinkedChain();
+      // 完了時の auto-toss でデザインは tossed のまま
+      expect(await holdersNow()).toEqual([dzTo]);
     });
   });
 

--- a/apps/web/src/features/plans/ItemSchedulePage.test.tsx
+++ b/apps/web/src/features/plans/ItemSchedulePage.test.tsx
@@ -307,6 +307,44 @@ describe('ItemSchedulePage (integration)', () => {
     expect(screen.getAllByText('ボール保持:').length).toBeGreaterThan(0);
   });
 
+  // #117 ケース3: ワイヤー完了・後続デザイン未TOSS の列ヘッダはデザインの実施者(FROM)を表示する
+  it('#117 ケース3: 完了した先行の後続(未TOSS)の実施者を代表保持者に表示する', async () => {
+    const dzFrom: ProjectMember = { ...meMember, id: 'm-dzfrom', name: 'デザイン実施', organizationName: '' };
+    const dzTo: ProjectMember = { ...meMember, id: 'm-dzto', name: 'デザイン確認', organizationName: '' };
+    const wire = makePlan({
+      id: 'w',
+      title: 'ワイヤー作成',
+      category: 'wireframe',
+      scheduledDate: '2026-06-19',
+      dueDate: '2026-06-20',
+      fromMember: ref(meMember),
+      toMember: ref(otherMember),
+      status: 'completed',
+      ballState: 'completed',
+      successorPlanId: 'd',
+    });
+    const design = makePlan({
+      id: 'd',
+      title: 'デザイン作成',
+      category: 'design',
+      scheduledDate: '2026-06-21',
+      dueDate: '2026-06-22',
+      fromMember: ref(dzFrom),
+      toMember: ref(dzTo),
+      status: 'active',
+      ballState: 'ready',
+      successorPlanId: null,
+    });
+    setupReads({ itemsResp: [items[0]!], plansResp: [wire, design] });
+    renderPage();
+
+    await screen.findByText('ワイヤー作成');
+    const holderRow = screen.getByText('ボール保持:').parentElement!;
+    // 代表保持者はデザインの FROM (デザイン実施)。ワイヤーの FROM は表示されない。
+    expect(holderRow.textContent).toContain('デザイン実施');
+    expect(holderRow.textContent).not.toContain(meMember.name);
+  });
+
   it('日付軸の日付セルとズームコントロールを描画する', async () => {
     setupReads();
     renderPage();


### PR DESCRIPTION
## 概要
#117 のボール保持者ロジック（ライン単位の代表保持者）について、実データでの挙動を固定する回帰テストを追加します。

- **実DB統合テスト**（`plans.integration.test.ts`）: ワイヤー→デザインを後続で連結し、ワイヤーを TOSS→完了（完了時にデザインが auto-toss される）した上で、
  - ケース3: デザインの auto-toss を差し戻して未TOSSに戻す → 代表保持者 = **デザインの実施者(FROM)**
  - ケース4: デザインは TOSS 済のまま → 代表保持者 = **デザインの確認者(TO)**
- **フロント描画テスト**（`ItemSchedulePage.test.tsx`）: 完了した先行の後続(未TOSS)の実施者が列ヘッダー「ボール保持:」に表示され、先行の実施者は表示されないことを確認。

## 補足（動作確認の調査結果）
ケース3で「田中太郎（＝先行の実施者）」が表示されるという報告を受けて調査しました。上記の実DB統合テスト・フロント描画テストのいずれも、ワイヤーが**完了状態**であれば代表保持者はデザインの実施者になることを確認しています。したがって「田中太郎」が出るのは、先行(ワイヤー)がデータ上まだ**完了していない**（＝未TOSSのケース1相当。この場合は先行の実施者が正しい保持者）ことを示唆します。切り分けのための質問は Issue/チャットにて。

🤖 Generated with [Claude Code](https://claude.com/claude-code)