### PR TITLE
refactor(plans): 差し戻し系ボタンを整理し TOSS ラベルを明確化 (#131)

### DIFF
--- a/apps/web/server/services/ballActions.test.ts
+++ b/apps/web/server/services/ballActions.test.ts
@@ -939,19 +939,37 @@ describe('sendBackToPredecessorPlan', () => {
     expect(auditStore.some((a) => a.action === 'send_back' && a.resourceId === predecessor.id)).toBe(true);
   });
 
-  it('後続が確認待ちなら確認依頼を取り消して実施中へリセットする', async () => {
-    const { client, successor } = setupChain();
-    addEvent(successor.id, 'review_requested'); // 後続を確認待ちにする
+  it('後続が差し戻し中(sent_back)からも前工程を再開できる', async () => {
+    const { executor, client, successor, predecessor } = setupChain();
+    addEvent(successor.id, 'sent_back'); // 後続を差し戻し中にする (ball=実施者=client)
 
     const res = await sendBackToPredecessorPlan({
       itemId: 'item-1',
       planId: successor.id,
       currentUserId: 'user-1',
-      currentMemberId: client.id, // 確認待ちの holder = approver(=client)
+      currentMemberId: client.id, // 差し戻し中の holder = 実施者(=client)
       isDirector: false,
     });
-    expect(res.plan.ballState).toBe('in_progress');
-    expect(eventTypesFor(successor.id)).toEqual(['review_requested', 'review_request_undone']);
+    // 先行が再開し、後続は差し戻し中のまま (確認依頼は無いので取り消しイベントは追加しない)
+    expect(res.predecessor.ballState).toBe('sent_back');
+    expect(res.predecessor.ballHolder?.id).toBe(executor.id);
+    expect(res.plan.ballState).toBe('sent_back');
+    expect(eventTypesFor(successor.id)).toEqual(['sent_back']);
+    void predecessor;
+  });
+
+  it('後続が確認待ち(review_pending)だと INVALID_STATE 409 (確認依頼前のみ許可)', async () => {
+    const { client, successor } = setupChain();
+    addEvent(successor.id, 'review_requested'); // 後続を確認待ちにする
+    await expect(
+      sendBackToPredecessorPlan({
+        itemId: 'item-1',
+        planId: successor.id,
+        currentUserId: 'user-1',
+        currentMemberId: client.id, // 確認待ちの holder = approver(=client)
+        isDirector: false,
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
   });
 
   it('先行予定(前工程)が無ければ NO_PREDECESSOR 422', async () => {

--- a/apps/web/server/services/ballActions.ts
+++ b/apps/web/server/services/ballActions.ts
@@ -301,10 +301,10 @@ export async function sendBackPlan(input: {
 }
 
 // -----------------------------------------------------------------------------
-// 前工程へ差し戻し (#131 §13)。後続予定の実施中/確認待ちから、先行予定(自分を
-// successor に指す予定)を再開する。新しい予定カードは作らない。
+// 前工程へ差し戻し (#131 §13)。後続予定の実施中/差し戻し中(=確認依頼前)から、先行予定
+// (自分を successor に指す予定)を再開する。新しい予定カードは作らない。
 //   - 先行予定: sent_back を追記し status=active・完了/TOSS履歴を解除 → 実施者にボール。
-//   - 後続予定(この予定): 実施中にリセット(確認依頼済みなら取り消し)。ボールは先行へ移る。
+//   - 後続予定(この予定): 状態はそのまま(実施者にボールがある)。ボールは先行へ移る。
 //   - 認可: 現ボール保持者 or director (会員のみ。共有リンクからは不可)。
 // -----------------------------------------------------------------------------
 export async function sendBackToPredecessorPlan(input: {
@@ -319,8 +319,8 @@ export async function sendBackToPredecessorPlan(input: {
     const plan = await loadPlanWithIncludes(tx, input.planId, input.itemId);
     assertActive(plan);
     const state = currentBallState(plan);
-    if (state !== 'in_progress' && state !== 'review_pending') {
-      throw new ApiException('INVALID_STATE', 409, '実施中または確認待ちの予定のみ前工程へ差し戻せます。');
+    if (state !== 'in_progress' && state !== 'sent_back') {
+      throw new ApiException('INVALID_STATE', 409, '実施中または差し戻し中の予定のみ前工程へ差し戻せます。');
     }
     // 認可: 後続予定の現ボール保持者 (実施者/承認者) または director。
     assertHolderOrDirector(plan, input.currentMemberId, input.isDirector);
@@ -347,17 +347,6 @@ export async function sendBackToPredecessorPlan(input: {
       where: { id: predecessor.id },
       data: { status: 'active', completedAt: null, fromMemberId: null, toMemberId: null },
     });
-
-    // 後続予定(この予定)を実施中にリセット。確認待ちなら確認依頼を取り消す。
-    if (state === 'review_pending') {
-      await createEvent({
-        tx,
-        planId: plan.id,
-        eventType: 'review_request_undone',
-        currentMemberId: input.currentMemberId,
-        currentUserId: input.currentUserId,
-      });
-    }
 
     // 監査は「先行予定が差し戻された」として先行予定に記録する。
     await recordAudit({ tx, actorUserId: input.currentUserId, action: 'send_back', planId: predecessor.id });

--- a/apps/web/src/features/plans/BallDetailModal.test.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.test.tsx
@@ -278,7 +278,7 @@ describe('BallDetailModal (integration)', () => {
     // 状態バッジ (承認済み・TOSS待ち)。
     expect(await screen.findByText('承認済み・TOSS待ち')).toBeInTheDocument();
     // 進行責任者 (=本人) なので TOSS ボタンが出る。
-    expect(screen.getByRole('button', { name: /^TOSS$/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^TOSS（/ })).toBeInTheDocument();
   });
 
   it('completed 状態: 完了済みバナーを表示し TOSS/完了ボタンを出さない', async () => {
@@ -312,7 +312,7 @@ describe('BallDetailModal (integration)', () => {
 
     // 詳細が描画されるまで待つ
     expect(await screen.findByText('承認済み・TOSS待ち')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /^TOSS$/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^TOSS（/ })).not.toBeInTheDocument();
   });
 
   it('認可: 進行責任者でなくてもディレクターなら TOSS できる', async () => {
@@ -330,7 +330,7 @@ describe('BallDetailModal (integration)', () => {
     );
     renderModal();
 
-    expect(await screen.findByRole('button', { name: /^TOSS$/ })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /^TOSS（/ })).toBeInTheDocument();
   });
 
   it('認可: 実施者が未設定なら操作の代わりに案内文を表示する (director)', async () => {
@@ -369,7 +369,7 @@ describe('BallDetailModal (integration)', () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     renderModal();
 
-    const btn = await screen.findByRole('button', { name: /^TOSS$/ });
+    const btn = await screen.findByRole('button', { name: /^TOSS（/ });
     await user.click(btn);
 
     await waitFor(() => expect(tossCalled).toBe(true));
@@ -397,7 +397,7 @@ describe('BallDetailModal (integration)', () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     renderModal();
 
-    const btn = await screen.findByRole('button', { name: /^TOSS$/ });
+    const btn = await screen.findByRole('button', { name: /^TOSS（/ });
     await user.click(btn);
 
     // mutation が呼ばれ、onError でトースト表示 (UI は維持される)
@@ -435,6 +435,16 @@ describe('BallDetailModal (integration)', () => {
     setupReads({ plan: makePlan({ ballState: 'in_progress' }), events: [] });
     renderModal({ plans: [] });
     // 詳細描画を待つ
+    expect(await screen.findByText('デザインカンプ作成')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '前工程へ差し戻す' })).not.toBeInTheDocument();
+  });
+
+  it('確認待ちでは前工程があっても「前工程へ差し戻す」は表示しない (確認依頼前のみ)', async () => {
+    setupReads({
+      plan: makePlan({ ballState: 'review_pending', approver: memberRef(meMember) }),
+      events: [makeEvent({ eventType: 'review_requested' })],
+    });
+    renderModal({ plans: [makePlan({ id: 'pred-1', successorPlanId: PLAN_ID })] });
     expect(await screen.findByText('デザインカンプ作成')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: '前工程へ差し戻す' })).not.toBeInTheDocument();
   });
@@ -516,10 +526,10 @@ describe('BallDetailModal (integration)', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // 差し戻し (send-back) : 確認待ち状態で承認者が実施者へ戻す
+  // 差し戻し集約: 確認待ちでは「差し戻す」を廃止し「確認依頼を取り消す」に集約
   // ---------------------------------------------------------------------------
-  it('差し戻し: 確認待ち状態の「差し戻す」ボタンで send-back へ POST する', async () => {
-    // 承認者=本人。確認待ちで承認者/director が差し戻せる。
+  it('確認待ち: 承認者=本人でも「差し戻す」は表示せず「確認依頼を取り消す」で request-review-undo へ POST する', async () => {
+    // 承認者=本人。確認待ちで承認者/実施者/director が実施者へ戻せる (集約後)。
     setupReads({
       plan: makePlan({
         ballState: 'review_pending',
@@ -528,13 +538,13 @@ describe('BallDetailModal (integration)', () => {
       }),
       events: [makeEvent({ eventType: 'review_requested' })],
     });
-    let sendBackCalled = false;
+    let undoCalled = false;
     server.use(
       http.post(
-        `*/api/v1/projects/${PROJECT_ID}/items/${ITEM_ID}/plans/${PLAN_ID}/send-back`,
+        `*/api/v1/projects/${PROJECT_ID}/items/${ITEM_ID}/plans/${PLAN_ID}/request-review-undo`,
         () => {
-          sendBackCalled = true;
-          return HttpResponse.json({ data: { plan: makePlan({ ballState: 'sent_back' }) } });
+          undoCalled = true;
+          return HttpResponse.json({ data: { plan: makePlan({ ballState: 'in_progress' }) } });
         },
       ),
     );
@@ -542,10 +552,12 @@ describe('BallDetailModal (integration)', () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     renderModal();
 
-    const btn = await screen.findByRole('button', { name: '差し戻す' });
+    const btn = await screen.findByRole('button', { name: '確認依頼を取り消す' });
+    // 「差し戻す」ボタンは廃止済み。
+    expect(screen.queryByRole('button', { name: '差し戻す' })).not.toBeInTheDocument();
     await user.click(btn);
 
-    await waitFor(() => expect(sendBackCalled).toBe(true));
+    await waitFor(() => expect(undoCalled).toBe(true));
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -48,7 +48,6 @@ import { CATEGORY_STYLE } from './categoryColor';
 import {
   useApprovePlan,
   useRequestReviewPlan,
-  useSendBackPlan,
   useSendBackToPredecessorPlan,
   useSetSuccessor,
   useTossPlan,
@@ -112,7 +111,6 @@ export function BallDetailModal({
   const undoRequestReviewMut = useUndoRequestReviewPlan({ projectId, itemId, planId });
   const approveMut = useApprovePlan({ projectId, itemId, planId });
   const undoApproveMut = useUndoApprovePlan({ projectId, itemId, planId });
-  const sendBackMut = useSendBackPlan({ projectId, itemId, planId });
   const sendBackToPredecessorMut = useSendBackToPredecessorPlan({ projectId, itemId, planId });
   const tossMut = useTossPlan({ projectId, itemId, planId });
   const undoTossMut = useUndoTossPlan({ projectId, itemId, planId });
@@ -146,7 +144,6 @@ export function BallDetailModal({
     undoRequestReviewMut.isPending ||
     approveMut.isPending ||
     undoApproveMut.isPending ||
-    sendBackMut.isPending ||
     sendBackToPredecessorMut.isPending ||
     tossMut.isPending ||
     undoTossMut.isPending;
@@ -186,7 +183,9 @@ export function BallDetailModal({
             const canRequestReview = active && inProgress && hasApprover && hasExecutor && (isExecutor || isDirector);
             const canApproveByExecutor = active && inProgress && !hasApprover && hasExecutor && (isExecutor || isDirector);
             const canApprove = active && s === 'review_pending' && (isApprover || isDirector);
-            const canSendBack = active && s === 'review_pending' && (isApprover || isDirector);
+            // 差し戻し=確認依頼の取り消しに集約。承認者/実施者/director が実施者へ戻せる。
+            const canUndoReview =
+              active && s === 'review_pending' && (isApprover || isExecutor || isDirector);
             const canToss = active && s === 'approved' && hasSuccessor && (isProgressManager || isDirector);
             const canUndoApprove = active && s === 'approved' && (isApprover || isProgressManager || isDirector);
             // TOSS 済み → 誰でも取り消せる (誤TOSS救済 #50)
@@ -194,12 +193,9 @@ export function BallDetailModal({
             // 承認=完了 (後続なし) の取り消し
             const canUndoCompleted =
               plan.status === 'completed' && s !== 'tossed' && (isApprover || isProgressManager || isDirector);
-            // 前工程へ差し戻し (§13): 後続予定の実施中/確認待ちから先行予定を再開。
+            // 前工程へ差し戻し (§13): 確認依頼前 (実施中/差し戻し中) のみ、先行予定を再開できる。
             const canSendBackToPredecessor =
-              active &&
-              (s === 'in_progress' || s === 'review_pending') &&
-              hasPredecessor &&
-              (isBallHolder || isDirector);
+              active && inProgress && hasPredecessor && (isBallHolder || isDirector);
             const executorMissingHint =
               active && inProgress && !hasExecutor && (isExecutor || isDirector || myMember == null);
 
@@ -331,16 +327,6 @@ export function BallDetailModal({
                         label={hasSuccessor ? '承認' : '完了'}
                       />
                     )}
-                    {canSendBack && (
-                      <ActionButton
-                        variant="outline"
-                        onClick={() => sendBackMut.mutate()}
-                        pending={sendBackMut.isPending}
-                        disabled={anyPending}
-                        icon={<CornerUpLeft className="size-4" />}
-                        label="差し戻す"
-                      />
-                    )}
                     {canSendBackToPredecessor && (
                       <ActionButton
                         variant="outline"
@@ -366,7 +352,7 @@ export function BallDetailModal({
                         pending={tossMut.isPending}
                         disabled={anyPending}
                         icon={<Send className="size-4" />}
-                        label="TOSS"
+                        label="TOSS（次の予定を開始する）"
                       />
                     )}
                     {canUndoApprove && (
@@ -379,8 +365,8 @@ export function BallDetailModal({
                         label="承認を取り消す"
                       />
                     )}
-                    {/* 確認待ちで実施者/director が誤依頼を取り消す */}
-                    {active && s === 'review_pending' && (isExecutor || isDirector) && (
+                    {/* 確認待ちで実施者/承認者/director が実施者へ戻す (差し戻しをここに集約) */}
+                    {canUndoReview && (
                       <ActionButton
                         variant="outline"
                         onClick={() => undoRequestReviewMut.mutate()}


### PR DESCRIPTION
## 概要
確認待ち状態のボール詳細モーダルに差し戻し系ボタンが 4 つ並び分かりづらい問題を解消し、TOSS ボタンの意味を明確にする。関連: #131

## 変更点
1. **「差し戻す」を廃止し「確認依頼を取り消す」に集約** — 挙動的に両者は「実施者へボールを戻す」で同一のため統合。承認者/実施者/director が確認待ちで実施者へ戻せる（承認者の差し戻し手段を失わないよう表示対象を合集に）。
2. **「前工程へ差し戻す」を確認依頼前のみに制限** — 実施中/差し戻し中（`in_progress`/`sent_back`）のみ実行可、確認待ち（`review_pending`）からは不可に。FE ボタン条件と BE `sendBackToPredecessorPlan` のガードを両方更新。
3. **TOSS ラベルを「TOSS（次の予定を開始する）」に変更** — 押すと後続予定が開始することを明示。

結果、確認待ちで見えるのは **承認 ＋ 確認依頼を取り消す** の 2 ボタンに集約。

## 補足（スコープ外・報告のみ）
役割別ゲーティング（`isExecutor`/`isApprover`/`isProgressManager` の出し分け）は #131 の意図的仕様として残置。現状は作成者＝director に `|| isDirector` が付くため常に全表示で、非作成者メンバーがログインした場合のみ差が出る（休眠状態）。将来のマルチログイン本格運用時に簡素化を別途判断。

## テスト
- `BallDetailModal.test.tsx`: 確認待ちで「差し戻す」非表示・「確認依頼を取り消す」で `request-review-undo` 呼び出し、確認待ちでは前工程差し戻し非表示、TOSS ラベル更新。
- `ballActions.test.ts`: `sent_back` からの前工程差し戻し成功、`review_pending` は `INVALID_STATE` 409。
- ローカル: type-check / lint（--max-warnings 0）緑、web ユニット 653 passed。

マイグレーション不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)