### PR TITLE
fix(web): 単日カードとボタンラベルの縦位置ズレを修正

### DIFF
--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -14,6 +14,11 @@ import { cn } from './utils';
  *   default 40px … ヘッダーの主要操作
  *   lg      44px … フォームの標準 (node 78:18「標準高さ 44px」)
  * 左右余白は「通常 18px 以上 / 主要操作 24px 以上」(同 node 78:18)。
+ *
+ * ラベルを含むサイズには pb-[0.11em] を入れている。Noto Sans JP は行ボックスが
+ * 上下非対称 (hhea ascent 1.16em / descent 0.288em) で、字面の中心が行ボックスの
+ * 中心より約 0.056em 下に来る。items-center だけだとラベルが沈んで見えるため、
+ * その 2 倍を下パディングで相殺して光学的に中央へ戻す (アイコンのみの size は対象外)。
  */
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-3 whitespace-nowrap rounded-md font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
@@ -30,9 +35,9 @@ const buttonVariants = cva(
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        sm: 'h-9 gap-2 px-3.5 text-body has-[>svg]:px-3',
-        default: 'h-10 px-4.5 text-body has-[>svg]:px-4',
-        lg: 'h-11 px-6 text-body has-[>svg]:px-5',
+        sm: 'h-9 gap-2 px-3.5 pb-[0.11em] text-body has-[>svg]:px-3',
+        default: 'h-10 px-4.5 pb-[0.11em] text-body has-[>svg]:px-4',
+        lg: 'h-11 px-6 pb-[0.11em] text-body has-[>svg]:px-5',
         icon: 'size-10',
         'icon-sm': 'size-9',
       },

--- a/apps/web/src/features/plans/schedule/BallChip.test.tsx
+++ b/apps/web/src/features/plans/schedule/BallChip.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { addDays, format } from 'date-fns';
+
+import type { MemberRef, Plan } from '../api';
+import { BallChip } from './BallChip';
+
+const TODAY = new Date('2026-07-01T00:00:00.000Z');
+const DAYS = Array.from({ length: 7 }, (_, i) => addDays(TODAY, i));
+const iso = (offset: number) => format(addDays(TODAY, offset), 'yyyy-MM-dd');
+
+const member: MemberRef = {
+  id: 'm1',
+  name: '杉野 遥',
+  organizationName: '余白デザイン室',
+  memberType: 'production',
+};
+
+const plan = (scheduledDate: string, dueDate: string | null): Plan => ({
+  id: 'p1',
+  itemId: 'i1',
+  title: '予定',
+  planType: 'toss',
+  category: 'design',
+  colorTheme: null,
+  scheduledDate,
+  dueDate,
+  executor: member,
+  approver: null,
+  progressManager: null,
+  fromMember: null,
+  toMember: null,
+  successorPlanId: null,
+  status: 'active',
+  memo: null,
+  ballHolder: member,
+  ballState: 'in_progress',
+  latestEvent: null,
+  completedAt: null,
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+});
+
+function chipOf(p: Plan) {
+  const { container } = render(
+    <BallChip plan={p} days={DAYS} rowHeight={40} laneWidth={240} lane={0} today={TODAY} />,
+  );
+  const el = container.querySelector('[data-plan-id="p1"]');
+  if (!el) throw new Error('chip not rendered');
+  return el;
+}
+
+describe('BallChip の上下パディング', () => {
+  it('単日の予定はパディングを畳んでタイトルを上下中央に置く', () => {
+    // 高さ = 1日 * 40 - インセット 8 = 32px。Figma の 11/12px を入れると
+    // タイトル 1 行 (20px) が収まらず下端へ押し出されるため中央寄せに切り替える。
+    const el = chipOf(plan(iso(0), iso(0)));
+    expect(el.className).toContain('justify-center');
+    expect(el.className).not.toContain('pt-[11px]');
+  });
+
+  it('高さが足りる予定は Figma どおりの上下パディングを保つ', () => {
+    // 高さ = 3日 * 40 - 8 = 112px。
+    const el = chipOf(plan(iso(0), iso(2)));
+    expect(el.className).toContain('pt-[11px]');
+    expect(el.className).not.toContain('justify-center');
+  });
+});

--- a/apps/web/src/features/plans/schedule/BallChip.tsx
+++ b/apps/web/src/features/plans/schedule/BallChip.tsx
@@ -117,6 +117,12 @@ export function BallChip({
 
   const statusStatus = completed ? 'completed' : plan.ballState;
 
+  // 単日のように背の低いカードでは、Figma (node 11:2) の上下パディング 11/12px を
+  // 入れるとタイトル 1 行 (14px * 1.5 = 20px) が収まらず、下端へ押し出されて見える。
+  // 収まらない高さのときだけパディングを畳み、タイトルを上下中央に置く。
+  // pb-[0.11em] は Noto Sans JP の行ボックス非対称の補正 (ui/button.tsx と同じ理由)。
+  const tight = height < 11 + 20 + 12;
+
   return (
     <div
       {...(clickable
@@ -138,7 +144,8 @@ export function BallChip({
       onPointerEnter={editing ? () => onHoverChange?.(plan.id) : undefined}
       onPointerLeave={editing ? () => onHoverChange?.(null) : undefined}
       className={cn(
-        'shadow-card group absolute flex flex-col overflow-hidden rounded-lg border pt-[11px] pr-[15px] pb-[12px] pl-[15px]',
+        'shadow-card group absolute flex flex-col overflow-hidden rounded-lg border px-[15px]',
+        tight ? 'justify-center pb-[0.11em]' : 'pt-[11px] pb-[12px]',
         surfaceClass,
         borderClass,
         ringClass,

--- a/apps/web/src/features/plans/schedule/ScheduleBoard.stories.tsx
+++ b/apps/web/src/features/plans/schedule/ScheduleBoard.stories.tsx
@@ -108,6 +108,17 @@ const PLANS: Plan[] = [
     ballState: 'review_pending',
     ballHolder: ishihara,
   }),
+  // 単日の予定 (高さが最小のカード)。上下パディングの畳み込みを目視するため常設する。
+  plan({
+    id: 'p7',
+    itemId: 'card',
+    title: 'ロゴ入稿',
+    category: 'other',
+    colorTheme: null,
+    scheduledDate: iso(1),
+    dueDate: iso(1),
+    executor: aoki,
+  }),
 ];
 
 const ITEMS = [


### PR DESCRIPTION
## 背景

デザイン反映後のスケジュール画面で、次の 2 箇所のテキストが下にずれて見える問題の修正です。

## 修正内容

### 1. 単日の予定カード（タイトルが下端に張り付く）

`BallChip` に Figma (node 11:2) の上下パディング `11px / 12px` を高さに関係なく当てていました。単日の予定はカード高が `rowHeight(40) - インセット(8) = 32px` しかなく、`11 + タイトル1行(14px×1.5=20px) + 12 = 43px` が収まりません。その結果タイトルが下端へ押し出され、上に大きな余白ができていました（ズームアウト時は下端が欠けます）。

**43px を確保できない高さのときだけ上下パディングを畳み、タイトルを上下中央に置く**ようにしました。高さが足りるカードは従来どおり Figma の 11/12px を保ちます。

### 2. ボタンのラベル（アイコンより沈んで見える）

Noto Sans JP は行ボックスが上下非対称（hhea ascent `1.16em` / descent `0.288em`）で、**字面の中心が行ボックスの中心より約 0.056em 下**に来ます。`items-center` は行ボックスを中央に揃えるため、ラベルだけが沈んで見え、同じ行の `size-4` アイコンとの高さが揃いませんでした。

`sm / default / lg` の各 size に `pb-[0.11em]`（ズレの 2 倍）を足して光学的に中央へ戻しています。アイコンのみの `icon / icon-sm` は対象外です。この補正は単日カードのタイトル（中央寄せ時）にも同じ理由で入れています。

## 確認

- Storybook `plans/ScheduleBoard` に単日の予定「ロゴ入稿」を常設し、目視で確認できるようにしました。
- `BallChip.test.tsx` を新規追加し、単日 → 中央寄せ / 3日 → Figma パディング維持を回帰テストとして固定。
- `pnpm lint` / `pnpm type-check` / `pnpm test:coverage`（73 files・687 tests、lines 88.55%）通過。

## レビューで見てほしい点

`pb-[0.11em]` はフォントメトリクス由来の補正なので、本来は `@font-face` の `ascent-override` / `descent-override` で直すのが筋です。ただし fontsource の日本語サブセットは `@font-face` が多数に分割されており全面再宣言が現実的でないため、影響範囲を Button とカードタイトルに絞った補正に留めています。同じズレは `StatusPill` などの中央寄せテキストにも理屈上ありますが、今回は指摘のあった 2 箇所のみ対応しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)