### PR TITLE
feat(share): 共有リンクにクライアントの確認/承認/差し戻しを追加 (#131)

### DIFF
--- a/apps/web/server/routes/v1/share.integration.test.ts
+++ b/apps/web/server/routes/v1/share.integration.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import type { PlanState } from '@trakon/shared';
+
 import { api } from '../../test/request.js';
 import {
   createItem,
@@ -9,16 +11,18 @@ import {
 } from '../../test/factories.js';
 
 // =============================================================================
-// public share ルートの統合テスト (実 DB + 未認証フロー)
-// 正常系: 閲覧 / TOSS / 完了、異常系: 無効トークン / scope 外 / 非 active
-// share トークンは認証付き作成ルート (POST /projects/:id/share-links) が返す
-// 生トークン (rawToken) を利用する。ハッシュ保存のため後から復元できない。
+// public share ルートの統合テスト (実 DB + 未認証フロー) — #131
+//   クライアント(非会員)の確認依頼 / 承認 / 差し戻しを検証する。
+//   進行責任者の TOSS は共有リンクからは提供しない。
+//   share トークンは認証付き作成ルートが返す生トークン (rawToken) を利用する。
 // =============================================================================
 
+type Ref = { id: string } | null;
 type SharePlanDTO = {
   id: string;
   status: 'active' | 'completed' | 'canceled';
-  ballState: 'ready' | 'tossed' | 'completed';
+  ballState: PlanState;
+  ballHolder: Ref;
 };
 
 type ShareViewBody = {
@@ -30,25 +34,22 @@ type ShareViewBody = {
   };
 };
 
-describe('share routes (integration)', () => {
+describe('share routes (integration, #131)', () => {
   let ctx: Awaited<ReturnType<typeof setupProjectWithDirector>>;
   let itemId: string;
-  let fromId: string;
-  let toId: string;
+  let execId: string;
+  let approverId: string;
+  let pmId: string;
 
   beforeEach(async () => {
     ctx = await setupProjectWithDirector();
     const item = await createItem({ projectId: ctx.project.id });
     itemId = item.id;
-    fromId = ctx.member.id;
-    const other = await createMember({
-      projectId: ctx.project.id,
-      memberType: 'production',
-    });
-    toId = other.id;
+    pmId = ctx.member.id;
+    execId = (await createMember({ projectId: ctx.project.id, memberType: 'client' })).id;
+    approverId = (await createMember({ projectId: ctx.project.id, memberType: 'client' })).id;
   });
 
-  // 認証付きルートで project scope の share-link を発行し、生トークンを得る。
   async function issueProjectShareToken(): Promise<string> {
     const res = await api<{ data: { rawToken: string } }>(
       `/api/v1/projects/${ctx.project.id}/share-links`,
@@ -62,12 +63,17 @@ describe('share routes (integration)', () => {
     return res.body.data.rawToken;
   }
 
+  const shareAct = (token: string, planId: string, action: string) =>
+    api<{ data: { plan: SharePlanDTO } }>(`/api/v1/share/${token}/plans/${planId}/${action}`, {
+      method: 'POST',
+      body: {},
+    });
+
   describe('正常系', () => {
     it('GET /share/:token は project scope の閲覧情報を返す', async () => {
       await createPlan({
         itemId,
-        fromMemberId: fromId,
-        toMemberId: toId,
+        executorMemberId: execId,
         scheduledDate: new Date('2026-06-01'),
       });
       const token = await issueProjectShareToken();
@@ -75,53 +81,73 @@ describe('share routes (integration)', () => {
       const res = await api<ShareViewBody>(`/api/v1/share/${token}`);
       expect(res.status).toBe(200);
       expect(res.body.data.share.scopeType).toBe('project');
-      expect(res.body.data.project.id).toBe(ctx.project.id);
-      expect(res.body.data.items.map((i) => i.id)).toContain(itemId);
       expect(res.body.data.plans).toHaveLength(1);
+      expect(res.body.data.plans[0]!.ballState).toBe('in_progress');
     });
 
-    it('POST /share/:token/plans/:planId/toss は ballState=tossed を返す', async () => {
+    it('承認者あり: 確認依頼→承認 で承認済みへ (クライアント操作)', async () => {
+      const successor = await createPlan({
+        itemId,
+        executorMemberId: execId,
+        progressManagerMemberId: pmId,
+      });
       const plan = await createPlan({
         itemId,
-        fromMemberId: fromId,
-        toMemberId: toId,
+        executorMemberId: execId,
+        approverMemberId: approverId,
+        progressManagerMemberId: pmId,
+        successorPlanId: successor.id,
         status: 'active',
       });
       const token = await issueProjectShareToken();
 
-      const res = await api<{ data: { plan: SharePlanDTO } }>(
-        `/api/v1/share/${token}/plans/${plan.id}/toss`,
-        { method: 'POST', body: {} },
-      );
-      expect(res.status).toBe(200);
-      expect(res.body.data.plan.id).toBe(plan.id);
-      expect(res.body.data.plan.ballState).toBe('tossed');
+      const reviewed = await shareAct(token, plan.id, 'request-review');
+      expect(reviewed.status).toBe(200);
+      expect(reviewed.body.data.plan.ballState).toBe('review_pending');
+
+      const approved = await shareAct(token, plan.id, 'approve');
+      expect(approved.status).toBe(200);
+      expect(approved.body.data.plan.ballState).toBe('approved');
+      expect(approved.body.data.plan.ballHolder?.id).toBe(pmId);
+      // 後続があるので承認だけでは完了しない (TOSS は会員=進行責任者が行う)
+      expect(approved.body.data.plan.status).toBe('active');
     });
 
-    it('POST /share/:token/plans/:planId/complete は status=completed を返す', async () => {
+    it('承認者なし短絡: approve で承認済みへ。後続なしは完了', async () => {
       const plan = await createPlan({
         itemId,
-        fromMemberId: fromId,
-        toMemberId: toId,
+        executorMemberId: execId,
+        progressManagerMemberId: pmId,
         status: 'active',
       });
       const token = await issueProjectShareToken();
 
-      const res = await api<{ data: { plan: SharePlanDTO; autoTossed: SharePlanDTO | null } }>(
-        `/api/v1/share/${token}/plans/${plan.id}/complete`,
-        { method: 'POST', body: {} },
-      );
+      const res = await shareAct(token, plan.id, 'approve');
       expect(res.status).toBe(200);
-      expect(res.body.data.plan.status).toBe('completed');
-      expect(res.body.data.autoTossed).toBeNull();
+      expect(res.body.data.plan.ballState).toBe('approved');
+      expect(res.body.data.plan.status).toBe('completed'); // 後続なし = 承認で完了
+    });
+
+    it('確認待ち → 差し戻し で実施中へ戻る', async () => {
+      const plan = await createPlan({
+        itemId,
+        executorMemberId: execId,
+        approverMemberId: approverId,
+        progressManagerMemberId: pmId,
+        status: 'active',
+      });
+      const token = await issueProjectShareToken();
+      await shareAct(token, plan.id, 'request-review');
+
+      const res = await shareAct(token, plan.id, 'send-back');
+      expect(res.status).toBe(200);
+      expect(res.body.data.plan.ballState).toBe('sent_back');
     });
   });
 
   describe('異常系', () => {
     it('未存在トークンは 404 SHARE_NOT_FOUND_OR_EXPIRED', async () => {
-      const res = await api<{ error: { code: string } }>(
-        '/api/v1/share/totally-invalid-token',
-      );
+      const res = await api<{ error: { code: string } }>('/api/v1/share/totally-invalid-token');
       expect(res.status).toBe(404);
       expect(res.body.error.code).toBe('SHARE_NOT_FOUND_OR_EXPIRED');
     });
@@ -137,11 +163,10 @@ describe('share routes (integration)', () => {
       );
       const token = created.body.data.rawToken;
       const shareLinkId = created.body.data.shareLink.id;
-      // 同じディレクターが revoke
-      const del = await api(
-        `/api/v1/projects/${ctx.project.id}/share-links/${shareLinkId}`,
-        { method: 'DELETE', token: ctx.token },
-      );
+      const del = await api(`/api/v1/projects/${ctx.project.id}/share-links/${shareLinkId}`, {
+        method: 'DELETE',
+        token: ctx.token,
+      });
       expect(del.status).toBe(204);
 
       const res = await api<{ error: { code: string } }>(`/api/v1/share/${token}`);
@@ -149,53 +174,46 @@ describe('share routes (integration)', () => {
       expect(res.body.error.code).toBe('SHARE_NOT_FOUND_OR_EXPIRED');
     });
 
-    it('scope 外 (別プロジェクト) の plan を TOSS すると 404', async () => {
+    it('scope 外 (別プロジェクト) の plan を承認すると 404', async () => {
       const token = await issueProjectShareToken();
-      // 別プロジェクトの plan
       const other = await setupProjectWithDirector();
       const otherItem = await createItem({ projectId: other.project.id });
       const otherPlan = await createPlan({ itemId: otherItem.id, status: 'active' });
 
       const res = await api<{ error: { code: string } }>(
-        `/api/v1/share/${token}/plans/${otherPlan.id}/toss`,
+        `/api/v1/share/${token}/plans/${otherPlan.id}/approve`,
         { method: 'POST', body: {} },
       );
       expect(res.status).toBe(404);
       expect(res.body.error.code).toBe('SHARE_NOT_FOUND_OR_EXPIRED');
     });
 
-    it('active でない plan の TOSS は 422 PLAN_NOT_ACTIVE', async () => {
+    it('active でない plan の承認は 422 PLAN_NOT_ACTIVE', async () => {
       const plan = await createPlan({ itemId, status: 'completed' });
       const token = await issueProjectShareToken();
 
       const res = await api<{ error: { code: string } }>(
-        `/api/v1/share/${token}/plans/${plan.id}/toss`,
+        `/api/v1/share/${token}/plans/${plan.id}/approve`,
         { method: 'POST', body: {} },
       );
       expect(res.status).toBe(422);
       expect(res.body.error.code).toBe('PLAN_NOT_ACTIVE');
     });
 
-    it('既に TOSS 済みの plan を再 TOSS すると 409 ALREADY_TOSSED', async () => {
+    it('TOSS エンドポイントは共有リンクに存在しない (404)', async () => {
       const plan = await createPlan({
         itemId,
-        fromMemberId: fromId,
-        toMemberId: toId,
+        executorMemberId: execId,
+        progressManagerMemberId: pmId,
         status: 'active',
       });
       const token = await issueProjectShareToken();
-      const first = await api(`/api/v1/share/${token}/plans/${plan.id}/toss`, {
-        method: 'POST',
-        body: {},
-      });
-      expect(first.status).toBe(200);
-
       const res = await api<{ error: { code: string } }>(
         `/api/v1/share/${token}/plans/${plan.id}/toss`,
         { method: 'POST', body: {} },
       );
-      expect(res.status).toBe(409);
-      expect(res.body.error.code).toBe('ALREADY_TOSSED');
+      // ルート未定義のため 404 (Hono の not found)
+      expect(res.status).toBe(404);
     });
   });
 });

--- a/apps/web/server/routes/v1/share.ts
+++ b/apps/web/server/routes/v1/share.ts
@@ -1,15 +1,19 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 
 import { ApiException } from '../../lib/errors.js';
 import {
-  shareComplete,
-  shareToss,
+  shareApprove,
+  shareRequestReview,
+  shareSendBack,
   viewShare,
 } from '../../services/shareAccess.js';
 
 /**
  * `/api/v1/share/:token` 配下 (未認証可)。
  * 全アクセスは audit_logs に shareLinkId / IP / UA を記録する。
+ *
+ * #131: 非会員(クライアント)に確認依頼/承認/差し戻しを許可する。
+ * 進行責任者の TOSS(次工程へ進める操作)は共有リンクからは提供しない。
  */
 export const shareRoute = new Hono()
   .get('/:token', async (c) => {
@@ -24,28 +28,28 @@ export const shareRoute = new Hono()
     return c.json({ data: dto });
   })
 
-  .post('/:token/plans/:planId/toss', async (c) => {
-    const token = c.req.param('token');
-    const planId = c.req.param('planId');
-    if (!token || !planId) throw new ApiException('BAD_REQUEST', 400, 'token and planId required.');
-    const result = await shareToss({
-      rawToken: token,
-      planId,
-      ip: c.req.header('x-forwarded-for') ?? undefined,
-      userAgent: c.req.header('user-agent') ?? undefined,
-    });
-    return c.json({ data: result });
-  })
+  .post('/:token/plans/:planId/request-review', shareActionHandler(shareRequestReview))
+  .post('/:token/plans/:planId/approve', shareActionHandler(shareApprove))
+  .post('/:token/plans/:planId/send-back', shareActionHandler(shareSendBack));
 
-  .post('/:token/plans/:planId/complete', async (c) => {
+type ShareAction = (input: {
+  rawToken: string;
+  planId: string;
+  ip?: string;
+  userAgent?: string;
+}) => Promise<{ plan: unknown }>;
+
+function shareActionHandler(action: ShareAction) {
+  return async (c: Context) => {
     const token = c.req.param('token');
     const planId = c.req.param('planId');
     if (!token || !planId) throw new ApiException('BAD_REQUEST', 400, 'token and planId required.');
-    const result = await shareComplete({
+    const result = await action({
       rawToken: token,
       planId,
       ip: c.req.header('x-forwarded-for') ?? undefined,
       userAgent: c.req.header('user-agent') ?? undefined,
     });
     return c.json({ data: result });
-  });
+  };
+}

--- a/apps/web/server/services/shareAccess.test.ts
+++ b/apps/web/server/services/shareAccess.test.ts
@@ -3,8 +3,9 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { hashToken } from '../lib/tokens.js';
 import type {
   viewShare as ViewShareType,
-  shareToss as ShareTossType,
-  shareComplete as ShareCompleteType,
+  shareRequestReview as ShareRequestReviewType,
+  shareApprove as ShareApproveType,
+  shareSendBack as ShareSendBackType,
 } from './shareAccess.js';
 
 // =============================================================================
@@ -326,11 +327,12 @@ function seedShareLink(over: Partial<MockShareLink> = {}): MockShareLink {
 // =============================================================================
 
 let viewShare: typeof ViewShareType;
-let shareToss: typeof ShareTossType;
-let shareComplete: typeof ShareCompleteType;
+let shareRequestReview: typeof ShareRequestReviewType;
+let shareApprove: typeof ShareApproveType;
+let shareSendBack: typeof ShareSendBackType;
 
 beforeAll(async () => {
-  ({ viewShare, shareToss, shareComplete } = await import('./shareAccess.js'));
+  ({ viewShare, shareRequestReview, shareApprove, shareSendBack } = await import('./shareAccess.js'));
 });
 
 afterEach(() => {
@@ -479,26 +481,132 @@ describe('viewShare', () => {
   });
 });
 
-describe('shareToss', () => {
-  function seedTossable() {
+// review_requested イベントを積んで「確認待ち」状態を作る。
+function pushEvent(planId: string, eventType: string) {
+  ballEventStore.push({
+    id: `be-${eventType}-${planId}`,
+    planId,
+    eventType,
+    source: 'human',
+    actorMemberId: null,
+    actorUserId: null,
+    actorMember: null,
+    occurredAt: new Date('2026-06-05T00:00:00Z'),
+    note: null,
+  });
+}
+
+describe('shareRequestReview', () => {
+  it('承認者あり実施中 → review_requested イベント + 監査 share_request_review', async () => {
     seedProject();
     seedItem({ id: 'item-a', name: 'A' });
-    return seedPlan({ id: 'plan-1', itemId: 'item-a', status: 'active' });
-  }
-
-  it('active かつ未 TOSS の plan に tossed イベントを作り、監査ログを記録する', async () => {
-    seedTossable();
+    const exec = makeMember({ id: 'ex' });
+    const appr = makeMember({ id: 'ap' });
+    seedPlan({
+      id: 'plan-1',
+      itemId: 'item-a',
+      status: 'active',
+      executorMemberId: exec.id,
+      executor: exec,
+      approverMemberId: appr.id,
+      approver: appr,
+    });
     const link = seedShareLink({ scopeType: 'project' });
 
-    const res = await shareToss({ rawToken: RAW_TOKEN, planId: 'plan-1', ip: '9.9.9.9' });
+    const res = await shareRequestReview({ rawToken: RAW_TOKEN, planId: 'plan-1', ip: '9.9.9.9' });
 
-    expect(res.plan.id).toBe('plan-1');
-    // tossed イベントが作られている (source=auto_chain, actor=null)
-    const tossed = ballEventStore.filter((e) => e.planId === 'plan-1' && e.eventType === 'tossed');
-    expect(tossed).toHaveLength(1);
-    expect(tossed[0]).toMatchObject({ source: 'auto_chain', actorMemberId: null, actorUserId: null });
-    expect(tossed[0]!.note).toContain(link.id);
-    expect(auditStore.some((a) => a.action === 'share_toss' && a.resourceId === 'plan-1')).toBe(true);
+    expect(res.plan.ballState).toBe('review_pending');
+    const ev = ballEventStore.filter((e) => e.planId === 'plan-1' && e.eventType === 'review_requested');
+    expect(ev).toHaveLength(1);
+    expect(ev[0]).toMatchObject({ source: 'auto_chain', actorMemberId: null, actorUserId: null });
+    expect(ev[0]!.note).toContain(link.id);
+    expect(auditStore.some((a) => a.action === 'share_request_review' && a.resourceId === 'plan-1')).toBe(true);
+  });
+
+  it('承認者なし → 422 NO_APPROVER', async () => {
+    seedProject();
+    seedItem({ id: 'item-a', name: 'A' });
+    const exec = makeMember({ id: 'ex' });
+    seedPlan({ id: 'plan-1', itemId: 'item-a', status: 'active', executorMemberId: exec.id, executor: exec });
+    seedShareLink({ scopeType: 'project' });
+    await expect(shareRequestReview({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
+      code: 'NO_APPROVER',
+      status: 422,
+    });
+  });
+});
+
+describe('shareApprove', () => {
+  it('承認者なし実施中 → approved イベント。後続なしで completed、監査 share_approve', async () => {
+    seedProject();
+    seedItem({ id: 'item-a', name: 'A' });
+    const exec = makeMember({ id: 'ex' });
+    seedPlan({ id: 'plan-1', itemId: 'item-a', status: 'active', executorMemberId: exec.id, executor: exec });
+    seedShareLink({ scopeType: 'project' });
+
+    const res = await shareApprove({ rawToken: RAW_TOKEN, planId: 'plan-1', userAgent: 'ua' });
+
+    expect(res.plan.ballState).toBe('approved');
+    expect(res.plan.status).toBe('completed'); // 後続なし = 承認で完了
+    expect(planStore.find((p) => p.id === 'plan-1')?.status).toBe('completed');
+    const ev = ballEventStore.filter((e) => e.planId === 'plan-1' && e.eventType === 'approved');
+    expect(ev[0]).toMatchObject({ source: 'auto_chain', actorMemberId: null, actorUserId: null });
+    expect(auditStore.some((a) => a.action === 'share_approve' && a.resourceId === 'plan-1')).toBe(true);
+  });
+
+  it('承認者あり確認待ち → approved (後続ありは active のまま)', async () => {
+    seedProject();
+    seedItem({ id: 'item-a', name: 'A' });
+    const exec = makeMember({ id: 'ex' });
+    const appr = makeMember({ id: 'ap' });
+    const pm = makeMember({ id: 'pm' });
+    seedPlan({
+      id: 'succ',
+      itemId: 'item-a',
+      status: 'active',
+      executorMemberId: exec.id,
+      executor: exec,
+    });
+    seedPlan({
+      id: 'plan-1',
+      itemId: 'item-a',
+      status: 'active',
+      executorMemberId: exec.id,
+      executor: exec,
+      approverMemberId: appr.id,
+      approver: appr,
+      progressManagerMemberId: pm.id,
+      progressManager: pm,
+      successorPlanId: 'succ',
+    });
+    pushEvent('plan-1', 'review_requested'); // 確認待ちにする
+    seedShareLink({ scopeType: 'project' });
+
+    const res = await shareApprove({ rawToken: RAW_TOKEN, planId: 'plan-1' });
+
+    expect(res.plan.ballState).toBe('approved');
+    expect(res.plan.status).toBe('active'); // 後続あり = TOSS 待ち
+  });
+
+  it('承認者あり実施中(確認依頼前)で承認 → 409 INVALID_STATE', async () => {
+    seedProject();
+    seedItem({ id: 'item-a', name: 'A' });
+    const exec = makeMember({ id: 'ex' });
+    const appr = makeMember({ id: 'ap' });
+    seedPlan({
+      id: 'plan-1',
+      itemId: 'item-a',
+      status: 'active',
+      executorMemberId: exec.id,
+      executor: exec,
+      approverMemberId: appr.id,
+      approver: appr,
+    });
+    seedShareLink({ scopeType: 'project' });
+    await expect(shareApprove({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
+      code: 'INVALID_STATE',
+      status: 409,
+    });
   });
 
   it('plan が active でない → 422 PLAN_NOT_ACTIVE', async () => {
@@ -506,38 +614,19 @@ describe('shareToss', () => {
     seedItem({ id: 'item-a', name: 'A' });
     seedPlan({ id: 'plan-1', itemId: 'item-a', status: 'completed' });
     seedShareLink({ scopeType: 'project' });
-    await expect(shareToss({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
+    await expect(shareApprove({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
       code: 'PLAN_NOT_ACTIVE',
       status: 422,
     });
   });
 
-  it('既に tossed 済み → 409 ALREADY_TOSSED', async () => {
-    seedTossable();
-    ballEventStore.push({
-      id: 'be-pre',
-      planId: 'plan-1',
-      eventType: 'tossed',
-      source: 'human',
-      actorMemberId: null,
-      actorUserId: null,
-      actorMember: null,
-      occurredAt: new Date('2026-06-02T00:00:00Z'),
-      note: null,
-    });
-    seedShareLink({ scopeType: 'project' });
-    await expect(shareToss({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
-      code: 'ALREADY_TOSSED',
-      status: 409,
-    });
-  });
-
+  // scope 検証 (runShareAction 共通)
   it('scope 外 plan (別 project) → 404', async () => {
     seedProject();
     seedItem({ id: 'item-a', name: 'A', projectId: 'other-proj' });
     seedPlan({ id: 'plan-1', itemId: 'item-a' });
     seedShareLink({ scopeType: 'project', projectId: 'proj-1' });
-    await expect(shareToss({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
+    await expect(shareApprove({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
       code: 'SHARE_NOT_FOUND_OR_EXPIRED',
       status: 404,
     });
@@ -549,106 +638,57 @@ describe('shareToss', () => {
     seedItem({ id: 'item-b', name: 'B' });
     seedPlan({ id: 'plan-1', itemId: 'item-b' });
     seedShareLink({ scopeType: 'item', scopeTargetId: 'item-a' });
-    await expect(shareToss({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
+    await expect(shareApprove({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
       code: 'SHARE_NOT_FOUND_OR_EXPIRED',
       status: 404,
     });
   });
 
-  it('plan scope で別 plan → 404', async () => {
-    seedProject();
-    seedItem({ id: 'item-a', name: 'A' });
-    seedPlan({ id: 'plan-1', itemId: 'item-a' });
-    seedPlan({ id: 'plan-2', itemId: 'item-a' });
-    seedShareLink({ scopeType: 'plan', scopeTargetId: 'plan-2' });
-    await expect(shareToss({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
-      code: 'SHARE_NOT_FOUND_OR_EXPIRED',
-      status: 404,
-    });
-  });
-
-  it('存在しない plan → 404 (assertPlanInShareScope)', async () => {
+  it('存在しない plan → 404', async () => {
     seedProject();
     seedItem({ id: 'item-a', name: 'A' });
     seedShareLink({ scopeType: 'project' });
-    await expect(shareToss({ rawToken: RAW_TOKEN, planId: 'ghost' })).rejects.toMatchObject({
+    await expect(shareApprove({ rawToken: RAW_TOKEN, planId: 'ghost' })).rejects.toMatchObject({
       code: 'SHARE_NOT_FOUND_OR_EXPIRED',
       status: 404,
     });
   });
 });
 
-describe('shareComplete', () => {
-  it('plan を完了し completed イベント・status 更新・監査ログを記録する (successor なし)', async () => {
+describe('shareSendBack', () => {
+  it('確認待ち → sent_back イベント + 監査 share_send_back', async () => {
     seedProject();
     seedItem({ id: 'item-a', name: 'A' });
-    seedPlan({ id: 'plan-1', itemId: 'item-a', status: 'active' });
-    seedShareLink({ scopeType: 'project' });
-
-    const res = await shareComplete({ rawToken: RAW_TOKEN, planId: 'plan-1', userAgent: 'ua' });
-
-    expect(res.plan.id).toBe('plan-1');
-    expect(res.plan.status).toBe('completed');
-    expect(res.autoTossed).toBeNull();
-    expect(planStore.find((p) => p.id === 'plan-1')?.status).toBe('completed');
-    expect(ballEventStore.some((e) => e.planId === 'plan-1' && e.eventType === 'completed')).toBe(true);
-    expect(auditStore.some((a) => a.action === 'share_complete' && a.resourceId === 'plan-1')).toBe(true);
-  });
-
-  it('後続があっても自動 TOSS しない (自動連鎖廃止 #117 / #131)', async () => {
-    seedProject();
-    seedItem({ id: 'item-a', name: 'A' });
-    const exec = makeMember({ id: 'mf' });
-    // successor: 実施者あり・イベント無し → 実施中
+    const exec = makeMember({ id: 'ex' });
+    const appr = makeMember({ id: 'ap' });
     seedPlan({
-      id: 'succ',
+      id: 'plan-1',
       itemId: 'item-a',
       status: 'active',
       executorMemberId: exec.id,
       executor: exec,
+      approverMemberId: appr.id,
+      approver: appr,
     });
-    seedPlan({ id: 'plan-1', itemId: 'item-a', status: 'active', successorPlanId: 'succ' });
+    pushEvent('plan-1', 'review_requested');
     seedShareLink({ scopeType: 'project' });
 
-    const res = await shareComplete({ rawToken: RAW_TOKEN, planId: 'plan-1' });
+    const res = await shareSendBack({ rawToken: RAW_TOKEN, planId: 'plan-1' });
 
-    expect(res.autoTossed).toBeNull();
-    // successor には TOSS イベントが作られない
-    expect(ballEventStore.some((e) => e.planId === 'succ' && e.eventType === 'tossed')).toBe(false);
+    expect(res.plan.ballState).toBe('sent_back');
+    expect(ballEventStore.some((e) => e.planId === 'plan-1' && e.eventType === 'sent_back')).toBe(true);
+    expect(auditStore.some((a) => a.action === 'share_send_back' && a.resourceId === 'plan-1')).toBe(true);
   });
 
-  it('successor が completed の場合は自動 TOSS しない', async () => {
+  it('確認待ちでない(実施中)で差し戻し → 409 INVALID_STATE', async () => {
     seedProject();
     seedItem({ id: 'item-a', name: 'A' });
-    seedPlan({ id: 'succ', itemId: 'item-a', status: 'completed' });
-    seedPlan({ id: 'plan-1', itemId: 'item-a', status: 'active', successorPlanId: 'succ' });
+    const exec = makeMember({ id: 'ex' });
+    seedPlan({ id: 'plan-1', itemId: 'item-a', status: 'active', executorMemberId: exec.id, executor: exec });
     seedShareLink({ scopeType: 'project' });
-
-    const res = await shareComplete({ rawToken: RAW_TOKEN, planId: 'plan-1' });
-
-    expect(res.autoTossed).toBeNull();
-    expect(ballEventStore.some((e) => e.planId === 'succ' && e.eventType === 'tossed')).toBe(false);
-  });
-
-  it('plan が active でない → 422 PLAN_NOT_ACTIVE', async () => {
-    seedProject();
-    seedItem({ id: 'item-a', name: 'A' });
-    seedPlan({ id: 'plan-1', itemId: 'item-a', status: 'completed' });
-    seedShareLink({ scopeType: 'project' });
-    await expect(shareComplete({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
-      code: 'PLAN_NOT_ACTIVE',
-      status: 422,
-    });
-  });
-
-  it('scope 外 plan → 404', async () => {
-    seedProject();
-    seedItem({ id: 'item-a', name: 'A', projectId: 'other-proj' });
-    seedPlan({ id: 'plan-1', itemId: 'item-a' });
-    seedShareLink({ scopeType: 'project', projectId: 'proj-1' });
-    await expect(shareComplete({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
-      code: 'SHARE_NOT_FOUND_OR_EXPIRED',
-      status: 404,
+    await expect(shareSendBack({ rawToken: RAW_TOKEN, planId: 'plan-1' })).rejects.toMatchObject({
+      code: 'INVALID_STATE',
+      status: 409,
     });
   });
 });

--- a/apps/web/server/services/shareAccess.ts
+++ b/apps/web/server/services/shareAccess.ts
@@ -1,4 +1,5 @@
 import { prisma, type Prisma } from '@trakon/db';
+import { deriveBallHolder, type BallEventType, type PlanState } from '@trakon/shared';
 
 import { ApiException } from '../lib/errors.js';
 import { toPlanDTO, type PlanDTO } from './plans.js';
@@ -148,17 +149,64 @@ async function loadPlanWithIncludes(tx: Prisma.TransactionClient, planId: string
   return row;
 }
 
-/**
- * 非会員 URL 経由で TOSS を発火。
- * Phase 0: actor=null (system_share)。Ball Holder 認可は適用せず scope のみで判定。
- * 設計書 §5.6: クライアントロール相当の操作を許可。
- */
-export async function shareToss(input: {
+// -----------------------------------------------------------------------------
+// 非会員 URL 経由のボール操作 (#131)
+//   クライアント(非会員)に「確認依頼 / 承認 / 差し戻し」を許可する。
+//   進行責任者の TOSS(次工程へ進める操作)は共有リンクからは行わない。
+//   認可: scope 内かつ状態機械が許す限り可 (保持者の種別は問わない)。
+//   actor は匿名のため source='auto_chain'(system actor, actor 両方 NULL)で記録し、
+//   誰が操作したかは audit_logs.share_link_id で辿る (設計書 §5.6)。
+// -----------------------------------------------------------------------------
+
+type ShareStatePlan = {
+  status: string;
+  executorMemberId: string | null;
+  approverMemberId: string | null;
+  progressManagerMemberId: string | null;
+  toMemberId: string | null;
+  ballEvents: { eventType: string; source: string; occurredAt: Date }[];
+};
+
+function shareBallState(plan: ShareStatePlan): PlanState {
+  const latest = plan.ballEvents[0]; // occurredAt DESC
+  return deriveBallHolder(
+    {
+      executorMemberId: plan.executorMemberId,
+      approverMemberId: plan.approverMemberId,
+      progressManagerMemberId: plan.progressManagerMemberId,
+      toMemberId: plan.toMemberId,
+      status: plan.status as 'active' | 'completed' | 'canceled',
+    },
+    latest
+      ? {
+          eventType: latest.eventType as BallEventType,
+          source: latest.source as 'human' | 'auto_chain',
+          occurredAt: latest.occurredAt,
+        }
+      : null,
+  ).state;
+}
+
+type ShareActionInput = {
   rawToken: string;
   planId: string;
   ip?: string;
   userAgent?: string;
-}): Promise<{ plan: PlanDTO }> {
+};
+
+/**
+ * 共有操作の共通スキャフォールド。scope 検証 → tx で plan ロード(active 必須) →
+ * apply(状態遷移: イベント作成 + status 更新) → 監査ログ → 再ロードして DTO 化。
+ */
+async function runShareAction(
+  input: ShareActionInput,
+  auditAction: 'share_request_review' | 'share_approve' | 'share_send_back',
+  apply: (
+    tx: Prisma.TransactionClient,
+    plan: Awaited<ReturnType<typeof loadPlanWithIncludes>>,
+    shareId: string,
+  ) => Promise<void>,
+): Promise<{ plan: PlanDTO }> {
   const share = await findActiveShareLinkByRawToken(input.rawToken);
   const { itemId } = await assertPlanInShareScope({
     shareId: share.id,
@@ -170,30 +218,14 @@ export async function shareToss(input: {
 
   const result = await prisma.$transaction(async (tx) => {
     const plan = await loadPlanWithIncludes(tx, input.planId, itemId);
-
     if (plan.status !== 'active') {
       throw new ApiException('PLAN_NOT_ACTIVE', 422, 'Plan is not active.');
     }
-    if (plan.ballEvents.some((e) => e.eventType === 'tossed')) {
-      throw new ApiException('ALREADY_TOSSED', 409, 'Ball has already been tossed.');
-    }
-
-    // 非会員アクセスは system actor 扱いで auto_chain と同じスキーマで記録
-    // (ck_be_actor_consistency: source='auto_chain' なら actor 両方 NULL)
-    await tx.ballEvent.create({
-      data: {
-        planId: plan.id,
-        eventType: 'tossed',
-        source: 'auto_chain',
-        actorMemberId: null,
-        actorUserId: null,
-        note: `via share_link:${share.id}`,
-      },
-    });
+    await apply(tx, plan, share.id);
     await tx.auditLog.create({
       data: {
         shareLinkId: share.id,
-        action: 'share_toss',
+        action: auditAction,
         resourceType: 'plan',
         resourceId: plan.id,
         result: 'success',
@@ -201,72 +233,81 @@ export async function shareToss(input: {
         userAgent: input.userAgent ?? null,
       },
     });
-    return await loadPlanWithIncludes(tx, plan.id, itemId);
+    return loadPlanWithIncludes(tx, plan.id, itemId);
   });
 
   return { plan: toPlanDTO(result, []) };
 }
 
-/**
- * 非会員 URL 経由で完了を発火。successor 自動連鎖も同一トランザクションで処理。
- */
-export async function shareComplete(input: {
-  rawToken: string;
-  planId: string;
-  ip?: string;
-  userAgent?: string;
-}): Promise<{ plan: PlanDTO; autoTossed: PlanDTO | null }> {
-  const share = await findActiveShareLinkByRawToken(input.rawToken);
-  const { itemId } = await assertPlanInShareScope({
-    shareId: share.id,
-    shareScopeType: share.scopeType,
-    shareScopeTargetId: share.scopeTargetId,
-    shareProjectId: share.projectId,
-    planId: input.planId,
+function createShareEvent(
+  tx: Prisma.TransactionClient,
+  planId: string,
+  eventType: string,
+  shareId: string,
+): Promise<unknown> {
+  // ck_be_actor_consistency: source='auto_chain' なら actor 両方 NULL
+  return tx.ballEvent.create({
+    data: {
+      planId,
+      eventType,
+      source: 'auto_chain',
+      actorMemberId: null,
+      actorUserId: null,
+      note: `via share_link:${shareId}`,
+    },
   });
+}
 
-  const result = await prisma.$transaction(async (tx) => {
-    const plan = await loadPlanWithIncludes(tx, input.planId, itemId);
-    if (plan.status !== 'active') {
-      throw new ApiException('PLAN_NOT_ACTIVE', 422, 'Plan is not active.');
+/** 確認依頼 (実施中/差し戻し → 確認待ち)。承認者・実施者が設定済みで承認者ありのみ。 */
+export function shareRequestReview(input: ShareActionInput): Promise<{ plan: PlanDTO }> {
+  return runShareAction(input, 'share_request_review', async (tx, plan, shareId) => {
+    const state = shareBallState(plan);
+    if (state !== 'in_progress' && state !== 'sent_back') {
+      throw new ApiException('INVALID_STATE', 409, '確認依頼は実施中の予定にのみ行えます。');
     }
-
-    await tx.ballEvent.create({
-      data: {
-        planId: plan.id,
-        eventType: 'completed',
-        source: 'auto_chain',
-        actorMemberId: null,
-        actorUserId: null,
-        note: `via share_link:${share.id}`,
-      },
-    });
-    await tx.plan.update({
-      where: { id: plan.id },
-      data: { status: 'completed', completedAt: new Date() },
-    });
-    await tx.auditLog.create({
-      data: {
-        shareLinkId: share.id,
-        action: 'share_complete',
-        resourceType: 'plan',
-        resourceId: plan.id,
-        result: 'success',
-        ip: input.ip ?? null,
-        userAgent: input.userAgent ?? null,
-      },
-    });
-
-    // 完了時の自動連鎖 TOSS は廃止済み (#117)。後続は未 TOSS のまま残す。
-    // NOTE(#131): 共有リンク (非会員=クライアント) 操作の新 3 ロール対応は別 issue。
-    // 現状は Phase 0 の簡易挙動 (tossed/completed イベントのみ) を維持する。
-    return {
-      completed: await loadPlanWithIncludes(tx, plan.id, itemId),
-    };
+    if (!plan.executorMemberId) {
+      throw new ApiException('INCOMPLETE_PLAN', 422, '実施者が設定されていません。');
+    }
+    if (!plan.approverMemberId) {
+      throw new ApiException('NO_APPROVER', 422, '承認者が設定されていません。');
+    }
+    await createShareEvent(tx, plan.id, 'review_requested', shareId);
   });
+}
 
-  return {
-    plan: toPlanDTO(result.completed, []),
-    autoTossed: null,
-  };
+/** 承認 (確認待ち→承認済み。承認者なしなら実施中→承認済み)。後続なしは承認=完了。 */
+export function shareApprove(input: ShareActionInput): Promise<{ plan: PlanDTO }> {
+  return runShareAction(input, 'share_approve', async (tx, plan, shareId) => {
+    const state = shareBallState(plan);
+    if (plan.approverMemberId) {
+      if (state !== 'review_pending') {
+        throw new ApiException('INVALID_STATE', 409, '確認待ちの予定のみ承認できます。');
+      }
+    } else {
+      if (state !== 'in_progress' && state !== 'sent_back') {
+        throw new ApiException('INVALID_STATE', 409, '実施中の予定のみ承認できます。');
+      }
+      if (!plan.executorMemberId) {
+        throw new ApiException('INCOMPLETE_PLAN', 422, '実施者が設定されていません。');
+      }
+    }
+    await createShareEvent(tx, plan.id, 'approved', shareId);
+    // 後続が無ければ承認で完了 (TOSS 先が無い)。TOSS 自体はクライアント不可。
+    if (!plan.successorPlanId) {
+      await tx.plan.update({
+        where: { id: plan.id },
+        data: { status: 'completed', completedAt: new Date() },
+      });
+    }
+  });
+}
+
+/** 差し戻し (確認待ち → 差し戻し。実施側へ戻す)。 */
+export function shareSendBack(input: ShareActionInput): Promise<{ plan: PlanDTO }> {
+  return runShareAction(input, 'share_send_back', async (tx, plan, shareId) => {
+    if (shareBallState(plan) !== 'review_pending') {
+      throw new ApiException('INVALID_STATE', 409, '確認待ちの予定のみ差し戻せます。');
+    }
+    await createShareEvent(tx, plan.id, 'sent_back', shareId);
+  });
 }

--- a/apps/web/src/features/shareLinks/ShareActionModal.test.tsx
+++ b/apps/web/src/features/shareLinks/ShareActionModal.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { server } from '@/test/handlers';
+import { renderWithProviders } from '@/test/render';
+import type { MemberRef, Plan, PlanState } from '@/features/plans/api';
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: { auth: { getSession: vi.fn().mockResolvedValue({ data: { session: null } }) } },
+}));
+
+import { ShareActionModal } from './ShareActionModal';
+
+beforeAll(() => {
+  const p = window.HTMLElement.prototype;
+  p.scrollIntoView = vi.fn();
+  p.hasPointerCapture = vi.fn();
+  p.releasePointerCapture = vi.fn();
+  p.setPointerCapture = vi.fn();
+});
+
+afterEach(() => vi.clearAllMocks());
+
+const m = (over: Partial<MemberRef> = {}): MemberRef => ({
+  id: 'm1',
+  name: '山田',
+  organizationName: 'Acme',
+  memberType: 'production',
+  ...over,
+});
+
+const plan = (over: Partial<Plan> = {}): Plan => ({
+  id: 'plan-1',
+  itemId: 'it1',
+  planType: 'toss',
+  title: 'デザイン確認',
+  category: 'review',
+  scheduledDate: '2026-06-10',
+  dueDate: null,
+  executor: m({ id: 'ex', name: '実施者' }),
+  approver: m({ id: 'ap', name: '承認者', memberType: 'client' }),
+  progressManager: m({ id: 'pm', name: '進行' }),
+  fromMember: null,
+  toMember: null,
+  successorPlanId: 'succ',
+  status: 'active',
+  memo: null,
+  ballHolder: m({ id: 'ex', name: '実施者' }),
+  ballState: 'in_progress' as PlanState,
+  latestEvent: null,
+  completedAt: null,
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+  ...over,
+});
+
+describe('ShareActionModal', () => {
+  it('実施中(承認者あり)は「確認依頼」を表示し、TOSSは出さない', () => {
+    renderWithProviders(
+      <ShareActionModal token="tok" plan={plan({ ballState: 'in_progress' })} onClose={() => {}} />,
+    );
+    expect(screen.getByRole('button', { name: '確認依頼' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'TOSS' })).not.toBeInTheDocument();
+  });
+
+  it('確認待ちは「承認」「差し戻す」を表示する', () => {
+    renderWithProviders(
+      <ShareActionModal token="tok" plan={plan({ ballState: 'review_pending' })} onClose={() => {}} />,
+    );
+    expect(screen.getByRole('button', { name: '承認' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '差し戻す' })).toBeInTheDocument();
+  });
+
+  it('承認済み(TOSS待ち)はクライアントの操作を出さない', () => {
+    renderWithProviders(
+      <ShareActionModal token="tok" plan={plan({ ballState: 'approved' })} onClose={() => {}} />,
+    );
+    expect(
+      screen.getByText('この予定に対してクライアントが行える操作はありません。'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'TOSS' })).not.toBeInTheDocument();
+  });
+
+  it('「承認」クリックで approve エンドポイントを呼び、onClose される', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    let called = false;
+    server.use(
+      http.post('*/api/v1/share/:token/plans/:planId/approve', () => {
+        called = true;
+        return HttpResponse.json({ data: { plan: plan({ ballState: 'approved' }) } });
+      }),
+    );
+    const onClose = vi.fn();
+    renderWithProviders(
+      <ShareActionModal token="tok" plan={plan({ ballState: 'review_pending' })} onClose={onClose} />,
+    );
+    await user.click(screen.getByRole('button', { name: '承認' }));
+    await waitFor(() => expect(called).toBe(true));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/apps/web/src/features/shareLinks/ShareActionModal.tsx
+++ b/apps/web/src/features/shareLinks/ShareActionModal.tsx
@@ -1,0 +1,164 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { format } from 'date-fns';
+import { CheckCircle2, ClipboardCheck, CornerUpLeft, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { ApiClientError } from '@/lib/api';
+import { CATEGORY_STYLE } from '@/features/plans/categoryColor';
+import type { MemberRef, Plan, PlanState } from '@/features/plans/api';
+import { shareAccessApi } from './api';
+
+const STATE_LABEL: Record<PlanState, string> = {
+  in_progress: '実施中',
+  review_pending: '確認待ち',
+  approved: '承認済み・TOSS待ち',
+  tossed: 'TOSS済み',
+  sent_back: '差し戻し',
+  completed: '完了',
+};
+
+/**
+ * 共有リンク (非会員=クライアント) 向けの操作モーダル (#131)。
+ *  - 確認依頼 / 承認 / 差し戻し のみ (状態で出し分け)。
+ *  - 進行責任者の TOSS(次工程へ進める操作)はクライアントには提供しない。
+ */
+export function ShareActionModal({
+  token,
+  plan,
+  onClose,
+}: {
+  token: string;
+  plan: Plan;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const style = CATEGORY_STYLE[plan.category];
+
+  const makeHandlers = (okMsg: string) => ({
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['share', token] });
+      toast.success(okMsg);
+      onClose();
+    },
+    onError: (e: unknown) =>
+      toast.error(e instanceof ApiClientError ? e.message : '操作に失敗しました'),
+  });
+
+  const requestReviewMut = useMutation({
+    mutationFn: () => shareAccessApi.requestReview(token, plan.id),
+    ...makeHandlers('確認を依頼しました'),
+  });
+  const approveMut = useMutation({
+    mutationFn: () => shareAccessApi.approve(token, plan.id),
+    ...makeHandlers('承認しました'),
+  });
+  const sendBackMut = useMutation({
+    mutationFn: () => shareAccessApi.sendBack(token, plan.id),
+    ...makeHandlers('差し戻しました'),
+  });
+  const pending = requestReviewMut.isPending || approveMut.isPending || sendBackMut.isPending;
+
+  const s = plan.ballState;
+  const active = plan.status === 'active';
+  const hasApprover = !!plan.approver;
+  const inProgress = s === 'in_progress' || s === 'sent_back';
+  const hasSuccessor = plan.successorPlanId !== null;
+
+  const canRequestReview = active && inProgress && hasApprover && !!plan.executor;
+  const canApproveDirect = active && inProgress && !hasApprover && !!plan.executor;
+  const canApprove = active && s === 'review_pending';
+  const canSendBack = active && s === 'review_pending';
+  const noAction = !canRequestReview && !canApproveDirect && !canApprove && !canSendBack;
+
+  return (
+    <Sheet open onOpenChange={(o) => !o && onClose()}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            <Badge variant="secondary" className={`${style.bg} ${style.text}`}>
+              {style.label}
+            </Badge>
+            {plan.title}
+          </SheetTitle>
+          <SheetDescription>
+            {format(new Date(plan.scheduledDate), 'yyyy/M/d')}
+            {plan.dueDate && ` 〜 期日 ${format(new Date(plan.dueDate), 'yyyy/M/d')}`}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 space-y-3 overflow-y-auto text-sm">
+          <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 p-2 text-xs">
+            <span className="text-muted-foreground">現在のホルダー</span>
+            <span className="font-medium">{plan.ballHolder?.name ?? '—'}</span>
+            <Badge variant="secondary" className="ml-auto">
+              {STATE_LABEL[plan.ballState]}
+            </Badge>
+          </div>
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+            <dt className="text-muted-foreground">実施者</dt>
+            <dd>{memberLabel(plan.executor)}</dd>
+            <dt className="text-muted-foreground">承認者</dt>
+            <dd>{plan.approver ? memberLabel(plan.approver) : '未設定 (実施者が承認)'}</dd>
+          </dl>
+          {plan.memo && (
+            <div className="rounded-md border border-border bg-muted/40 p-3 text-xs whitespace-pre-wrap">
+              {plan.memo}
+            </div>
+          )}
+          {noAction && (
+            <p className="text-xs text-muted-foreground">
+              この予定に対してクライアントが行える操作はありません。
+            </p>
+          )}
+        </div>
+
+        <SheetFooter className="flex-row flex-wrap justify-end gap-2">
+          {canRequestReview && (
+            <Button onClick={() => requestReviewMut.mutate()} disabled={pending}>
+              {requestReviewMut.isPending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <ClipboardCheck className="size-4" />
+              )}
+              確認依頼
+            </Button>
+          )}
+          {canSendBack && (
+            <Button variant="outline" onClick={() => sendBackMut.mutate()} disabled={pending}>
+              {sendBackMut.isPending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <CornerUpLeft className="size-4" />
+              )}
+              差し戻す
+            </Button>
+          )}
+          {(canApprove || canApproveDirect) && (
+            <Button onClick={() => approveMut.mutate()} disabled={pending}>
+              {approveMut.isPending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <CheckCircle2 className="size-4" />
+              )}
+              {hasSuccessor ? '承認' : '承認して完了'}
+            </Button>
+          )}
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function memberLabel(m: MemberRef | null): string {
+  return m ? `${m.name} (${m.organizationName || '—'})` : '—';
+}

--- a/apps/web/src/features/shareLinks/SharePage.test.tsx
+++ b/apps/web/src/features/shareLinks/SharePage.test.tsx
@@ -58,12 +58,12 @@ afterEach(() => {
 });
 
 describe('SharePage', () => {
-  it('共有ビューを取得してヘッダ (プロジェクト名/scope/閲覧専用) を描画する', async () => {
+  it('共有ビューを取得してヘッダ (プロジェクト名/scope/確認・承認) を描画する', async () => {
     server.use(http.get('*/api/v1/share/:token', () => HttpResponse.json({ data: view })));
     renderWithProviders(<SharePage />);
 
     expect(await screen.findByText('共有プロジェクト')).toBeInTheDocument();
-    expect(screen.getByText('共有リンク (閲覧専用)')).toBeInTheDocument();
+    expect(screen.getByText('共有リンク (確認・承認)')).toBeInTheDocument();
     expect(screen.getByText('scope: project')).toBeInTheDocument();
   });
 

--- a/apps/web/src/features/shareLinks/SharePage.tsx
+++ b/apps/web/src/features/shareLinks/SharePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { format } from 'date-fns';
@@ -6,7 +6,9 @@ import { AlertCircle, Lock } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
+import type { Plan } from '@/features/plans/api';
 import { ShareSchedule } from './ShareSchedule';
+import { ShareActionModal } from './ShareActionModal';
 import { shareAccessApi, type ShareView } from './api';
 
 /**
@@ -38,6 +40,7 @@ export function SharePage() {
 }
 
 function Inner({ token }: { token: string }) {
+  const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
   const viewQuery = useQuery({
     queryKey: ['share', token] as const,
     queryFn: () => shareAccessApi.view(token),
@@ -51,10 +54,26 @@ function Inner({ token }: { token: string }) {
     );
   }
   const data = viewQuery.data!;
+  // 最新データ (invalidate 後の再取得) から選択中の予定を解決する。
+  const selectedPlan = selectedPlanId
+    ? (data.plans.find((p) => p.id === selectedPlanId) ?? null)
+    : null;
   return (
     <div className="flex h-screen flex-col">
       <Header view={data} />
-      <ShareSchedule project={data.project} items={data.items} plans={data.plans} />
+      <ShareSchedule
+        project={data.project}
+        items={data.items}
+        plans={data.plans}
+        onSelectPlan={(plan: Plan) => setSelectedPlanId(plan.id)}
+      />
+      {selectedPlan && (
+        <ShareActionModal
+          token={token}
+          plan={selectedPlan}
+          onClose={() => setSelectedPlanId(null)}
+        />
+      )}
     </div>
   );
 }
@@ -65,7 +84,7 @@ function Header({ view }: { view: ShareView }) {
       <div className="space-y-1">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <Lock className="size-3" />
-          共有リンク (閲覧専用)
+          共有リンク (確認・承認)
         </div>
         <h1 className="text-xl font-semibold tracking-tight">{view.project.name}</h1>
         <p className="text-xs text-muted-foreground">

--- a/apps/web/src/features/shareLinks/ShareSchedule.test.tsx
+++ b/apps/web/src/features/shareLinks/ShareSchedule.test.tsx
@@ -129,15 +129,15 @@ describe('ShareSchedule (閲覧専用)', () => {
     expect(screen.getByText('田中 一郎')).toBeInTheDocument();
   });
 
-  it('normal tier (長期間) のボールは実施者 / 確認者 / 保持者バッジを表示する', () => {
+  it('normal tier (長期間) のボールは実施者 / 保持者を表示する', () => {
     // rowHeight=40, 4日span → height=157 ≥ 120 → normal tier。
+    // #131: FROM/TO は TOSS 履歴のため、カード表示は 実施者(executor) + 保持者(ballHolder)。
     const p = plan({
       id: 'p1',
       title: '長期タスク',
       scheduledDate: '2026-06-10',
       dueDate: '2026-06-13',
-      fromMember: memberRef({ name: '実施 太郎' }),
-      toMember: memberRef({ id: 'm2', name: '確認 花子' }),
+      executor: memberRef({ name: '実施 太郎' }),
       ballHolder: memberRef({ id: 'm2', name: '確認 花子' }),
       ballState: 'in_progress',
     });
@@ -145,9 +145,9 @@ describe('ShareSchedule (閲覧専用)', () => {
 
     expect(screen.getByText('長期タスク')).toBeInTheDocument();
     expect(screen.getByText('実施者')).toBeInTheDocument();
-    expect(screen.getByText('確認者')).toBeInTheDocument();
+    expect(screen.getByText('保持者')).toBeInTheDocument();
     expect(screen.getByText('実施 太郎')).toBeInTheDocument();
-    // 確認者名 / 保持者バッジの両方で出るため複数。
+    // 保持者名 (カード内 + 列ヘッダーのボール保持) で複数出る。
     expect(screen.getAllByText('確認 花子').length).toBeGreaterThanOrEqual(1);
     // カテゴリラベル (normal/compact tier で表示)。
     expect(screen.getByText('デザイン')).toBeInTheDocument();

--- a/apps/web/src/features/shareLinks/ShareSchedule.tsx
+++ b/apps/web/src/features/shareLinks/ShareSchedule.tsx
@@ -29,19 +29,21 @@ const DATE_AXIS_WIDTH = 76;
 type ShareItem = { id: string; name: string };
 
 /**
- * 共有リンク (非会員) 向けの「閲覧専用」スケジュールカレンダー (#59)。
- * ItemSchedulePage の ScheduleBoard と同等のレイアウトを描画するが、
- * ドラッグ移動 / TOSS / 完了 / 作成といった操作ハンドラを一切持たず、
- * 操作不能であることをコンポーネント構造として保証する。
+ * 共有リンク (非会員) 向けスケジュールカレンダー。
+ * ItemSchedulePage の ScheduleBoard と同等のレイアウトを描画する。
+ * ドラッグ移動 / 作成はできない。#131 でクライアントの確認/承認/差し戻し操作を
+ * 追加したため、ボールをクリックすると操作モーダル (onSelectPlan) が開く。
  */
 export function ShareSchedule({
   project,
   items,
   plans,
+  onSelectPlan,
 }: {
   project: { startDate: string; endDate: string };
   items: ShareItem[];
   plans: Plan[];
+  onSelectPlan?: (plan: Plan) => void;
 }) {
   const [rowHeight, setRowHeight] = useState(ROW_HEIGHT_DEFAULT);
 
@@ -73,7 +75,13 @@ export function ShareSchedule({
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
-      <ScheduleBoard days={days} items={items} plansByItem={plansByItem} rowHeight={rowHeight} />
+      <ScheduleBoard
+        days={days}
+        items={items}
+        plansByItem={plansByItem}
+        rowHeight={rowHeight}
+        onSelectPlan={onSelectPlan}
+      />
       <ZoomControl rowHeight={rowHeight} onChange={setRowHeight} />
     </div>
   );
@@ -88,11 +96,13 @@ function ScheduleBoard({
   items,
   plansByItem,
   rowHeight,
+  onSelectPlan,
 }: {
   days: Date[];
   items: ShareItem[];
   plansByItem: Map<string, Plan[]>;
   rowHeight: number;
+  onSelectPlan?: (plan: Plan) => void;
 }) {
   const today = new Date();
   const totalHeight = days.length * rowHeight;
@@ -238,6 +248,7 @@ function ScheduleBoard({
                     laneWidth={laneWidth}
                     lane={laneOf.get(plan.id) ?? 0}
                     today={today}
+                    onSelect={onSelectPlan}
                   />
                 ))}
               </div>
@@ -340,6 +351,7 @@ function BallChip({
   laneWidth,
   lane,
   today,
+  onSelect,
 }: {
   plan: Plan;
   days: Date[];
@@ -347,6 +359,7 @@ function BallChip({
   laneWidth: number;
   lane: number;
   today: Date;
+  onSelect?: (plan: Plan) => void;
 }) {
   const { start, end } = planRange(plan);
   const startIdx = dayIndex(days, start);
@@ -369,12 +382,14 @@ function BallChip({
         ? 'border-slate-300 bg-slate-100 text-slate-600'
         : cn(style.bg, style.border, style.text);
 
+  const clickable = !!onSelect;
   return (
     <div
       className={cn(
         'absolute overflow-hidden rounded-md border px-2 py-1 text-xs shadow-sm',
         cardClass,
         active && !completed && 'ring-2 ring-primary/40',
+        clickable && 'cursor-pointer hover:brightness-95',
       )}
       style={{
         top,
@@ -382,6 +397,19 @@ function BallChip({
         left: lane * laneWidth + 6,
         width: laneWidth - 12,
       }}
+      {...(clickable
+        ? {
+            role: 'button' as const,
+            tabIndex: 0,
+            onClick: () => onSelect(plan),
+            onKeyDown: (e: React.KeyboardEvent) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onSelect(plan);
+              }
+            },
+          }
+        : {})}
     >
       <div className="flex items-center justify-between gap-1">
         <span className="line-clamp-1 font-medium">{plan.title}</span>
@@ -402,16 +430,11 @@ function BallChip({
         <div className="mt-1 border-t border-current/10 pt-1 text-[10px] leading-tight">
           <div className="flex items-center gap-1">
             <span className="opacity-60">実施者</span>
-            <span className="line-clamp-1 font-medium">{plan.fromMember?.name ?? '—'}</span>
+            <span className="line-clamp-1 font-medium">{plan.executor?.name ?? '—'}</span>
           </div>
           <div className="flex items-center gap-1">
-            <span className="opacity-60">確認者</span>
-            <span className="line-clamp-1 font-medium">{plan.toMember?.name ?? '—'}</span>
-            {plan.ballHolder && (
-              <Badge variant="secondary" className="ml-auto px-1 py-0 text-[9px]">
-                {plan.ballHolder.name}
-              </Badge>
-            )}
+            <span className="opacity-60">保持者</span>
+            <span className="line-clamp-1 font-medium">{plan.ballHolder?.name ?? '—'}</span>
           </div>
         </div>
       )}

--- a/apps/web/src/features/shareLinks/api.ts
+++ b/apps/web/src/features/shareLinks/api.ts
@@ -58,9 +58,26 @@ export const shareLinksApi = {
 };
 
 export const shareAccessApi = {
-  // 共有画面は閲覧専用 (#59)。操作系 (toss/complete) は FE からは呼び出さない。
   view: (token: string) =>
     apiRequest<ShareView>(`/share/${encodeURIComponent(token)}`),
+
+  // #131: 非会員(クライアント)の操作。確認依頼 / 承認 / 差し戻し。
+  // 進行責任者の TOSS(次工程へ進める操作)は共有リンクからは提供しない。
+  requestReview: (token: string, planId: string) =>
+    apiRequest<{ plan: Plan }>(
+      `/share/${encodeURIComponent(token)}/plans/${planId}/request-review`,
+      { method: 'POST', body: {} },
+    ),
+  approve: (token: string, planId: string) =>
+    apiRequest<{ plan: Plan }>(`/share/${encodeURIComponent(token)}/plans/${planId}/approve`, {
+      method: 'POST',
+      body: {},
+    }),
+  sendBack: (token: string, planId: string) =>
+    apiRequest<{ plan: Plan }>(`/share/${encodeURIComponent(token)}/plans/${planId}/send-back`, {
+      method: 'POST',
+      body: {},
+    }),
 };
 
 export const shareLinksQueryKey = {

--- a/packages/db/prisma/migrations/20260724000002_add_share_action_events/migration.sql
+++ b/packages/db/prisma/migrations/20260724000002_add_share_action_events/migration.sql
@@ -1,0 +1,42 @@
+-- -----------------------------------------------------------------------------
+-- Migration: 20260724000002_add_share_action_events
+-- issue #131 follow-up: 共有リンク(非会員=クライアント)から新状態機械の操作
+-- (確認依頼 / 承認 / 差し戻し) を許可するため、audit_logs.action に share_* を追加する。
+--   - share_request_review / share_approve / share_send_back
+-- TOSS(進行責任者の操作)は共有リンクからは行わないため追加しない。
+-- 旧 share_toss / share_complete は CHECK に残す(既存行の互換のため。ルートは廃止)。
+--
+-- 許可値の追加のみ(スーパーセット)で既存行は全て満たすため、実データへの破壊なし。
+-- ball_events 側は既存の source='auto_chain'(system actor, actor 両方 NULL)を再利用するため
+-- ck_be_event_type / ck_be_source の変更は不要。
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE "audit_logs" DROP CONSTRAINT "ck_al_action";
+
+ALTER TABLE "audit_logs"
+  ADD CONSTRAINT "ck_al_action" CHECK ("action" IN (
+    'login',
+    'logout',
+    'complete_signup',
+    'update_profile',
+    'email_changed',
+    'account_delete',
+    'toss',
+    'untoss',
+    'complete',
+    'undo_complete',
+    'auto_toss',
+    'request_review',
+    'undo_request_review',
+    'approve',
+    'undo_approve',
+    'send_back',
+    'share_access',
+    'share_create',
+    'share_revoke',
+    'share_toss',
+    'share_complete',
+    'share_request_review',
+    'share_approve',
+    'share_send_back'
+  ));


### PR DESCRIPTION
## 概要

issue #131 のフォローアップ1。これまで **閲覧専用（#59）** だった共有リンク（非会員＝クライアント）に、#131 の新状態機械に沿った操作を追加する。

**クライアントができること**：確認依頼 / 承認 / 差し戻し。
**できないこと**：進行責任者の **TOSS（＝予定を次工程へ進める完了操作）**。§12 の「クライアントから実装者へ直接TOSSはしない。承認後、進行責任者がTOSSする」に一致。

関連: #131

## 仕様（ユーザー確認済み）
- **操作の認可**：共有リンクは匿名アクセスのため、**scope 内かつ状態機械が許す限り**操作可（現在のボール保持者の種別は問わない）。
- **承認は常に許可**：後続の無い予定の承認（＝完了）もクライアント可。ブロックするのは進行責任者の TOSS のみ。
- **表示**：カードは「実施者＋現在の保持者」を表示（旧「実施者/確認者」＝FROM/TO は #131 で TOSS 履歴に意味が変わり、未TOSSでは空になるため）。

## 主な変更

**マイグレーション** `20260724000002_add_share_action_events`
- `audit_logs.action` に `share_request_review` / `share_approve` / `share_send_back` を追加（許可値の追加＝スーパーセット、**実データ非破壊**）。
- `ball_events` は既存の `source='auto_chain'`（system actor、actor 両方 NULL）を再利用（migration 不要）。誰が操作したかは `audit_logs.share_link_id` で辿る（設計書 §5.6）。

**バックエンド**
- `shareAccess.ts`: 未使用の `shareToss` / `shareComplete` を**廃止**し、`shareRequestReview` / `shareApprove` / `shareSendBack` を追加。状態遷移はメンバー版と同じ前提条件（active・状態機械）を踏むが、holder 認可は行わない。
- `share.ts` ルート: `/toss` `/complete` を**廃止**、`/request-review` `/approve` `/send-back` を追加（未認証で誰でも TOSS/完了できた旧エンドポイントの攻撃面も除去）。

**フロントエンド**
- `SharePage`: ボールをクリックすると操作モーダル `ShareActionModal`（新規）が開く。状態に応じて確認依頼／承認／差し戻しを出し分け、TOSS は出さない。
- `ShareSchedule`: カード表示を実施者＋保持者へ修正。ボールをクリック可能に。ヘッダを「閲覧専用」→「確認・承認」に更新。

## テスト
- `shareAccess.test.ts`（in-memory）: 旧 toss/complete テストを新 3 操作へ全面差し替え（確認依頼→承認済み、承認者なし短絡、承認=完了、差し戻し、scope 404、状態違反 409）。
- `share.integration.test.ts`（実DB）: 確認依頼→承認→（後続あり=active/後続なし=completed）、差し戻し、scope/PLAN_NOT_ACTIVE、TOSS エンドポイント不在(404) を検証。
- FE: `ShareSchedule.test` / `SharePage.test` 更新、`ShareActionModal.test` 追加。
- ローカル: type-check / lint(0 warning) / prisma format / unit **668 件緑**。統合テストは CI 実DBジョブで検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)