### PR TITLE
feat(plans): 予定に実施者/承認者/進行責任者の役割列を追加 (#131 PR1)

### DIFF
--- a/packages/db/prisma/migrations/20260724000001_add_plan_roles/migration.sql
+++ b/packages/db/prisma/migrations/20260724000001_add_plan_roles/migration.sql
@@ -1,0 +1,150 @@
+-- -----------------------------------------------------------------------------
+-- Migration: 20260724000001_add_plan_roles
+-- issue #131「確認者付き予定と進行責任者の追加」PR1: DB 土台。
+--
+-- 目的:
+--   予定に 3 つの役割 (実施者 executor / 承認者 approver / 進行責任者 progressManager)
+--   を持たせ、ボールの状態機械を「実施中 → 確認待ち → 承認済み → TOSS済み」へ拡張する
+--   ための列・制約・イベント種別を追加する。UI/サービス層の切替は後続 PR。
+--
+-- 実データ影響 (精査済み・破壊的操作なし):
+--   * 追加する列はすべて nullable UUID。既存行は NULL が入るだけ (テーブル書き換えなし)。
+--   * 既存 from_member_id / to_member_id は残す (併存)。DROP COLUMN / DELETE は無い。
+--   * CHECK 変更は許可値の「追加」= スーパーセットのため、既存の全行が新制約を満たす。
+--   * 新 FK は既存同様 ON DELETE RESTRICT。値は NULL か有効メンバー由来なので拒否されない。
+--   * バックフィルは「新列を埋めるだけ」で既存列は書き換えない。updated_at を保持するため
+--     set_updated_at トリガを一時 DISABLE する。
+-- -----------------------------------------------------------------------------
+
+-- =============================================================================
+-- 1. 列の追加 (nullable, 非破壊)
+-- =============================================================================
+ALTER TABLE "projects"
+  ADD COLUMN "progress_manager_member_id" UUID;
+
+ALTER TABLE "plans"
+  ADD COLUMN "executor_member_id"         UUID,
+  ADD COLUMN "approver_member_id"         UUID,
+  ADD COLUMN "progress_manager_member_id" UUID;
+
+COMMENT ON COLUMN "projects"."progress_manager_member_id" IS '予定作成時の進行責任者の既定値 (#131)';
+COMMENT ON COLUMN "plans"."executor_member_id"         IS '実施者 (#131)';
+COMMENT ON COLUMN "plans"."approver_member_id"         IS '承認者 (#131, 任意)';
+COMMENT ON COLUMN "plans"."progress_manager_member_id" IS '進行責任者 (#131)';
+COMMENT ON COLUMN "plans"."from_member_id" IS 'TOSS 履歴スナップショット FROM=TOSS した進行責任者 (#131 §14)';
+COMMENT ON COLUMN "plans"."to_member_id"   IS 'TOSS 履歴スナップショット TO=後続予定の実施者 (#131 §14)';
+
+-- =============================================================================
+-- 2. インデックス
+-- =============================================================================
+CREATE INDEX "idx_plans_executor_member"         ON "plans"("executor_member_id");
+CREATE INDEX "idx_plans_progress_manager_member" ON "plans"("progress_manager_member_id");
+
+-- =============================================================================
+-- 3. CHECK 制約の拡張 (許可値の追加 = スーパーセット)
+-- =============================================================================
+-- 3a. ball_events.event_type に #131 の新イベントを追加
+ALTER TABLE "ball_events" DROP CONSTRAINT "ck_be_event_type";
+ALTER TABLE "ball_events"
+  ADD CONSTRAINT "ck_be_event_type" CHECK ("event_type" IN (
+    'tossed',
+    'completed',
+    'toss_undone',
+    'completion_undone',
+    'review_requested',
+    'approved',
+    'sent_back',
+    'review_request_undone',
+    'approval_undone'
+  ));
+
+-- 3b. audit_logs.action に #131 の新アクションを追加
+ALTER TABLE "audit_logs" DROP CONSTRAINT "ck_al_action";
+ALTER TABLE "audit_logs"
+  ADD CONSTRAINT "ck_al_action" CHECK ("action" IN (
+    'login',
+    'logout',
+    'complete_signup',
+    'update_profile',
+    'email_changed',
+    'account_delete',
+    'toss',
+    'untoss',
+    'complete',
+    'undo_complete',
+    'auto_toss',
+    'request_review',
+    'undo_request_review',
+    'approve',
+    'undo_approve',
+    'send_back',
+    'share_access',
+    'share_create',
+    'share_revoke',
+    'share_toss',
+    'share_complete'
+  ));
+
+-- 3c. ck_plans_toss_members を撤去。
+--   旧制約は from/to を「実施者/確認者」として from <> to を強制していたが、#131 では
+--   from/to は TOSS 履歴スナップショット (進行責任者→後続実施者) に意味が変わり、かつ
+--   1 人が複数役割を兼ねうる (§5) ため from = to もありうる。役割相違制約は課さない。
+ALTER TABLE "plans" DROP CONSTRAINT "ck_plans_toss_members";
+
+-- =============================================================================
+-- 4. バックフィル (新列のみ書き込み。updated_at 保持のためトリガを一時停止)
+-- =============================================================================
+ALTER TABLE "plans"    DISABLE TRIGGER "trg_plans_set_updated_at";
+ALTER TABLE "projects" DISABLE TRIGGER "trg_projects_set_updated_at";
+
+-- 4a. 実施者 ← 旧 FROM (from_member_id は既に FK 有効)
+UPDATE "plans"
+  SET "executor_member_id" = "from_member_id"
+  WHERE "from_member_id" IS NOT NULL;
+
+-- 4b. プロジェクト既定の進行責任者 ← 作成者(created_by)の該当メンバー行 (無ければ NULL)
+UPDATE "projects" AS p
+  SET "progress_manager_member_id" = pm."id"
+  FROM "project_members" AS pm
+  WHERE pm."project_id" = p."id"
+    AND pm."user_id"    = p."created_by"
+    AND pm."deleted_at" IS NULL;
+
+-- 4c. 既存予定の進行責任者 ← 作成者の該当メンバー行 (item → project 経由。無ければ NULL)。
+--     既存予定を新ルール (承認→TOSS) で操作可能にするため。
+UPDATE "plans" AS pl
+  SET "progress_manager_member_id" = pm."id"
+  FROM "project_items" AS pi
+  JOIN "projects"        AS p  ON p."id"  = pi."project_id"
+  JOIN "project_members" AS pm ON pm."project_id" = p."id"
+                              AND pm."user_id"    = p."created_by"
+                              AND pm."deleted_at" IS NULL
+  WHERE pl."item_id" = pi."id";
+
+-- approver_member_id は NULL のまま (旧 TO は "確認者" ではなく "次工程" 相当のため移さない)
+
+ALTER TABLE "plans"    ENABLE TRIGGER "trg_plans_set_updated_at";
+ALTER TABLE "projects" ENABLE TRIGGER "trg_projects_set_updated_at";
+
+-- =============================================================================
+-- 5. 外部キー (バックフィル後に追加し、実データを検証)
+-- =============================================================================
+ALTER TABLE "projects"
+  ADD CONSTRAINT "fk_projects_progress_manager_member_id"
+  FOREIGN KEY ("progress_manager_member_id") REFERENCES "project_members"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "plans"
+  ADD CONSTRAINT "fk_plans_executor_member_id"
+  FOREIGN KEY ("executor_member_id") REFERENCES "project_members"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "plans"
+  ADD CONSTRAINT "fk_plans_approver_member_id"
+  FOREIGN KEY ("approver_member_id") REFERENCES "project_members"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "plans"
+  ADD CONSTRAINT "fk_plans_progress_manager_member_id"
+  FOREIGN KEY ("progress_manager_member_id") REFERENCES "project_members"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -54,25 +54,28 @@ model User {
 // 設計書 §2.4.2
 // -----------------------------------------------------------------------------
 model Project {
-  id             String    @id @default(uuid(7)) @db.Uuid
-  organizationId String?   @map("organization_id") @db.Uuid
-  name           String
-  startDate      DateTime  @map("start_date") @db.Date
-  endDate        DateTime  @map("end_date") @db.Date
+  id                      String    @id @default(uuid(7)) @db.Uuid
+  organizationId          String?   @map("organization_id") @db.Uuid
+  name                    String
+  startDate               DateTime  @map("start_date") @db.Date
+  endDate                 DateTime  @map("end_date") @db.Date
   /// 'active' | 'closed' (CHECK 制約)
-  status         String    @default("active")
-  createdBy      String    @map("created_by") @db.Uuid
-  closedAt       DateTime? @map("closed_at") @db.Timestamptz
-  archivedAt     DateTime? @map("archived_at") @db.Timestamptz
-  deletedAt      DateTime? @map("deleted_at") @db.Timestamptz
-  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt      DateTime  @default(now()) @map("updated_at") @db.Timestamptz
+  status                  String    @default("active")
+  createdBy               String    @map("created_by") @db.Uuid
+  /// 予定作成時の進行責任者(progressManager)の既定値 (#131)。予定ごとに変更可
+  progressManagerMemberId String?   @map("progress_manager_member_id") @db.Uuid
+  closedAt                DateTime? @map("closed_at") @db.Timestamptz
+  archivedAt              DateTime? @map("archived_at") @db.Timestamptz
+  deletedAt               DateTime? @map("deleted_at") @db.Timestamptz
+  createdAt               DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt               DateTime  @default(now()) @map("updated_at") @db.Timestamptz
 
-  creator     User            @relation("ProjectsCreatedBy", fields: [createdBy], references: [id], onDelete: Restrict, map: "fk_projects_created_by")
-  members     ProjectMember[]
-  items       ProjectItem[]
-  invitations Invitation[]
-  shareLinks  ShareLink[]
+  creator         User            @relation("ProjectsCreatedBy", fields: [createdBy], references: [id], onDelete: Restrict, map: "fk_projects_created_by")
+  progressManager ProjectMember?  @relation("ProjectProgressManager", fields: [progressManagerMemberId], references: [id], onDelete: Restrict, map: "fk_projects_progress_manager_member_id")
+  members         ProjectMember[]
+  items           ProjectItem[]
+  invitations     Invitation[]
+  shareLinks      ShareLink[]
 
   @@index([organizationId], map: "idx_projects_organization_id")
   @@index([createdBy, status], map: "idx_projects_created_by_status")
@@ -102,13 +105,17 @@ model ProjectMember {
   createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt        DateTime  @default(now()) @map("updated_at") @db.Timestamptz
 
-  project           Project      @relation(fields: [projectId], references: [id], onDelete: Cascade, map: "fk_pm_project_id")
-  user              User?        @relation(fields: [userId], references: [id], onDelete: SetNull, map: "fk_pm_user_id")
-  invitations       Invitation[]
-  plansFrom         Plan[]       @relation("PlanFromMember")
-  plansTo           Plan[]       @relation("PlanToMember")
-  ballEventsAsActor BallEvent[]
-  shareLinksIssued  ShareLink[]
+  project               Project      @relation(fields: [projectId], references: [id], onDelete: Cascade, map: "fk_pm_project_id")
+  user                  User?        @relation(fields: [userId], references: [id], onDelete: SetNull, map: "fk_pm_user_id")
+  invitations           Invitation[]
+  plansFrom             Plan[]       @relation("PlanFromMember")
+  plansTo               Plan[]       @relation("PlanToMember")
+  plansAsExecutor       Plan[]       @relation("PlanExecutor")
+  plansAsApprover       Plan[]       @relation("PlanApprover")
+  plansAsProgressMgr    Plan[]       @relation("PlanProgressManager")
+  projectsAsProgressMgr Project[]    @relation("ProjectProgressManager")
+  ballEventsAsActor     BallEvent[]
+  shareLinksIssued      ShareLink[]
 
   @@unique([projectId, email], map: "uq_pm_project_email")
   @@index([projectId, sortOrder], map: "idx_pm_project_sort")
@@ -145,35 +152,48 @@ model ProjectItem {
 // 設計書 §2.4.5
 // -----------------------------------------------------------------------------
 model Plan {
-  id              String    @id @default(uuid(7)) @db.Uuid
-  itemId          String    @map("item_id") @db.Uuid
+  id                      String    @id @default(uuid(7)) @db.Uuid
+  itemId                  String    @map("item_id") @db.Uuid
   /// 'toss' (Phase 0 / CHECK 制約)
-  planType        String    @default("toss") @map("plan_type")
-  title           String
+  planType                String    @default("toss") @map("plan_type")
+  title                   String
   /// 'wireframe' | 'design' | 'coding' | 'review' | 'meeting' | 'other' (CHECK 制約)
-  category        String
-  scheduledDate   DateTime  @map("scheduled_date") @db.Date
-  dueDate         DateTime? @map("due_date") @db.Date
-  fromMemberId    String?   @map("from_member_id") @db.Uuid
-  toMemberId      String?   @map("to_member_id") @db.Uuid
+  category                String
+  scheduledDate           DateTime  @map("scheduled_date") @db.Date
+  dueDate                 DateTime? @map("due_date") @db.Date
+  /// 実施者 (#131)。作業/確認を行う人。DBは任意だがアプリ層で実質必須
+  executorMemberId        String?   @map("executor_member_id") @db.Uuid
+  /// 承認者 (#131)。任意。未設定なら実施者自身が承認/完了できる
+  approverMemberId        String?   @map("approver_member_id") @db.Uuid
+  /// 進行責任者 (#131)。承認済みの予定を後続へ TOSS できる人
+  progressManagerMemberId String?   @map("progress_manager_member_id") @db.Uuid
+  /// TOSS 実行時の履歴スナップショット (#131 §14)。FROM=TOSS した進行責任者
+  fromMemberId            String?   @map("from_member_id") @db.Uuid
+  /// TOSS 実行時の履歴スナップショット (#131 §14)。TO=後続予定の実施者
+  toMemberId              String?   @map("to_member_id") @db.Uuid
   /// 後続紐付け (UNIQUE, 自己参照 CHECK で禁止)
-  successorPlanId String?   @unique(map: "uq_plans_successor_plan_id") @map("successor_plan_id") @db.Uuid
+  successorPlanId         String?   @unique(map: "uq_plans_successor_plan_id") @map("successor_plan_id") @db.Uuid
   /// 'active' | 'completed' | 'canceled' (CHECK 制約)
-  status          String    @default("active")
-  memo            String?
-  completedAt     DateTime? @map("completed_at") @db.Timestamptz
-  deletedAt       DateTime? @map("deleted_at") @db.Timestamptz
-  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt       DateTime  @default(now()) @map("updated_at") @db.Timestamptz
+  status                  String    @default("active")
+  memo                    String?
+  completedAt             DateTime? @map("completed_at") @db.Timestamptz
+  deletedAt               DateTime? @map("deleted_at") @db.Timestamptz
+  createdAt               DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt               DateTime  @default(now()) @map("updated_at") @db.Timestamptz
 
-  item        ProjectItem    @relation(fields: [itemId], references: [id], onDelete: Cascade, map: "fk_plans_item_id")
-  fromMember  ProjectMember? @relation("PlanFromMember", fields: [fromMemberId], references: [id], onDelete: Restrict, map: "fk_plans_from_member_id")
-  toMember    ProjectMember? @relation("PlanToMember", fields: [toMemberId], references: [id], onDelete: Restrict, map: "fk_plans_to_member_id")
-  successor   Plan?          @relation("PlanSuccessor", fields: [successorPlanId], references: [id], onDelete: SetNull, map: "fk_plans_successor_plan_id")
-  predecessor Plan?          @relation("PlanSuccessor")
-  ballEvents  BallEvent[]
+  item            ProjectItem    @relation(fields: [itemId], references: [id], onDelete: Cascade, map: "fk_plans_item_id")
+  executor        ProjectMember? @relation("PlanExecutor", fields: [executorMemberId], references: [id], onDelete: Restrict, map: "fk_plans_executor_member_id")
+  approver        ProjectMember? @relation("PlanApprover", fields: [approverMemberId], references: [id], onDelete: Restrict, map: "fk_plans_approver_member_id")
+  progressManager ProjectMember? @relation("PlanProgressManager", fields: [progressManagerMemberId], references: [id], onDelete: Restrict, map: "fk_plans_progress_manager_member_id")
+  fromMember      ProjectMember? @relation("PlanFromMember", fields: [fromMemberId], references: [id], onDelete: Restrict, map: "fk_plans_from_member_id")
+  toMember        ProjectMember? @relation("PlanToMember", fields: [toMemberId], references: [id], onDelete: Restrict, map: "fk_plans_to_member_id")
+  successor       Plan?          @relation("PlanSuccessor", fields: [successorPlanId], references: [id], onDelete: SetNull, map: "fk_plans_successor_plan_id")
+  predecessor     Plan?          @relation("PlanSuccessor")
+  ballEvents      BallEvent[]
 
   @@index([itemId, scheduledDate], map: "idx_plans_item_scheduled")
+  @@index([executorMemberId], map: "idx_plans_executor_member")
+  @@index([progressManagerMemberId], map: "idx_plans_progress_manager_member")
   @@index([fromMemberId], map: "idx_plans_from_member")
   @@index([toMemberId], map: "idx_plans_to_member")
   @@index([category], map: "idx_plans_category")
@@ -188,7 +208,9 @@ model Plan {
 model BallEvent {
   id            String   @id @default(uuid(7)) @db.Uuid
   planId        String   @map("plan_id") @db.Uuid
-  /// 'tossed' | 'completed' | 'toss_undone' (CHECK 制約)
+  /// 'tossed' | 'completed' | 'toss_undone' | 'completion_undone'
+  /// | 'review_requested' | 'approved' | 'sent_back'
+  /// | 'review_request_undone' | 'approval_undone' (CHECK 制約, #131)
   eventType     String   @map("event_type")
   /// 'human' | 'auto_chain' (CHECK 制約 + actor_consistency)
   source        String   @default("human")


### PR DESCRIPTION
## 概要

issue #131「確認者付き予定と進行責任者の追加」の **PR1（DB 土台）**。
確認工程を独立予定にせず、1 つの予定内で「実施 → 確認 → 承認 → TOSS」を回すための状態機械拡張に向け、まず**スキーマとマイグレーションのみ**を入れる。ドメイン純関数・バックエンド・フロントの本実装は後続の PR2 で行う。

関連: #131

## この PR のスコープ（休眠列のみ・完全後方互換）

- `plans` に役割 3 列を追加：`executor_member_id`（実施者）/ `approver_member_id`（承認者・任意）/ `progress_manager_member_id`（進行責任者）
- `projects` に `progress_manager_member_id`（予定作成時の進行責任者の既定値）を追加
- 既存 `from_member_id` / `to_member_id` は**残置**し、意味を「TOSS 実行時の履歴スナップショット」へ移行（#131 §14）。本 PR では書き込みタイミングは変えない
- `ball_events.event_type` の CHECK に `review_requested / approved / sent_back / review_request_undone / approval_undone` を追加
- `audit_logs.action` の CHECK に `request_review / undo_request_review / approve / undo_approve / send_back` を追加
- `ck_plans_toss_members` を撤去（役割は 1 人が兼務可＝ `from = to` もありうるため）

コード（`ballHolder.ts` 等）は本 PR では**未変更**。新列は使われず休眠状態のため、既存の挙動・テストに影響しない。

## 実データ影響の精査（⚠️レビュー観点）

**破壊的操作は含まれない**：
- 追加列はすべて **nullable UUID**（`ADD COLUMN` のメタデータ操作、テーブル書き換えなし）
- `DROP COLUMN` / `DELETE` なし。`from/to` 列は残す
- CHECK 変更は**許可値の追加＝スーパーセット**のため、既存全行が新制約を満たす（拒否も改変もなし）
- 新 FK は既存同様 `ON DELETE RESTRICT`

**追加専用バックフィル**（既存列は書き換えず新列のみ埋める）：
1. `plans.executor_member_id ← from_member_id`
2. `projects.progress_manager_member_id ← 作成者(created_by)の該当メンバー`（無ければ NULL）
3. `plans.progress_manager_member_id ← 同上`（既存予定を新ルールで操作可能にする）
4. `approver_member_id` は NULL のまま

`updated_at` を保持するため、バックフィル中のみ `trg_plans_set_updated_at` / `trg_projects_set_updated_at` を `DISABLE`（migration ロールはテーブル所有者のため実行可能。CI の postgres は superuser）。

**既存予定の Ball Holder の「人」は移行後も保存される**（イベント無し→実施者=旧 from をバックフィル、tossed→to_member 不変、completed→to_member 不変）＝誰もボールを失わない。

## 検証

- ローカル：`prisma format --check` / `type-check` / `lint`（`--max-warnings 0`）/ unit（web 609 + shared 17）すべて緑
- マイグレーション本体は **CI の `integration` ジョブ**（実 postgres:15 + `prisma migrate deploy`）で適用・検証される
  - ※作業環境のローカル Supabase(docker) が未起動のため、マイグレーションのローカル適用は未実施。CI で検証

## 後続 PR
- **PR2**：状態機械の全面実装（FE/BE 共有の `deriveBallHolder`/`deriveLineBallHolders` 書き換え＋バックエンド新アクション＋フロント UI ＋テスト）。共有ドメイン契約が原子的に変わるため FE/BE を同時に着地させる
- **別 issue**：§13 の前工程再開型の差し戻し、共有リンク（`shareAccess.ts`）の新ロール対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)