### PR TITLE
feat(plans): 前工程再開型の差し戻しを追加 (#131 §13)

### DIFF
--- a/apps/web/server/routes/v1/plans.integration.test.ts
+++ b/apps/web/server/routes/v1/plans.integration.test.ts
@@ -170,6 +170,50 @@ describe('plans routes (integration, #131)', () => {
       expect(approved.body.data.plan.status).toBe('completed');
     });
 
+    it('前工程へ差し戻し (§13): 後続の実施中から先行(デザイン作成)を再開する', async () => {
+      const clientId = (await createMember({ projectId: ctx.project.id, memberType: 'client' })).id;
+      // 後続: デザイン確認 (実施者=クライアント)
+      const review = await createPlanViaApi({
+        title: 'デザイン確認',
+        category: 'review',
+        scheduledDate: '2026-07-20',
+        executorMemberId: clientId,
+        progressManagerMemberId: pmId,
+      });
+      // 先行: デザイン作成 (実施者=execId)、後続=デザイン確認
+      const design = await createPlanViaApi({
+        title: 'デザイン作成',
+        category: 'design',
+        scheduledDate: '2026-07-10',
+        executorMemberId: execId,
+        progressManagerMemberId: pmId,
+        successorPlanId: review.body.data.id,
+      });
+      // デザイン作成を承認→TOSS (先行完了、ボールはデザイン確認の実施者=クライアントへ)
+      await act(design.body.data.id, 'approve');
+      await act(design.body.data.id, 'toss');
+      const reviewAfterToss = await getPlan(review.body.data.id);
+      expect(reviewAfterToss.body.data.plan.ballState).toBe('in_progress');
+
+      // デザイン確認(実施中)から前工程へ差し戻し
+      const res = await api<{ data: { plan: PlanDTO; predecessor: PlanDTO } }>(
+        `${base}/${review.body.data.id}/send-back-to-predecessor`,
+        { method: 'POST', token: ctx.token, body: { note: '色を修正してください' } },
+      );
+      expect(res.status).toBe(200);
+      // 先行(デザイン作成)が再開: 実施者にボール、active、FROM/TO 履歴は解除
+      expect(res.body.data.predecessor.ballState).toBe('sent_back');
+      expect(res.body.data.predecessor.ballHolder?.id).toBe(execId);
+      expect(res.body.data.predecessor.status).toBe('active');
+      expect(res.body.data.predecessor.fromMember).toBeNull();
+      // 後続(デザイン確認)は実施中のまま (新カードは作られない)
+      expect(res.body.data.plan.ballState).toBe('in_progress');
+
+      // ライン保持者は先行の実施者へ戻る
+      const design2 = await getPlan(design.body.data.id);
+      expect(design2.body.data.plan.status).toBe('active');
+    });
+
     it('同一予定内の差し戻し: 確認待ち→差し戻し→実施中 (新カードを作らない)', async () => {
       const created = await createPlanViaApi({
         title: 'デザイン作成',

--- a/apps/web/server/routes/v1/plans.ts
+++ b/apps/web/server/routes/v1/plans.ts
@@ -27,6 +27,7 @@ import {
   completePlan,
   requestReviewPlan,
   sendBackPlan,
+  sendBackToPredecessorPlan,
   tossPlan,
   undoApprovePlan,
   undoCompletePlan,
@@ -50,6 +51,7 @@ import {
  *  - POST   /:planId/approve             承認 (→ 承認済み) #131
  *  - POST   /:planId/approve-undo        承認の取り消し
  *  - POST   /:planId/send-back           差し戻し (承認者 → 実施者) #131
+ *  - POST   /:planId/send-back-to-predecessor 前工程へ差し戻し (先行予定を再開) #131 §13
  *  - POST   /:planId/toss                TOSS 実行 (進行責任者 → 後続実施者)
  *  - POST   /:planId/toss-undo           TOSS の取り消し
  *  - POST   /:planId/complete            完了 (= approve のエイリアス, 後方互換)
@@ -187,6 +189,22 @@ export const plansRoute = new Hono()
     if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
     const body = sendBackBodySchema.parse(await c.req.json().catch(() => ({})));
     const result = await sendBackPlan({
+      itemId: c.get('itemId'),
+      planId,
+      note: body?.note ?? null,
+      currentUserId: c.get('currentUserId'),
+      currentMemberId: project.memberId,
+      isDirector: project.isDirector,
+    });
+    return c.json({ data: result });
+  })
+
+  .post('/:planId/send-back-to-predecessor', async (c) => {
+    const project = c.get('project');
+    const planId = c.req.param('planId');
+    if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
+    const body = sendBackBodySchema.parse(await c.req.json().catch(() => ({})));
+    const result = await sendBackToPredecessorPlan({
       itemId: c.get('itemId'),
       planId,
       note: body?.note ?? null,

--- a/apps/web/server/services/ballActions.test.ts
+++ b/apps/web/server/services/ballActions.test.ts
@@ -5,6 +5,7 @@ import type {
   completePlan as CompletePlanType,
   requestReviewPlan as RequestReviewPlanType,
   sendBackPlan as SendBackPlanType,
+  sendBackToPredecessorPlan as SendBackToPredecessorPlanType,
   tossPlan as TossPlanType,
   undoApprovePlan as UndoApprovePlanType,
   undoCompletePlan as UndoCompletePlanType,
@@ -122,6 +123,7 @@ type FindFirstArgs = {
     id?: string;
     itemId?: string;
     projectId?: string;
+    successorPlanId?: string;
     deletedAt?: null;
   };
   include?: unknown;
@@ -131,12 +133,14 @@ type FindFirstArgs = {
 const txClient = {
   plan: {
     // select 指定でも生 plan (+ hydrate) を返す。ballActions が読むのは
-    // .executorMemberId (toss の successor) と .status/.ballEvents (undoToss の successor) のみ。
+    // .executorMemberId (toss の successor) と .status/.ballEvents (undoToss の successor)、
+    // sendBackToPredecessor は successorPlanId で先行予定を引く。
     findFirst: vi.fn(async ({ where }: FindFirstArgs) => {
       const plan = Object.values(planStore).find(
         (p) =>
           (where.id === undefined || p.id === where.id) &&
           (where.itemId === undefined || p.itemId === where.itemId) &&
+          (where.successorPlanId === undefined || p.successorPlanId === where.successorPlanId) &&
           (where.deletedAt === undefined || p.deletedAt === where.deletedAt),
       );
       if (!plan) return null;
@@ -269,6 +273,7 @@ let undoRequestReviewPlan: typeof UndoRequestReviewPlanType;
 let approvePlan: typeof ApprovePlanType;
 let undoApprovePlan: typeof UndoApprovePlanType;
 let sendBackPlan: typeof SendBackPlanType;
+let sendBackToPredecessorPlan: typeof SendBackToPredecessorPlanType;
 let tossPlan: typeof TossPlanType;
 let undoTossPlan: typeof UndoTossPlanType;
 let completePlan: typeof CompletePlanType;
@@ -281,6 +286,7 @@ beforeAll(async () => {
     approvePlan,
     undoApprovePlan,
     sendBackPlan,
+    sendBackToPredecessorPlan,
     tossPlan,
     undoTossPlan,
     completePlan,
@@ -872,6 +878,123 @@ describe('sendBackPlan', () => {
         isDirector: false,
       }),
     ).rejects.toMatchObject({ code: 'NOT_FOUND', status: 404 });
+  });
+});
+
+// -----------------------------------------------------------------------------
+// sendBackToPredecessorPlan (§13 前工程へ差し戻し)
+// -----------------------------------------------------------------------------
+describe('sendBackToPredecessorPlan', () => {
+  /** 先行(デザイン作成) → 後続(デザイン確認) を連結。先行は TOSS 済み(完了)状態にする。 */
+  function setupChain() {
+    const { executor, approver, pm } = makeRoles();
+    const client = makeMember({ name: 'クライアント' });
+    const successor = makePlan({
+      title: 'デザイン確認',
+      executorMemberId: client.id,
+      approverMemberId: client.id,
+      progressManagerMemberId: pm.id,
+    });
+    const predecessor = makePlan({
+      title: 'デザイン作成',
+      executorMemberId: executor.id,
+      approverMemberId: approver.id,
+      progressManagerMemberId: pm.id,
+      successorPlanId: successor.id,
+      // TOSS 済み(完了)を再現: from=進行責任者/to=後続実施者、status=completed、tossed イベント
+      fromMemberId: pm.id,
+      toMemberId: client.id,
+      status: 'completed',
+      completedAt: new Date('2026-05-02T00:00:00Z'),
+    });
+    addEvent(predecessor.id, 'tossed');
+    return { executor, approver, pm, client, successor, predecessor };
+  }
+
+  it('後続の実施中から前工程を再開する: 先行に sent_back・status=active・FROM/TO解除、監査は先行に記録', async () => {
+    const { executor, client, successor, predecessor } = setupChain();
+
+    const res = await sendBackToPredecessorPlan({
+      itemId: 'item-1',
+      planId: successor.id,
+      note: '色を修正してください',
+      currentUserId: 'user-1',
+      currentMemberId: client.id, // 後続の実施者=現ボール保持者
+      isDirector: false,
+    });
+
+    // 先行予定(デザイン作成)が再開: 実施者にボール
+    expect(res.predecessor.ballState).toBe('sent_back');
+    expect(res.predecessor.ballHolder?.id).toBe(executor.id);
+    expect(res.predecessor.status).toBe('active');
+    expect(res.predecessor.fromMember).toBeNull();
+    expect(res.predecessor.toMember).toBeNull();
+    expect(eventTypesFor(predecessor.id)).toEqual(['tossed', 'sent_back']);
+    // 差し戻し理由が履歴に引き継がれる
+    const sb = ballEventStore.find((e) => e.planId === predecessor.id && e.eventType === 'sent_back');
+    expect(sb?.note).toBe('色を修正してください');
+    // 後続(デザイン確認)は実施中のまま
+    expect(res.plan.ballState).toBe('in_progress');
+    // 監査は先行予定に対して記録
+    expect(auditStore.some((a) => a.action === 'send_back' && a.resourceId === predecessor.id)).toBe(true);
+  });
+
+  it('後続が確認待ちなら確認依頼を取り消して実施中へリセットする', async () => {
+    const { client, successor } = setupChain();
+    addEvent(successor.id, 'review_requested'); // 後続を確認待ちにする
+
+    const res = await sendBackToPredecessorPlan({
+      itemId: 'item-1',
+      planId: successor.id,
+      currentUserId: 'user-1',
+      currentMemberId: client.id, // 確認待ちの holder = approver(=client)
+      isDirector: false,
+    });
+    expect(res.plan.ballState).toBe('in_progress');
+    expect(eventTypesFor(successor.id)).toEqual(['review_requested', 'review_request_undone']);
+  });
+
+  it('先行予定(前工程)が無ければ NO_PREDECESSOR 422', async () => {
+    const { executor } = makeRoles();
+    const plan = makePlan({ executorMemberId: executor.id });
+    await expect(
+      sendBackToPredecessorPlan({
+        itemId: 'item-1',
+        planId: plan.id,
+        currentUserId: 'user-1',
+        currentMemberId: executor.id,
+        isDirector: false,
+      }),
+    ).rejects.toMatchObject({ code: 'NO_PREDECESSOR', status: 422 });
+  });
+
+  it('後続が承認済み(TOSS待ち)だと INVALID_STATE 409', async () => {
+    const { pm, client, successor } = setupChain();
+    addEvent(successor.id, 'approved'); // 承認済みにする
+    await expect(
+      sendBackToPredecessorPlan({
+        itemId: 'item-1',
+        planId: successor.id,
+        currentUserId: 'user-1',
+        currentMemberId: pm.id,
+        isDirector: true,
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
+    void client;
+  });
+
+  it('現ボール保持者でもディレクターでもなければ FORBIDDEN 403', async () => {
+    const { successor } = setupChain();
+    const stranger = makeMember();
+    await expect(
+      sendBackToPredecessorPlan({
+        itemId: 'item-1',
+        planId: successor.id,
+        currentUserId: 'user-1',
+        currentMemberId: stranger.id,
+        isDirector: false,
+      }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', status: 403 });
   });
 });
 

--- a/apps/web/server/services/ballActions.ts
+++ b/apps/web/server/services/ballActions.ts
@@ -301,6 +301,76 @@ export async function sendBackPlan(input: {
 }
 
 // -----------------------------------------------------------------------------
+// 前工程へ差し戻し (#131 §13)。後続予定の実施中/確認待ちから、先行予定(自分を
+// successor に指す予定)を再開する。新しい予定カードは作らない。
+//   - 先行予定: sent_back を追記し status=active・完了/TOSS履歴を解除 → 実施者にボール。
+//   - 後続予定(この予定): 実施中にリセット(確認依頼済みなら取り消し)。ボールは先行へ移る。
+//   - 認可: 現ボール保持者 or director (会員のみ。共有リンクからは不可)。
+// -----------------------------------------------------------------------------
+export async function sendBackToPredecessorPlan(input: {
+  itemId: string;
+  planId: string;
+  note?: string | null;
+  currentUserId: string;
+  currentMemberId: string;
+  isDirector: boolean;
+}): Promise<{ plan: PlanDTO; predecessor: PlanDTO }> {
+  const result = await prisma.$transaction(async (tx) => {
+    const plan = await loadPlanWithIncludes(tx, input.planId, input.itemId);
+    assertActive(plan);
+    const state = currentBallState(plan);
+    if (state !== 'in_progress' && state !== 'review_pending') {
+      throw new ApiException('INVALID_STATE', 409, '実施中または確認待ちの予定のみ前工程へ差し戻せます。');
+    }
+    // 認可: 後続予定の現ボール保持者 (実施者/承認者) または director。
+    assertHolderOrDirector(plan, input.currentMemberId, input.isDirector);
+
+    // 先行予定 = この予定を successor に指す予定 (successorPlanId は UNIQUE のため最大1件)。
+    const predecessor = await tx.plan.findFirst({
+      where: { successorPlanId: plan.id, deletedAt: null },
+      select: { id: true },
+    });
+    if (!predecessor) {
+      throw new ApiException('NO_PREDECESSOR', 422, '前工程(先行予定)がありません。');
+    }
+
+    // 先行予定を再開: sent_back を追記し、完了/TOSS履歴を解除 → 実施者にボールが戻る。
+    await createEvent({
+      tx,
+      planId: predecessor.id,
+      eventType: 'sent_back',
+      currentMemberId: input.currentMemberId,
+      currentUserId: input.currentUserId,
+      note: input.note ?? null,
+    });
+    await tx.plan.update({
+      where: { id: predecessor.id },
+      data: { status: 'active', completedAt: null, fromMemberId: null, toMemberId: null },
+    });
+
+    // 後続予定(この予定)を実施中にリセット。確認待ちなら確認依頼を取り消す。
+    if (state === 'review_pending') {
+      await createEvent({
+        tx,
+        planId: plan.id,
+        eventType: 'review_request_undone',
+        currentMemberId: input.currentMemberId,
+        currentUserId: input.currentUserId,
+      });
+    }
+
+    // 監査は「先行予定が差し戻された」として先行予定に記録する。
+    await recordAudit({ tx, actorUserId: input.currentUserId, action: 'send_back', planId: predecessor.id });
+
+    return {
+      plan: await loadPlanWithIncludes(tx, plan.id, input.itemId),
+      predecessor: await loadPlanWithIncludes(tx, predecessor.id, input.itemId),
+    };
+  });
+  return { plan: toPlanDTO(result.plan), predecessor: toPlanDTO(result.predecessor) };
+}
+
+// -----------------------------------------------------------------------------
 // TOSS (承認済み → TOSS済み)。進行責任者が後続予定へボールを渡す。
 //   FROM=進行責任者 / TO=後続予定の実施者 を履歴として書き込む (#131 §14)。
 //   先行予定は status=completed になる (承認=完了扱い、後続あり版)。

--- a/apps/web/src/features/plans/BallDetailModal.test.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.test.tsx
@@ -406,6 +406,40 @@ describe('BallDetailModal (integration)', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // 前工程へ差し戻し (§13)
+  // ---------------------------------------------------------------------------
+  it('前工程がある実施中の予定に「前工程へ差し戻す」を表示し、クリックでAPIを呼ぶ', async () => {
+    setupReads({ plan: makePlan({ ballState: 'in_progress' }), events: [] });
+    let called = false;
+    server.use(
+      http.post(
+        `*/api/v1/projects/${PROJECT_ID}/items/${ITEM_ID}/plans/${PLAN_ID}/send-back-to-predecessor`,
+        () => {
+          called = true;
+          return HttpResponse.json({
+            data: { plan: makePlan(), predecessor: makePlan({ id: 'pred-1' }) },
+          });
+        },
+      ),
+    );
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    // 先行予定 = この予定を後続に指す予定
+    renderModal({ plans: [makePlan({ id: 'pred-1', successorPlanId: PLAN_ID })] });
+
+    const btn = await screen.findByRole('button', { name: '前工程へ差し戻す' });
+    await user.click(btn);
+    await waitFor(() => expect(called).toBe(true));
+  });
+
+  it('前工程が無ければ「前工程へ差し戻す」は表示しない', async () => {
+    setupReads({ plan: makePlan({ ballState: 'in_progress' }), events: [] });
+    renderModal({ plans: [] });
+    // 詳細描画を待つ
+    expect(await screen.findByText('デザインカンプ作成')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '前工程へ差し戻す' })).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
   // 承認 mutation (承認者なし → 実施者が承認 = 完了)
   // ---------------------------------------------------------------------------
   it('承認 成功: 承認者なしの実施中で「完了」ボタンを押すと approve へ POST する', async () => {

--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -10,6 +10,7 @@ import {
   Link2Off,
   Loader2,
   Pencil,
+  Rewind,
   Send,
   Trash2,
   Undo2,
@@ -48,6 +49,7 @@ import {
   useApprovePlan,
   useRequestReviewPlan,
   useSendBackPlan,
+  useSendBackToPredecessorPlan,
   useSetSuccessor,
   useTossPlan,
   useUndoApprovePlan,
@@ -111,6 +113,7 @@ export function BallDetailModal({
   const approveMut = useApprovePlan({ projectId, itemId, planId });
   const undoApproveMut = useUndoApprovePlan({ projectId, itemId, planId });
   const sendBackMut = useSendBackPlan({ projectId, itemId, planId });
+  const sendBackToPredecessorMut = useSendBackToPredecessorPlan({ projectId, itemId, planId });
   const tossMut = useTossPlan({ projectId, itemId, planId });
   const undoTossMut = useUndoTossPlan({ projectId, itemId, planId });
   const successorMut = useSetSuccessor(projectId);
@@ -144,6 +147,7 @@ export function BallDetailModal({
     approveMut.isPending ||
     undoApproveMut.isPending ||
     sendBackMut.isPending ||
+    sendBackToPredecessorMut.isPending ||
     tossMut.isPending ||
     undoTossMut.isPending;
 
@@ -173,6 +177,9 @@ export function BallDetailModal({
             const isExecutor = !!myMember && plan.executor?.id === myMember.id;
             const isApprover = !!myMember && plan.approver?.id === myMember.id;
             const isProgressManager = !!myMember && plan.progressManager?.id === myMember.id;
+            const isBallHolder = !!myMember && plan.ballHolder?.id === myMember.id;
+            // 先行予定 = この予定を後続に指す予定 (successorPlanId は UNIQUE のため最大1件)。
+            const hasPredecessor = plans.some((p) => p.successorPlanId === plan.id);
 
             // 操作の可否 (役割 + 状態)
             const inProgress = s === 'in_progress' || s === 'sent_back';
@@ -187,6 +194,12 @@ export function BallDetailModal({
             // 承認=完了 (後続なし) の取り消し
             const canUndoCompleted =
               plan.status === 'completed' && s !== 'tossed' && (isApprover || isProgressManager || isDirector);
+            // 前工程へ差し戻し (§13): 後続予定の実施中/確認待ちから先行予定を再開。
+            const canSendBackToPredecessor =
+              active &&
+              (s === 'in_progress' || s === 'review_pending') &&
+              hasPredecessor &&
+              (isBallHolder || isDirector);
             const executorMissingHint =
               active && inProgress && !hasExecutor && (isExecutor || isDirector || myMember == null);
 
@@ -326,6 +339,16 @@ export function BallDetailModal({
                         disabled={anyPending}
                         icon={<CornerUpLeft className="size-4" />}
                         label="差し戻す"
+                      />
+                    )}
+                    {canSendBackToPredecessor && (
+                      <ActionButton
+                        variant="outline"
+                        onClick={() => sendBackToPredecessorMut.mutate()}
+                        pending={sendBackToPredecessorMut.isPending}
+                        disabled={anyPending}
+                        icon={<Rewind className="size-4" />}
+                        label="前工程へ差し戻す"
                       />
                     )}
                     {canApprove && (

--- a/apps/web/src/features/plans/api.ts
+++ b/apps/web/src/features/plans/api.ts
@@ -177,6 +177,12 @@ export const plansApi = {
       method: 'POST',
       body: note ? { note } : {},
     }),
+  /** 前工程へ差し戻し (#131 §13)。後続予定から先行予定を再開する。 */
+  sendBackToPredecessor: (projectId: string, itemId: string, planId: string, note?: string) =>
+    apiRequest<{ plan: Plan; predecessor: Plan }>(
+      `${basePath(projectId, itemId)}/${planId}/send-back-to-predecessor`,
+      { method: 'POST', body: note ? { note } : {} },
+    ),
   /** TOSS (承認済み → TOSS済み)。進行責任者が後続予定へボールを渡す。 */
   toss: (projectId: string, itemId: string, planId: string) =>
     apiRequest<BallActionResult>(`${basePath(projectId, itemId)}/${planId}/toss`, {

--- a/apps/web/src/features/plans/useOptimisticBallAction.ts
+++ b/apps/web/src/features/plans/useOptimisticBallAction.ts
@@ -168,6 +168,30 @@ export function useUndoTossPlan(input: { projectId: string; itemId: string; plan
 }
 
 /**
+ * 前工程へ差し戻し (#131 §13)。後続予定と先行予定の両方が変化するため楽観更新はせず、
+ * onSuccess で一覧/詳細を再フェッチする。
+ */
+export function useSendBackToPredecessorPlan(input: {
+  projectId: string;
+  itemId: string;
+  planId: string;
+}) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      plansApi.sendBackToPredecessor(input.projectId, input.itemId, input.planId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: plansQueryKey.list(input.projectId, input.itemId) });
+      qc.invalidateQueries({ queryKey: plansQueryKey.detail(input.projectId, input.itemId, input.planId) });
+      qc.invalidateQueries({ queryKey: plansQueryKey.projectList(input.projectId) });
+      toast.success('前工程へ差し戻しました');
+    },
+    onError: (err) =>
+      toast.error(err instanceof ApiClientError ? err.message : '前工程への差し戻しに失敗しました'),
+  });
+}
+
+/**
  * 後続予定 (successorPlanId) の紐づけ / 解除。
  * - スケジュールのドラッグ紐づけ・モーダルの解除で共用するため projectId のみ固定し、
  *   itemId / planId / successorPlanId は mutate 引数で受ける。


### PR DESCRIPTION
## 概要

issue #131 のフォローアップ2（最後）。§13 の「後続予定で問題があったとき、**前工程（先行予定）を再開する**」クロス予定の差し戻しを追加する。実装済みの「承認者→実施者の同一予定内差し戻し（§7）」とは別操作で、**新しい予定カードは作らない**。

例：デザイン確認（後続）中に問題 → デザイン作成（先行）を再開 → 横山が修正 → 再度確認依頼→承認→再TOSS→クライアント再確認。

関連: #131

## 仕様（ユーザー確認済み）
- **実行者**：後続予定の現ボール保持者（実施者/承認者）or ディレクター。**会員のみ**（共有リンクからは不可）。
- **発動可能状態**：後続予定が **実施中（in_progress）／確認待ち（review_pending）** のとき。
- **後続予定の帰結**：**実施中にリセット**（確認依頼済みなら取り消し）。ボールは先行予定へ。
- **差し戻し理由**：先行予定の履歴（note）へ引き継ぐ。

## 実装

**バックエンド** `ballActions.ts` に `sendBackToPredecessorPlan`：
- 先行予定（自分を `successorPlanId` に指す予定＝UNIQUE で最大1件）に `sent_back` を追記し、`status='active'`・`completed_at=null`・`from/to` 履歴を解除 → **先行の実施者にボールが戻る**。
- 後続予定は実施中にリセット（`review_pending` なら `review_request_undone` を追記）。
- 認可は後続の現ボール保持者 or director。監査は既存 `send_back` を先行予定に記録。
- `deriveLineBallHolders` は**変更不要**：先行が `active` に戻れば、ライン先頭からの走査で自然にボールが先行へ戻る。
- **マイグレーション不要**（新イベント型・新監査アクションなし）。

`route`：`POST /plans/:planId/send-back-to-predecessor` を追加。

**フロントエンド**：`api` に `sendBackToPredecessor`、hook `useSendBackToPredecessorPlan`（2予定が変わるため非楽観・再フェッチ）、`BallDetailModal` に「**前工程へ差し戻す**」ボタン（先行予定あり＆実施中/確認待ち＆現保持者/director）。先行予定の有無は `plans` 一覧から判定（DTO変更なし）。

## テスト
- `ballActions.test`（単体）：先行再開＋後続リセット、確認待ちからのリセット、`NO_PREDECESSOR` 422、`INVALID_STATE` 409、`FORBIDDEN` 403。
- `plans.integration.test`（実DB）：§13 フロー（承認→TOSS→前工程へ差し戻し→先行が実施者に戻り after status=active）。
- `BallDetailModal.test`：ボタン表示条件＋クリックでAPI呼び出し、先行なしで非表示。
- ローカル：type-check / lint(0 warning) / prisma format / unit **675 件緑**。統合は CI 実DBジョブで検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)