### PR TITLE
feat(auth): パスワードユーザーのメールアドレス変更機能 (#129)

### DIFF
--- a/apps/web/server/services/auth.test.ts
+++ b/apps/web/server/services/auth.test.ts
@@ -307,6 +307,52 @@ describe('syncUser', () => {
       details: { primaryAuthMethod: 'password' },
     });
   });
+
+  it('reconciles users.email when the JWT email differs (email change confirmed) and audits it', async () => {
+    userStore['auth-ec'] = {
+      id: 'u-ec',
+      authUserId: 'auth-ec',
+      email: 'old@example.com',
+      fullName: 'E',
+      displayName: 'E',
+      primaryAuthMethod: 'password',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      deletedAt: null,
+    };
+    const res = await syncUser('auth-ec', 'new@example.com');
+    expect(res.status).toBe('ready');
+    if (res.status === 'ready') {
+      expect(res.user.id).toBe('u-ec');
+      expect(res.user.email).toBe('new@example.com');
+    }
+    expect(userStore['auth-ec']!.email).toBe('new@example.com');
+    expect(auditStore).toHaveLength(1);
+    expect(auditStore[0]).toMatchObject({
+      actorUserId: 'u-ec',
+      action: 'email_changed',
+      resourceType: 'user',
+      extra: { previousEmail: 'old@example.com' },
+    });
+    // Supabase admin を叩かず (JWT email のみで) 追随する
+    expect(getUserByIdMock).not.toHaveBeenCalled();
+  });
+
+  it('does not reconcile or audit when the JWT email only differs in case', async () => {
+    userStore['auth-eq'] = {
+      id: 'u-eq',
+      authUserId: 'auth-eq',
+      email: 'Same@Example.com',
+      fullName: 'S',
+      displayName: 'S',
+      primaryAuthMethod: 'password',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      deletedAt: null,
+    };
+    const res = await syncUser('auth-eq', 'same@example.com');
+    expect(res.status).toBe('ready');
+    if (res.status === 'ready') expect(res.user.email).toBe('Same@Example.com');
+    expect(auditStore).toHaveLength(0);
+  });
 });
 
 describe('completeSignup', () => {

--- a/apps/web/server/services/auth.ts
+++ b/apps/web/server/services/auth.ts
@@ -92,7 +92,12 @@ export async function syncUser(authUserId: string, jwtEmail: string): Promise<Sy
   const existing = await prisma.user.findUnique({ where: { authUserId } });
   // 退会済み (deletedAt) は未存在として扱い、ready を返さない (締め出し)。
   if (existing && !existing.deletedAt) {
-    return { status: 'ready', user: toDTO(existing) };
+    // メールアドレス変更 (#129) の同期。パスワードユーザーが Supabase 組み込みの
+    // email 変更フロー (updateUser({ email }) → 新旧両アドレス確認) を完了すると
+    // auth.users.email が変わり JWT の email クレームも新メールになる。public.users.email は
+    // ここで追随させる (webhook を使わず、次回 sync でリコンサイルする)。
+    const reconciled = await reconcileEmailIfChanged(existing, jwtEmail);
+    return { status: 'ready', user: toDTO(reconciled) };
   }
 
   const supabase = getSupabaseAdmin();
@@ -155,6 +160,47 @@ export async function syncUser(authUserId: string, jwtEmail: string): Promise<Sy
   });
 
   return { status: 'ready', user: toDTO(created) };
+}
+
+type UserRow = NonNullable<Awaited<ReturnType<typeof prisma.user.findUnique>>>;
+
+/**
+ * JWT (= auth.users) の email が public.users.email と食い違う場合に追随させる (#129)。
+ * メールアドレス変更フロー (Supabase 組み込み) 完了後の同期点。変更が無ければ何もしない。
+ *
+ * email は @unique。理論上 auth.users 側でも一意なので衝突しないが、万一の一意制約違反
+ * (P2002) では sync 自体を落とさず旧行のまま返す (ログインを止めない best-effort 同期)。
+ */
+async function reconcileEmailIfChanged(user: UserRow, jwtEmail: string): Promise<UserRow> {
+  if (!jwtEmail || user.email.toLowerCase() === jwtEmail.toLowerCase()) {
+    return user;
+  }
+  const previousEmail = user.email;
+  try {
+    const [updated] = await prisma.$transaction([
+      prisma.user.update({
+        where: { id: user.id },
+        data: { email: jwtEmail },
+      }),
+      prisma.auditLog.create({
+        data: {
+          actorUserId: user.id,
+          action: 'email_changed',
+          resourceType: 'user',
+          resourceId: user.id,
+          result: 'success',
+          extra: { previousEmail },
+        },
+      }),
+    ]);
+    return updated;
+  } catch (err) {
+    if ((err as { code?: string }).code === 'P2002') {
+      console.error('[syncUser] email reconcile skipped (unique conflict):', jwtEmail);
+      return user;
+    }
+    throw err;
+  }
 }
 
 /**

--- a/apps/web/src/features/auth/ProfileModal.test.tsx
+++ b/apps/web/src/features/auth/ProfileModal.test.tsx
@@ -5,14 +5,16 @@ import { http, HttpResponse } from 'msw';
 
 // supabase は apiRequest の Authorization 注入で getSession を呼ぶためモックする。
 // 退会成功時の signOut({ scope: 'local' }) も捕捉する。
-const { signOutMock } = vi.hoisted(() => ({
+const { signOutMock, updateUserMock } = vi.hoisted(() => ({
   signOutMock: vi.fn().mockResolvedValue({ error: null }),
+  updateUserMock: vi.fn().mockResolvedValue({ data: { user: {} }, error: null }),
 }));
 vi.mock('@/lib/supabase', () => ({
   supabase: {
     auth: {
       getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
       signOut: signOutMock,
+      updateUser: updateUserMock,
     },
   },
 }));
@@ -48,6 +50,8 @@ const user: CurrentUser = {
 beforeEach(() => {
   toastSuccess.mockReset();
   toastError.mockReset();
+  updateUserMock.mockClear();
+  updateUserMock.mockResolvedValue({ data: { user: {} }, error: null });
 });
 
 describe('ProfileModal', () => {
@@ -188,6 +192,64 @@ describe('ProfileModal', () => {
     expect(body).toEqual({ newPassword: 'abcd1234!' });
   });
 
+  it('メールアドレス変更 → 新メール入力で supabase.updateUser を呼び成功トーストを出す', async () => {
+    const u = userEvent.setup({ pointerEventsCheck: 0 });
+    renderWithProviders(
+      <ProfileModal user={user} open onClose={() => {}} onSignOut={() => {}} />,
+    );
+
+    await u.click(screen.getByRole('button', { name: 'メールアドレスを変更' }));
+    const input = await screen.findByPlaceholderText('new@example.com');
+    await u.type(input, 'next@example.com');
+    await u.click(screen.getByRole('button', { name: '確認メールを送信' }));
+
+    await waitFor(() => expect(updateUserMock).toHaveBeenCalledTimes(1));
+    expect(updateUserMock).toHaveBeenCalledWith(
+      { email: 'next@example.com' },
+      { emailRedirectTo: expect.stringContaining('/auth/callback') },
+    );
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining('確認メールを送信しました')),
+    );
+  });
+
+  it('現在と同じメールアドレスはバリデーションエラーを出し supabase を呼ばない', async () => {
+    const u = userEvent.setup({ pointerEventsCheck: 0 });
+    renderWithProviders(
+      <ProfileModal user={user} open onClose={() => {}} onSignOut={() => {}} />,
+    );
+
+    await u.click(screen.getByRole('button', { name: 'メールアドレスを変更' }));
+    const input = await screen.findByPlaceholderText('new@example.com');
+    await u.type(input, 'me@example.com');
+    await u.click(screen.getByRole('button', { name: '確認メールを送信' }));
+
+    expect(await screen.findByText('現在のメールアドレスと同じです')).toBeInTheDocument();
+    expect(updateUserMock).not.toHaveBeenCalled();
+  });
+
+  it('supabase.updateUser がエラーを返すとエラートーストを出す', async () => {
+    updateUserMock.mockResolvedValueOnce({
+      data: { user: null },
+      error: new Error('A user with this email address has already been registered'),
+    });
+    const u = userEvent.setup({ pointerEventsCheck: 0 });
+    renderWithProviders(
+      <ProfileModal user={user} open onClose={() => {}} onSignOut={() => {}} />,
+    );
+
+    await u.click(screen.getByRole('button', { name: 'メールアドレスを変更' }));
+    const input = await screen.findByPlaceholderText('new@example.com');
+    await u.type(input, 'taken@example.com');
+    await u.click(screen.getByRole('button', { name: '確認メールを送信' }));
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        'A user with this email address has already been registered',
+      ),
+    );
+  });
+
   it('退会する → 理由選択＋「退会」入力で DELETE /auth/me を送り local signOut する', async () => {
     let body: { reason?: string } | null = null;
     server.use(
@@ -243,7 +305,7 @@ describe('ProfileModal', () => {
     expect(signOutMock).not.toHaveBeenCalled();
   });
 
-  it('OAuth ユーザーにはパスワード変更ボタンを出さない', () => {
+  it('OAuth ユーザーにはパスワード変更・メールアドレス変更ボタンを出さない', () => {
     renderWithProviders(
       <ProfileModal
         user={{ ...user, primaryAuthMethod: 'google' }}
@@ -255,6 +317,9 @@ describe('ProfileModal', () => {
     expect(screen.getByText('Google')).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'パスワードを変更' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'メールアドレスを変更' }),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/auth/ProfileModal.tsx
+++ b/apps/web/src/features/auth/ProfileModal.tsx
@@ -30,7 +30,7 @@ const AUTH_METHOD_LABEL: Record<CurrentUser['primaryAuthMethod'], string> = {
   microsoft: 'Microsoft',
 };
 
-type Mode = 'view' | 'profile' | 'password' | 'withdraw';
+type Mode = 'view' | 'profile' | 'email' | 'password' | 'withdraw';
 
 /**
  * プロフィール / 認証情報モーダル (プロトタイプ ProfileModal 準拠)。
@@ -62,11 +62,13 @@ export function ProfileModal({
           <DialogDescription>
             {mode === 'password'
               ? 'パスワードを変更します。'
-              : mode === 'profile'
-                ? 'お名前と表示名を変更します。'
-                : mode === 'withdraw'
-                  ? 'アカウントを退会します。この操作は取り消せません。'
-                  : 'プロフィール情報を確認・編集できます。'}
+              : mode === 'email'
+                ? 'メールアドレスを変更します。確認メールで変更を確定します。'
+                : mode === 'profile'
+                  ? 'お名前と表示名を変更します。'
+                  : mode === 'withdraw'
+                    ? 'アカウントを退会します。この操作は取り消せません。'
+                    : 'プロフィール情報を確認・編集できます。'}
           </DialogDescription>
         </DialogHeader>
 
@@ -74,6 +76,7 @@ export function ProfileModal({
           <ViewMode
             user={user}
             onEdit={() => setMode('profile')}
+            onChangeEmail={() => setMode('email')}
             onChangePassword={() => setMode('password')}
             onWithdraw={() => setMode('withdraw')}
             onSignOut={onSignOut}
@@ -81,6 +84,7 @@ export function ProfileModal({
           />
         )}
         {mode === 'profile' && <ProfileForm user={user} onDone={() => setMode('view')} />}
+        {mode === 'email' && <EmailForm user={user} onDone={() => setMode('view')} />}
         {mode === 'password' && <PasswordForm onDone={() => setMode('view')} />}
         {mode === 'withdraw' && <WithdrawForm onCancel={() => setMode('view')} />}
       </DialogContent>
@@ -91,6 +95,7 @@ export function ProfileModal({
 function ViewMode({
   user,
   onEdit,
+  onChangeEmail,
   onChangePassword,
   onWithdraw,
   onSignOut,
@@ -98,6 +103,7 @@ function ViewMode({
 }: {
   user: CurrentUser;
   onEdit: () => void;
+  onChangeEmail: () => void;
   onChangePassword: () => void;
   onWithdraw: () => void;
   onSignOut: () => void;
@@ -129,6 +135,11 @@ function ViewMode({
         <Button variant="outline" size="sm" onClick={onEdit}>
           プロフィールを編集
         </Button>
+        {user.primaryAuthMethod === 'password' && (
+          <Button variant="outline" size="sm" onClick={onChangeEmail}>
+            メールアドレスを変更
+          </Button>
+        )}
         {user.primaryAuthMethod === 'password' && (
           <Button variant="outline" size="sm" onClick={onChangePassword}>
             パスワードを変更
@@ -198,6 +209,83 @@ function ProfileForm({ user, onDone }: { user: CurrentUser; onDone: () => void }
         <Button type="submit" disabled={mut.isPending}>
           {mut.isPending && <Loader2 className="size-4 animate-spin" />}
           保存
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+const emailSchema = (currentEmail: string) =>
+  z.object({
+    newEmail: z
+      .string()
+      .trim()
+      .min(1, 'メールアドレスは必須')
+      .email('メールアドレスの形式が正しくありません')
+      .refine((v) => v.toLowerCase() !== currentEmail.toLowerCase(), {
+        message: '現在のメールアドレスと同じです',
+      }),
+  });
+type EmailValues = { newEmail: string };
+
+/**
+ * メールアドレス変更フォーム (パスワード認証ユーザーのみ, #129)。
+ *
+ * Supabase 組み込みの email 変更フローを利用する。`updateUser({ email })` を呼ぶと
+ * `double_confirm_changes = true` により新旧両アドレスへ確認メール (Resend SMTP 経由) が届く。
+ * ユーザーが両方のリンクを確定すると auth.users.email が変わり、次回 `/auth/me/sync` で
+ * public.users.email が追随する (server: reconcileEmailIfChanged)。確認リンクは
+ * `emailRedirectTo` (= /auth/callback) に着地し、そこで sync が走る。
+ */
+function EmailForm({ user, onDone }: { user: CurrentUser; onDone: () => void }) {
+  const form = useForm<EmailValues>({
+    resolver: zodResolver(emailSchema(user.email)),
+    defaultValues: { newEmail: '' },
+  });
+
+  const mut = useMutation({
+    mutationFn: async (v: EmailValues) => {
+      const { error } = await supabase.auth.updateUser(
+        { email: v.newEmail.trim() },
+        { emailRedirectTo: `${window.location.origin}/auth/callback` },
+      );
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success(
+        '確認メールを送信しました。現在のアドレスと新しいアドレスの両方に届くリンクから変更を確定してください。',
+      );
+      onDone();
+    },
+    onError: (e) =>
+      toast.error(e instanceof Error ? e.message : 'メールアドレスの変更に失敗しました'),
+  });
+
+  return (
+    <form onSubmit={form.handleSubmit((v) => mut.mutate(v))} className="space-y-3">
+      <div className="space-y-1.5">
+        <Label>現在のメールアドレス</Label>
+        <p className="text-sm text-muted-foreground">{user.email}</p>
+      </div>
+      <FormField label="新しいメールアドレス" error={form.formState.errors.newEmail?.message}>
+        <Input
+          type="email"
+          autoComplete="email"
+          autoFocus
+          placeholder="new@example.com"
+          {...form.register('newEmail')}
+        />
+      </FormField>
+      <p className="text-xs text-muted-foreground">
+        変更を確定するには、現在のアドレスと新しいアドレスの両方に届く確認メールのリンクを開く必要があります。
+      </p>
+      <DialogFooter>
+        <Button type="button" variant="ghost" onClick={onDone} disabled={mut.isPending}>
+          キャンセル
+        </Button>
+        <Button type="submit" disabled={mut.isPending}>
+          {mut.isPending && <Loader2 className="size-4 animate-spin" />}
+          確認メールを送信
         </Button>
       </DialogFooter>
     </form>

--- a/docs/design/implementation-notes.md
+++ b/docs/design/implementation-notes.md
@@ -18,6 +18,7 @@ Sub-Phase 0.0〜0.6 の実装過程で、基本設計書 v1.1 から意図的に
 | **マイグレーション diff の自動生成** | `prisma migrate dev` 推奨 | **手書き SQL** で CHECK 制約・トリガを明示 | `prisma migrate dev` だけでは CHECK / トリガ / 部分インデックスを自動生成できない | 設計書 §6.9 に追記想定 |
 | **Supabase キー新方式移行（Phase 1 直前）** | 設計書 §6 は Legacy API keys（`anon` JWT / `service_role` JWT）前提 | **新方式 `sb_publishable_*` / `sb_secret_*` へ移行**。BE 側 env は `SUPABASE_SECRET_KEY` 優先 / `SUPABASE_SERVICE_ROLE_KEY` フォールバック、FE 側は `VITE_SUPABASE_PUBLISHABLE_KEY` に完全切替。JWT 署名キーとは独立管理になったため、`server/middleware/auth.ts` の iss/aud/JWKS 検証ロジックは不変 | Supabase Legacy API keys は 2026 年末でサポート終了予定。商用デプロイ前に新方式へ寄せて将来負債を回避。supabase-js は ^2.106.2 へ更新（新キー形式は apikey ヘッダーに渡すだけで透過対応） | 設計書 v1.2 § 6 環境変数表を新方式に書き換え |
 | **認証メールのブランド統制（§5.3.2）** | Supabase 標準メールを OFF にし **auth Webhook 経由で Resend 送信**、テンプレは `server/lib/mail/` でコード管理 | **Supabase Custom SMTP に Resend を設定**し、件名/本文は Supabase Email Templates、from は SMTP 送信者設定で管理 | Webhook + Send Email Hook 実装より大幅に軽量。レート制限解消（デフォルト共有 SMTP 脱却）とブランド文言変更を設定作業のみで両立。手順は `operations.md §2.4.2` | 文言をコード/i18n で一元管理したくなれば Send Email Hook 方式へ移行 |
+| **メールアドレス変更（#129）** | §5.3.9.5 は OAuth のメール変更を Webhook で片方向同期する想定 | **パスワードユーザーのみ実装**。FE `supabase.auth.updateUser({ email })`（`double_confirm_changes=true` で新旧両アドレスへ Resend 経由の確認メール）→ 確認後 `/auth/callback` 着地で `/auth/me/sync` が走り、`syncUser` の `reconcileEmailIfChanged` が `public.users.email` を JWT(=auth.users) に追随。Webhook は使わない | Supabase 組み込みフローを使うため BE の変更点は sync のリコンサイル 1 箇所のみ。監査は `email_changed`（`extra.previousEmail`）。OAuth ユーザーの変更 UI は非表示 | OAuth のメール変更（下記参照）と、必要なら変更完了の Resend 通知メール |
 
 ## 設計書 v1.2 で追加・改訂すべき項目（提案）
 
@@ -26,6 +27,30 @@ Sub-Phase 0.0〜0.6 の実装過程で、基本設計書 v1.1 から意図的に
 3. **`source='share'`**：`ck_be_actor_consistency` を 3 値 (`human`/`auto_chain`/`share`) に拡張する DDL を予約
 4. **削除セマンティクス**：plan の物理削除は `ball_events` が無い場合のみ可能、キャンセル機能は Phase 1 で `status='canceled'` を使う
 5. **shadcn 取り込み**：プロトタイプから流用する場合の `"use client"` の扱い指針
+
+## OAuth ユーザーのメールアドレス変更（#129・未実装 / 方針メモ）
+
+パスワードユーザーのメール変更は本 PR で実装済み。OAuth（Google/Microsoft）ユーザーの
+メール変更は、issue #129 で「良い方針があれば検討したい」とされた探索項目であり、**本 PR では
+未実装**。以下は検討結果と将来方針。
+
+- **ユースケース**（issue 記載）：フリー Gmail → Google Workspace への切替でメールが変わっても、
+  TRAKON アカウントは同一のまま使い続けたい。
+- **難所**：OAuth のメールは**プロバイダが正**であり、`updateUser({ email })` では変えられない。
+  さらに Gmail → Workspace は**別の Google アカウント**（`identities[].id` が別物）になるため、
+  実体は「別 OAuth アイデンティティを既存 TRAKON ユーザーへ**再リンク / 移行**する」問題。
+  現行 `syncUser` は新しい `auth_user_id` を**新規ユーザー**として作るため、そのままでは別アカウント化する。
+- **想定アプローチ（いずれも Phase 1+）**：
+  1. **アカウント連携（推奨）**：ログイン中に「別の Google/Microsoft を連携」させ、
+     `oauth_identities` に 2 つ目の provider identity を追加。ログインは複数 identity → 同一
+     `users.id` に解決。`primaryAuthMethod` は据え置き。UI とセキュリティ（乗っ取り防止の再認証）設計が要る。
+  2. **メール到達性ベースの移行**：新メールに確認メール（Resend）を送り、確定後に
+     `users.email` と `oauth_identities.email`、必要なら `auth_user_id` を張り替える。実装は重い。
+  3. **プロバイダ側メール変更の片方向同期**：同一 Google アカウントのプライマリメールだけが変わる
+     ケースに限り、§5.3.9.5 の Webhook 同期で `users.email` / `oauth_identities.email` を追随
+     （別アカウント移行は対象外）。本 PR の `reconcileEmailIfChanged` は JWT email が変われば
+     provider を問わず `users.email` を追随するため、この片方向同期の一部は既に満たしている。
+- **結論**：安全な UX を伴う「アカウント連携」を第一候補として別 issue 化する。
 
 ## 各サブフェーズで生まれた追加成果物
 

--- a/packages/db/prisma/migrations/20260712000001_add_email_changed_action/migration.sql
+++ b/packages/db/prisma/migrations/20260712000001_add_email_changed_action/migration.sql
@@ -1,0 +1,31 @@
+-- -----------------------------------------------------------------------------
+-- Migration: 20260712000001_add_email_changed_action
+-- メールアドレス変更機能 (#129) のため、audit_logs.action に 'email_changed' を追加する。
+--  - email_changed: パスワード認証ユーザーが Supabase 組み込みの email 変更フロー
+--    (updateUser({ email }) → 新旧両アドレス確認メール) を完了し、public.users.email を
+--    新メールへ同期 (syncUser) した際の監査アクション。旧メールは
+--    audit_logs.extra.previousEmail に格納する。
+-- この値が ck_al_action CHECK 制約に含まれていないと INSERT が CHECK 違反で失敗する。
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE "audit_logs" DROP CONSTRAINT "ck_al_action";
+
+ALTER TABLE "audit_logs"
+  ADD CONSTRAINT "ck_al_action" CHECK ("action" IN (
+    'login',
+    'logout',
+    'complete_signup',
+    'update_profile',
+    'email_changed',
+    'account_delete',
+    'toss',
+    'untoss',
+    'complete',
+    'undo_complete',
+    'auto_toss',
+    'share_access',
+    'share_create',
+    'share_revoke',
+    'share_toss',
+    'share_complete'
+  ));

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -264,7 +264,7 @@ model AuditLog {
   actorUserId  String?  @map("actor_user_id") @db.Uuid
   /// share_links FK は Sub-Phase 0.5 で実装 (share_links テーブル追加時)
   shareLinkId  String?  @map("share_link_id") @db.Uuid
-  /// Phase 0 許可値: login | logout | complete_signup | update_profile | account_delete | toss | untoss | complete | undo_complete | auto_toss | share_access | share_create | share_revoke | share_toss | share_complete
+  /// Phase 0 許可値: login | logout | complete_signup | update_profile | email_changed | account_delete | toss | untoss | complete | undo_complete | auto_toss | share_access | share_create | share_revoke | share_toss | share_complete
   action       String
   resourceType String   @map("resource_type")
   resourceId   String?  @map("resource_id") @db.Uuid


### PR DESCRIPTION
Closes #129

## 概要
メール+パスワードでログインするユーザーが、アプリ内からメールアドレスを変更できるようにします。実装は既存の設計方針（`docs/email-templates.md §4` の変更確認メールテンプレート、`supabase/config.toml` の `double_confirm_changes = true`）に準拠し、**Supabase 組み込みの email 変更フロー + Resend 経由の確認メール**を利用します。自前トークン管理は追加しません。

OAuth（Google/Microsoft）ユーザーのメール変更は issue で「良い方針があれば検討したい」とされた探索項目のため、**本 PR では未実装**。検討結果と将来方針を `docs/design/implementation-notes.md` に記載しました（要点: 実質的にアカウント連携/移行の問題なので別 issue 化を推奨）。

## 変更点
- **FE** `apps/web/src/features/auth/ProfileModal.tsx`
  - アカウントモーダルに「メールアドレスを変更」モードを追加（`primaryAuthMethod === 'password'` のユーザーのみ表示。パスワード変更ボタンと同じガード）。
  - `supabase.auth.updateUser({ email }, { emailRedirectTo: /auth/callback })` を呼び、新旧両アドレスへ確認メールを送信。バリデーション（形式・現メールとの同一チェック）と成功/失敗トーストを実装。
- **BE** `apps/web/server/services/auth.ts`
  - `syncUser` に `reconcileEmailIfChanged` を追加。ユーザーが両アドレスの確認リンクを開くと `auth.users.email`（＝JWT の email クレーム）が新メールになるので、次回 `/auth/me/sync`（`/auth/callback` 着地時に実行）で `public.users.email` を追随させる。**Webhook 不要**。
  - 監査ログ `email_changed`（`extra.previousEmail`）を記録。`email` は `@unique` のため、万一の一意制約違反（P2002）では sync を落とさず旧値のまま返す best-effort。
  - リコンサイルは provider を問わず「auth.users を正としたミラー同期」として機能します（OAuth 再リンク機能ではありません）。
- **DB** `packages/db/prisma/migrations/20260712000001_add_email_changed_action/`
  - `audit_logs.action` の CHECK 制約に `email_changed` を追加（既存 `account_delete` 追加と同一パターンの手書き SQL）。`schema.prisma` の許可値コメントも更新。
- **Docs** `docs/design/implementation-notes.md`
  - 実装方針の差分行と、OAuth メール変更の検討メモ（未実装・将来方針）を追記。

## フロー
1. パスワードユーザーがモーダルで新メールを入力 → `supabase.auth.updateUser({ email })`。
2. Supabase が新旧両アドレスへ確認メール（Resend SMTP 経由、テンプレは `email-templates.md §4`）を送信。
3. ユーザーが両方のリンクを開く → `auth.users.email` 更新 → `/auth/callback` 着地。
4. 着地時の `/auth/me/sync` で `reconcileEmailIfChanged` が `public.users.email` を追随、`email_changed` を監査記録。

## テスト
- `pnpm type-check` / `pnpm lint`（zero-warnings）/ `pnpm test`（609 passed）すべて green。
- 追加テスト:
  - `auth.test.ts`: JWT email が変わった時に `users.email` を追随し `email_changed` を監査すること／大文字小文字違いだけなら追随・監査しないこと。
  - `ProfileModal.test.tsx`: 新メール入力で `updateUser` を正しい引数で呼ぶ／現メールと同一はバリデーションで送信しない／Supabase エラー時にエラートースト／OAuth ユーザーには変更ボタンを出さない。

## デプロイ時の前提（コード外）
- 本番でも確認メールが Resend で届くには、既存ドキュメント（`operations.md §2.4.2`）どおり **Supabase Custom SMTP = Resend** が設定済みである必要があります（サインアップ確認・パスワード再設定と同じ経路。新規の本番設定は不要）。
- Supabase Dashboard の **Email Templates → Change Email Address** に `email-templates.md §4` のテンプレートを貼り付け（未貼付でも Supabase 既定文面で機能はします）。
- リダイレクト許可 URL に `/auth/callback` が含まれること（既存フローと共通）。

## レビュー観点
- リコンサイルを全 provider に効かせている点（OAuth もミラー同期される）が意図どおりか。パスワードユーザー限定にしたい場合は `primaryAuthMethod === 'password'` ガードを追加します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)