### PR TITLE
Storybook: 実際に使用中のUIコンポーネント全てにstoryを追加

### DIFF
--- a/apps/web/src/components/layout/PageContainer.stories.tsx
+++ b/apps/web/src/components/layout/PageContainer.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PageContainer } from './PageContainer';
+
+const meta = {
+  title: 'layout/PageContainer',
+  component: PageContainer,
+  tags: ['autodocs'],
+  argTypes: {
+    width: {
+      control: 'select',
+      options: ['md', 'lg', 'xl'],
+    },
+  },
+  args: {
+    children: (
+      <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+        ページ本文がここに入ります。
+      </div>
+    ),
+  },
+} satisfies Meta<typeof PageContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Medium: Story = { args: { width: 'md' } };
+export const ExtraLarge: Story = { args: { width: 'xl' } };

--- a/apps/web/src/components/layout/PageHeader.stories.tsx
+++ b/apps/web/src/components/layout/PageHeader.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PageHeader } from './PageHeader';
+import { Button } from '@/components/ui/button';
+
+const meta = {
+  title: 'layout/PageHeader',
+  component: PageHeader,
+  tags: ['autodocs'],
+  args: {
+    title: 'プロジェクト一覧',
+  },
+} satisfies Meta<typeof PageHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithDescriptionAndActions: Story = {
+  args: {
+    description: '担当しているプロジェクトの進行状況を確認できます。',
+    actions: <Button size="sm">新規プロジェクト</Button>,
+  },
+};

--- a/apps/web/src/components/ui/alert-dialog.stories.tsx
+++ b/apps/web/src/components/ui/alert-dialog.stories.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './button';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from './alert-dialog';
+
+const meta = {
+  title: 'ui/AlertDialog',
+  component: AlertDialog,
+  tags: ['autodocs'],
+} satisfies Meta<typeof AlertDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// アプリ内では AlertDialogTrigger を使わず、親コンポーネントが `open` state を制御する。
+export const Default: Story = {
+  render: function Render() {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button variant="destructive" onClick={() => setOpen(true)}>
+          アカウントを削除
+        </Button>
+        <AlertDialog open={open} onOpenChange={setOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>本当に削除しますか？</AlertDialogTitle>
+              <AlertDialogDescription>
+                この操作は取り消せません。アカウントに関するすべてのデータが完全に削除されます。
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>キャンセル</AlertDialogCancel>
+              <AlertDialogAction>削除する</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </>
+    );
+  },
+};

--- a/apps/web/src/components/ui/avatar.stories.tsx
+++ b/apps/web/src/components/ui/avatar.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Avatar } from './avatar';
+
+const meta = {
+  title: 'ui/Avatar',
+  component: Avatar,
+  tags: ['autodocs'],
+  args: { name: '田中太郎', className: 'size-8 text-xs' },
+} satisfies Meta<typeof Avatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Large: Story = { args: { className: 'size-12 text-base' } };

--- a/apps/web/src/components/ui/date-field.stories.tsx
+++ b/apps/web/src/components/ui/date-field.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DateField } from './date-field';
+
+const meta = {
+  title: 'ui/DateField',
+  component: DateField,
+  tags: ['autodocs'],
+} satisfies Meta<typeof DateField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const WithValue: Story = { args: { defaultValue: '2026-08-04' } };

--- a/apps/web/src/components/ui/dialog.stories.tsx
+++ b/apps/web/src/components/ui/dialog.stories.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from './dialog';
+
+const meta = {
+  title: 'ui/Dialog',
+  component: Dialog,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Dialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// アプリ内では DialogTrigger を使わず、親コンポーネントが `open` state を制御する。
+export const Default: Story = {
+  render: function Render() {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>ダイアログを開く</Button>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>プランを削除しますか？</DialogTitle>
+              <DialogDescription>
+                この操作は取り消せません。関連する工程のデータも削除されます。
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="outline">キャンセル</Button>
+              </DialogClose>
+              <Button variant="destructive">削除する</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </>
+    );
+  },
+};

--- a/apps/web/src/components/ui/input.stories.tsx
+++ b/apps/web/src/components/ui/input.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Input } from './input';
+
+const meta = {
+  title: 'ui/Input',
+  component: Input,
+  tags: ['autodocs'],
+  args: { placeholder: 'テキストを入力' },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Disabled: Story = { args: { disabled: true, value: '編集不可' } };
+export const Invalid: Story = { args: { 'aria-invalid': true, defaultValue: '不正な値' } };

--- a/apps/web/src/components/ui/label.stories.tsx
+++ b/apps/web/src/components/ui/label.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Label } from './label';
+import { Input } from './input';
+
+const meta = {
+  title: 'ui/Label',
+  component: Label,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="grid gap-1.5">
+      <Label htmlFor="story-email">メールアドレス</Label>
+      <Input id="story-email" type="email" placeholder="you@example.com" />
+    </div>
+  ),
+};

--- a/apps/web/src/components/ui/select.stories.tsx
+++ b/apps/web/src/components/ui/select.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from './select';
+
+const meta = {
+  title: 'ui/Select',
+  component: Select,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Select>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Select defaultValue="production">
+      <SelectTrigger className="w-48">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="production">制作側</SelectItem>
+        <SelectItem value="client">クライアント</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};

--- a/apps/web/src/components/ui/separator.stories.tsx
+++ b/apps/web/src/components/ui/separator.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Separator } from './separator';
+
+const meta = {
+  title: 'ui/Separator',
+  component: Separator,
+  tags: ['autodocs'],
+  argTypes: {
+    orientation: {
+      control: 'select',
+      options: ['horizontal', 'vertical'],
+    },
+  },
+} satisfies Meta<typeof Separator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {
+  render: (args) => (
+    <div className="w-64">
+      <p className="text-sm">上のコンテンツ</p>
+      <Separator {...args} className="my-4" />
+      <p className="text-sm">下のコンテンツ</p>
+    </div>
+  ),
+};
+
+export const Vertical: Story = {
+  args: { orientation: 'vertical' },
+  render: (args) => (
+    <div className="flex h-12 items-center gap-4">
+      <span className="text-sm">左</span>
+      <Separator {...args} />
+      <span className="text-sm">右</span>
+    </div>
+  ),
+};

--- a/apps/web/src/components/ui/sheet.stories.tsx
+++ b/apps/web/src/components/ui/sheet.stories.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './button';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription, SheetFooter, SheetClose } from './sheet';
+
+const meta = {
+  title: 'ui/Sheet',
+  component: Sheet,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Sheet>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Sheet は `@radix-ui/react-dialog` を modal={false} で使う非ブロッキングパネルで、
+// アプリ内では SheetTrigger を使わず親コンポーネントが `open` を制御する。
+export const Default: Story = {
+  render: function Render() {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>予定を作成</Button>
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetContent>
+            <SheetHeader>
+              <SheetTitle>新しい予定</SheetTitle>
+              <SheetDescription>カレンダーに新しい工程予定を追加します。</SheetDescription>
+            </SheetHeader>
+            <SheetFooter>
+              <SheetClose asChild>
+                <Button variant="outline">閉じる</Button>
+              </SheetClose>
+              <Button>保存</Button>
+            </SheetFooter>
+          </SheetContent>
+        </Sheet>
+      </>
+    );
+  },
+};

--- a/apps/web/src/components/ui/skeleton.stories.tsx
+++ b/apps/web/src/components/ui/skeleton.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Skeleton } from './skeleton';
+
+const meta = {
+  title: 'ui/Skeleton',
+  component: Skeleton,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { className: 'h-4 w-48' } };
+
+export const CardPlaceholder: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 w-64">
+      <Skeleton className="h-32 w-full rounded-lg" />
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="h-4 w-1/2" />
+    </div>
+  ),
+};

--- a/apps/web/src/components/ui/sonner.stories.tsx
+++ b/apps/web/src/components/ui/sonner.stories.tsx
@@ -1,0 +1,23 @@
+import { toast } from 'sonner';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './button';
+import { Toaster } from './sonner';
+
+const meta = {
+  title: 'ui/Toaster',
+  component: Toaster,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Toaster>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// アプリでは SidebarLayout に一度だけ配置し、各機能から `toast()` を呼び出して表示する。
+export const Default: Story = {
+  render: () => (
+    <div>
+      <Button onClick={() => toast.success('保存しました')}>トーストを表示</Button>
+      <Toaster richColors position="bottom-center" />
+    </div>
+  ),
+};

--- a/apps/web/src/components/ui/table.stories.tsx
+++ b/apps/web/src/components/ui/table.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from './table';
+
+const meta = {
+  title: 'ui/Table',
+  component: Table,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Table>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const members = [
+  { name: '田中太郎', role: '制作側', email: 'tanaka@example.com' },
+  { name: '佐藤花子', role: 'クライアント', email: 'sato@example.com' },
+];
+
+export const Default: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>名前</TableHead>
+          <TableHead>役割</TableHead>
+          <TableHead>メールアドレス</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {members.map((member) => (
+          <TableRow key={member.email}>
+            <TableCell>{member.name}</TableCell>
+            <TableCell>{member.role}</TableCell>
+            <TableCell>{member.email}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+};

--- a/apps/web/src/components/ui/tabs.stories.tsx
+++ b/apps/web/src/components/ui/tabs.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs';
+
+const meta = {
+  title: 'ui/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Tabs defaultValue="active" className="w-80">
+      <TabsList>
+        <TabsTrigger value="active">進行中</TabsTrigger>
+        <TabsTrigger value="archived">アーカイブ済み</TabsTrigger>
+      </TabsList>
+      <TabsContent value="active" className="mt-4 text-sm">
+        進行中のプロジェクト一覧です。
+      </TabsContent>
+      <TabsContent value="archived" className="mt-4 text-sm">
+        アーカイブ済みのプロジェクト一覧です。
+      </TabsContent>
+    </Tabs>
+  ),
+};

--- a/apps/web/src/components/ui/textarea.stories.tsx
+++ b/apps/web/src/components/ui/textarea.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Textarea } from './textarea';
+
+const meta = {
+  title: 'ui/Textarea',
+  component: Textarea,
+  tags: ['autodocs'],
+  args: { placeholder: '備考を入力してください' },
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Disabled: Story = { args: { disabled: true, defaultValue: '編集不可' } };


### PR DESCRIPTION
## Summary
- #138 で導入した Storybook カタログは Button/Badge/Card の3つのみだったが、`apps/web/src/components` 配下でアプリが実際に使用している残り全コンポーネントに story を追加した。
- 対象: AlertDialog, Avatar, DateField, Dialog, Input, Label, Select, Separator, Sheet, Skeleton, Sonner(Toaster), Table, Tabs, Textarea (`components/ui`)、PageContainer, PageHeader (`components/layout`)。
- Dialog/AlertDialog/Sheet は実アプリと同じく `*Trigger` を使わず、親コンポーネントが `open` state を制御するパターンで story を書いている（実際のコードベースを grep して使用パターンを確認済み）。
- `components/ui` 配下で story が無いのは `utils.ts`（コンポーネントではない cn ヘルパー）のみ。

## Test plan
- [x] `pnpm --filter @trakon/web build-storybook` がローカルで成功し、全16件の新規 story を含めてビルドされることを確認
- [x] `pnpm --filter @trakon/web lint` / `type-check` / `test`（653件）が green
- [x] ローカルの Storybook dev server (`:6006`) で Sheet / AlertDialog / Dialog / Select / Toaster を実際にブラウザで開き、実 Tailwind スタイルで正しく描画されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)