### PR TITLE
fix(plans): 完了時の自動連鎖TOSSを廃止しケース3を成立させる (#117)

### DIFF
--- a/apps/web/server/routes/v1/plans.integration.test.ts
+++ b/apps/web/server/routes/v1/plans.integration.test.ts
@@ -120,7 +120,7 @@ describe('plans routes (integration)', () => {
       expect(res.body.data.plan.ballState).toBe('completed');
     });
 
-    it('後続を持つ予定を完了すると後続が auto_chain で TOSS される', async () => {
+    it('後続を持つ予定を完了しても後続は自動 TOSS されない (自動連鎖廃止 #117)', async () => {
       const successor = await createPlanViaApi({
         title: 'Coding',
         category: 'coding',
@@ -142,8 +142,13 @@ describe('plans routes (integration)', () => {
         { method: 'POST', token: ctx.token },
       );
       expect(res.status).toBe(200);
-      expect(res.body.data.autoTossed?.id).toBe(successor.body.data.id);
-      expect(res.body.data.autoTossed?.latestEvent?.source).toBe('auto_chain');
+      expect(res.body.data.autoTossed).toBeNull();
+
+      // 後続は ready のまま (ボールは後続の実施者=FROM に残る)
+      const succ = await api<{ data: { plan: PlanDTO } }>(`${base}/${successor.body.data.id}`, {
+        token: ctx.token,
+      });
+      expect(succ.body.data.plan.ballState).toBe('ready');
     });
   });
 
@@ -173,7 +178,7 @@ describe('plans routes (integration)', () => {
     }
 
     // ワイヤー(FROM=fromId TO=toId) → デザイン(FROM=dzFrom TO=dzTo) を後続で連結し、
-    // ワイヤーを TOSS→完了 する (完了時にデザインが auto-toss される)。
+    // ワイヤーを TOSS→完了 する (自動連鎖廃止によりデザインは未TOSS のまま)。
     async function setupLinkedChain() {
       const dzFrom = await createMember({ projectId: ctx.project.id, memberType: 'production' });
       const dzTo = await createMember({ projectId: ctx.project.id, memberType: 'production' });
@@ -199,16 +204,16 @@ describe('plans routes (integration)', () => {
       return { wire: wire.body.data, design: design.body.data, dzFrom: dzFrom.id, dzTo: dzTo.id };
     }
 
-    it('ケース3: ワイヤー完了・デザイン未TOSS → デザインの FROM', async () => {
-      const { design, dzFrom } = await setupLinkedChain();
-      // 完了時に auto-toss されたデザインを差し戻して「未TOSS」に戻す
-      await api(`${base}/${design.id}/toss-undo`, { method: 'POST', token: ctx.token, body: {} });
+    it('ケース3: ワイヤー完了・デザイン未TOSS → デザインの FROM (実施者)', async () => {
+      // 自動連鎖廃止により、ワイヤー完了後もデザインは未TOSS のまま
+      const { dzFrom } = await setupLinkedChain();
       expect(await holdersNow()).toEqual([dzFrom]);
     });
 
-    it('ケース4: ワイヤー完了・デザインTOSS済 → デザインの TO', async () => {
-      const { dzTo } = await setupLinkedChain();
-      // 完了時の auto-toss でデザインは tossed のまま
+    it('ケース4: ワイヤー完了・デザインTOSS済 → デザインの TO (確認者)', async () => {
+      const { design, dzTo } = await setupLinkedChain();
+      // デザインの実施者が作業後に手動 TOSS するとケース4 になる
+      await api(`${base}/${design.id}/toss`, { method: 'POST', token: ctx.token, body: {} });
       expect(await holdersNow()).toEqual([dzTo]);
     });
   });

--- a/apps/web/server/services/ballActions.test.ts
+++ b/apps/web/server/services/ballActions.test.ts
@@ -458,7 +458,7 @@ describe('completePlan', () => {
     expect(auditStore.some((a) => a.action === 'complete')).toBe(true);
   });
 
-  it('後続が ready のとき auto_chain で TOSS される (autoTossed を返す)', async () => {
+  it('後続が ready でも自動 TOSS しない (自動連鎖廃止 #117)', async () => {
     const from = makeMember();
     const to = makeMember();
     const sFrom = makeMember();
@@ -475,13 +475,10 @@ describe('completePlan', () => {
       currentMemberId: to.id,
       isDirector: false,
     });
-    expect(res.autoTossed).not.toBeNull();
-    expect(res.autoTossed?.id).toBe(successor.id);
-    expect(res.autoTossed?.ballState).toBe('tossed');
-    const autoEvents = ballEventStore.filter((e) => e.planId === successor.id);
-    expect(autoEvents).toHaveLength(1);
-    expect(autoEvents[0]!.source).toBe('auto_chain');
-    expect(auditStore.some((a) => a.action === 'auto_toss' && a.resourceId === successor.id)).toBe(true);
+    expect(res.autoTossed).toBeNull();
+    // 後続にはイベントが一切追記されず、ready のまま (ボールは後続の実施者=FROM に残る)
+    expect(ballEventStore.filter((e) => e.planId === successor.id)).toHaveLength(0);
+    expect(auditStore.some((a) => a.action === 'auto_toss')).toBe(false);
   });
 
   it('後続が既に tossed (ready でない) なら auto_chain しない', async () => {
@@ -685,10 +682,11 @@ describe('undoCompletePlan', () => {
     expect(auditStore.some((a) => a.action === 'undo_complete')).toBe(true);
   });
 
-  it('後続が auto_chain で TOSS されていた場合、後続も toss_undone で巻き戻す', async () => {
+  it('完了取り消し時、後続 (未完了) には触れない (自動連鎖廃止 #117)', async () => {
     const from = makeMember();
     const to = makeMember();
     const successor = makePlan({ fromMemberId: makeMember().id, toMemberId: makeMember().id });
+    // 過去に auto_chain で TOSS された履歴があっても巻き戻さない
     addEvent(successor.id, 'tossed', 'auto_chain');
     const plan = makePlan({
       fromMemberId: from.id,
@@ -708,8 +706,9 @@ describe('undoCompletePlan', () => {
       isDirector: false,
     });
     expect(res.plan.status).toBe('active');
-    expect(eventTypesFor(successor.id)).toEqual(['tossed', 'toss_undone']);
-    expect(auditStore.some((a) => a.action === 'untoss' && a.resourceId === successor.id)).toBe(true);
+    // 後続は一切変更されない
+    expect(eventTypesFor(successor.id)).toEqual(['tossed']);
+    expect(auditStore.some((a) => a.action === 'untoss' && a.resourceId === successor.id)).toBe(false);
   });
 
   it('後続が auto_chain ではなく既に完了済みなら SUCCESSOR_ALREADY_COMPLETED 409', async () => {

--- a/apps/web/server/services/ballActions.ts
+++ b/apps/web/server/services/ballActions.ts
@@ -209,40 +209,18 @@ export async function completePlan(input: {
       planId: plan.id,
     });
 
-    // 自動連鎖 (Phase 0 は同一 item 内、1 段のみ)
-    let autoTossed: PlanWithIncludes | null = null;
-    if (plan.successorPlanId) {
-      const successor = await tx.plan.findFirst({
-        where: { id: plan.successorPlanId, itemId: input.itemId, deletedAt: null },
-        include: PLAN_INCLUDE,
-      });
-      if (successor && successor.status === 'active' && currentBallState(successor) === 'ready') {
-        await tx.ballEvent.create({
-          data: {
-            planId: successor.id,
-            eventType: 'tossed',
-            source: 'auto_chain',
-            actorMemberId: null,
-            actorUserId: null,
-          },
-        });
-        await recordAudit({
-          tx,
-          actorUserId: input.currentUserId,
-          action: 'auto_toss',
-          planId: successor.id,
-        });
-        autoTossed = await loadPlanWithIncludes(tx, successor.id, input.itemId);
-      }
-    }
+    // 完了時の自動連鎖 TOSS は廃止 (#117)。
+    // 先行を完了しても後続は未TOSS (実施者=FROM にボール) のままにし、後続の実施者が
+    // 作業後に手動で TOSS する運用とする。これによりケース3 (後続未TOSS→後続の実施者) が
+    // 自然に成立する。autoTossed は後方互換のため常に null を返す。
 
     const completed = await loadPlanWithIncludes(tx, plan.id, input.itemId);
-    return { completed, autoTossed };
+    return { completed };
   });
 
   return {
     plan: toPlanDTO(result.completed, []),
-    autoTossed: result.autoTossed ? toPlanDTO(result.autoTossed, []) : null,
+    autoTossed: null,
   };
 }
 
@@ -321,42 +299,19 @@ export async function undoCompletePlan(input: {
       );
     }
 
-    // 完了時に後続を自動 TOSS していた場合、その auto_chain TOSS も巻き戻す。
-    // - 後続の最新イベントが auto_chain の tossed → この完了が誘発したもの。toss_undone で ready に戻す。
-    // - 後続が既に完了している → 差し戻すと不整合になるためブロックする。
-    // - それ以外 (自動連鎖していない / 既に人手で操作済み) → 後続には触れない。
+    // 後続が既に完了している場合は、この予定の完了を取り消すと不整合になるためブロックする。
+    // (自動連鎖 TOSS は廃止済みのため巻き戻し処理は不要 — #117)
     if (plan.successorPlanId) {
       const successor = await tx.plan.findFirst({
         where: { id: plan.successorPlanId, itemId: input.itemId, deletedAt: null },
-        include: PLAN_INCLUDE,
+        select: { status: true },
       });
-      if (successor) {
-        const succLatest = successor.ballEvents[0];
-        const wasAutoChainedByThis =
-          !!succLatest && succLatest.eventType === 'tossed' && succLatest.source === 'auto_chain';
-        if (wasAutoChainedByThis) {
-          await tx.ballEvent.create({
-            data: {
-              planId: successor.id,
-              eventType: 'toss_undone',
-              source: 'human',
-              actorMemberId: input.currentMemberId,
-              actorUserId: input.currentUserId,
-            },
-          });
-          await recordAudit({
-            tx,
-            actorUserId: input.currentUserId,
-            action: 'untoss',
-            planId: successor.id,
-          });
-        } else if (successor.status === 'completed') {
-          throw new ApiException(
-            'SUCCESSOR_ALREADY_COMPLETED',
-            409,
-            '後続予定が完了済みのため、この予定の完了を取り消せません。',
-          );
-        }
+      if (successor?.status === 'completed') {
+        throw new ApiException(
+          'SUCCESSOR_ALREADY_COMPLETED',
+          409,
+          '後続予定が完了済みのため、この予定の完了を取り消せません。',
+        );
       }
     }
 

--- a/apps/web/src/features/plans/useOptimisticBallAction.test.ts
+++ b/apps/web/src/features/plans/useOptimisticBallAction.test.ts
@@ -173,12 +173,12 @@ describe('useTossPlan', () => {
 });
 
 describe('useCompletePlan', () => {
-  it('楽観更新で status=completed になり、成功時に autoTossed トーストを出す', async () => {
+  it('楽観更新で status=completed になり、成功トーストを出す (自動連鎖廃止 #117)', async () => {
     seedList(makePlan());
     const snapshots = recordListSnapshots();
     server.use(
       http.post(completeUrl, () =>
-        HttpResponse.json({ data: { plan: makePlan(), autoTossed: makePlan() } }),
+        HttpResponse.json({ data: { plan: makePlan(), autoTossed: null } }),
       ),
     );
 
@@ -198,7 +198,8 @@ describe('useCompletePlan', () => {
     expect(optimistic).toBeDefined();
     expect(optimistic?.status).toBe('completed');
     expect(toastSuccess).toHaveBeenCalledWith('完了しました');
-    expect(toastMessage).toHaveBeenCalledWith('後続の予定に自動 TOSS しました');
+    // 自動 TOSS トーストはもう出ない
+    expect(toastMessage).not.toHaveBeenCalledWith('後続の予定に自動 TOSS しました');
   });
 
   it('エラー時にロールバックして失敗トーストを出す', async () => {

--- a/apps/web/src/features/plans/useOptimisticBallAction.ts
+++ b/apps/web/src/features/plans/useOptimisticBallAction.ts
@@ -138,11 +138,8 @@ export function useCompletePlan(input: { projectId: string; itemId: string; plan
       }
       toast.error(err instanceof ApiClientError ? err.message : '完了に失敗しました');
     },
-    onSuccess: (result) => {
+    onSuccess: () => {
       toast.success('完了しました');
-      if (result.autoTossed) {
-        toast.message('後続の予定に自動 TOSS しました');
-      }
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: listKey });


### PR DESCRIPTION
## 概要
#117 の追加調査で判明した根本原因を修正します。動作確認のスクリーンショットで、後続(デザイン)が「TOSS 自動連鎖 by system」と「差し戻し」を繰り返しており、**先行を完了すると後続が自動 TOSS され、ボールが後続の確認者(TO=高橋)へ移る**のが原因でした。そのためケース3(後続未TOSS→後続の実施者=山田)に到達できていませんでした。

## 根本原因
`completePlan` に「先行を完了すると後続を自動で TOSS する（自動連鎖）」処理があり、これが後続のボールを実施者(FROM)ではなく確認者(TO)へ移していました。差し戻しても再度自動連鎖で TOSS される状態でした。

## 修正（自動連鎖 TOSS の廃止）
ボールの意味（未TOSS=実施者が作業中／TOSS済=確認者が確認）に沿って、**先行を完了しても後続は未TOSS（実施者にボール）のまま**にします。後続の実施者が作業後に手動 TOSS すればケース4（確認者）になります。

- `completePlan`: 後続の自動 TOSS を廃止（`autoTossed` は後方互換のため常に `null`）
- `undoCompletePlan`: 自動連鎖 TOSS の巻き戻しを削除（後続が完了済みなら取り消し不可のガードは維持）
- フロント: 「後続の予定に自動 TOSS しました」トーストを削除（履歴の `auto_chain` バッジ表示は既存データ用に維持）

## 確認
- `pnpm type-check` / `pnpm lint` / `pnpm test`（web 604 + shared 17）成功。
- ユニット/実DB統合テストを新挙動に更新。特に **ケース3: ワイヤー完了・デザイン未TOSS → デザインの実施者(FROM)**、**ケース4: デザイン手動TOSS → デザインの確認者(TO)** を実DBで検証。

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)