### PR TITLE
style(web): ボール詳細モーダルの概要タブを履歴タブと同じ作りに揃える

### DIFF
--- a/apps/web/src/components/trakon/RoleRow.tsx
+++ b/apps/web/src/components/trakon/RoleRow.tsx
@@ -58,9 +58,14 @@ export function RoleRow({
         {initial}
       </span>
       <span className="flex min-w-0 flex-col">
-        <span className={cn('truncate font-medium', detail ? 'text-sm' : 'text-mini')}>{name}</span>
+        {/* detail は行の高さをアバター (32px) に揃えたいので行間を詰める (Figma node 38:12) */}
+        <span
+          className={cn('truncate font-medium', detail ? 'text-sm leading-tight' : 'text-mini')}
+        >
+          {name}
+        </span>
         {detail && caption ? (
-          <span className="text-text-secondary truncate text-tiny">{caption}</span>
+          <span className="text-text-secondary truncate text-tiny leading-tight">{caption}</span>
         ) : null}
       </span>
       {!detail && caption ? (

--- a/apps/web/src/features/plans/BallDetailModal.stories.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.stories.tsx
@@ -1,0 +1,204 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { addDays, format, subDays, subHours } from 'date-fns';
+
+import type { ProjectDetail } from '@/features/projects/api';
+import { projectsQueryKey } from '@/features/projects/api';
+import type { ProjectMember } from '@/features/projects/membersApi';
+
+import { BallDetailModal } from './BallDetailModal';
+import { plansQueryKey, type BallEvent, type MemberRef, type Plan, type PlanDetail } from './api';
+
+// デモデータは Figma node 20:2 の架空名称に揃える。
+const member = (
+  id: string,
+  name: string,
+  organizationName: string,
+  memberType: MemberRef['memberType'] = 'production',
+): MemberRef => ({ id, name, organizationName, memberType });
+
+const sugino = member('m1', '杉野 遥', '余白デザイン室');
+const ishihara = member('m2', '石原 美咲', '株式会社灯和食品', 'client');
+const yokoyama = member('m3', '横山 直樹', '余白デザイン室');
+const aoki = member('m4', '青木 蓮', '余白デザイン室');
+
+const PROJECT_ID = 'pj1';
+const ITEM_ID = 'it1';
+const PLAN_ID = 'pl1';
+
+const TODAY = new Date();
+const iso = (offset: number) => format(addDays(TODAY, offset), 'yyyy-MM-dd');
+
+const PLAN: Plan = {
+  id: PLAN_ID,
+  itemId: ITEM_ID,
+  planType: 'toss',
+  title: 'Webデザイン',
+  category: 'design',
+  colorTheme: 'violet',
+  scheduledDate: iso(0),
+  dueDate: iso(3),
+  executor: sugino,
+  approver: ishihara,
+  progressManager: yokoyama,
+  fromMember: null,
+  toMember: null,
+  successorPlanId: 'pl2',
+  status: 'active',
+  memo: null,
+  ballHolder: ishihara,
+  ballState: 'review_pending',
+  latestEvent: null,
+  completedAt: null,
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+};
+
+const SUCCESSOR: Plan = {
+  ...PLAN,
+  id: 'pl2',
+  itemId: 'it2',
+  title: 'フロントエンド実装',
+  category: 'coding',
+  colorTheme: null,
+  scheduledDate: iso(4),
+  dueDate: iso(9),
+  executor: aoki,
+  successorPlanId: null,
+  ballHolder: aoki,
+  ballState: 'in_progress',
+};
+
+const event = (
+  id: string,
+  eventType: BallEvent['eventType'],
+  actor: MemberRef,
+  occurredAt: Date,
+  note: string | null = null,
+): BallEvent => ({ id, eventType, source: 'human', actor, occurredAt: occurredAt.toISOString(), note });
+
+const EVENTS: BallEvent[] = [
+  event('e1', 'review_requested', sugino, subHours(TODAY, 2)),
+  event('e2', 'sent_back', ishihara, subDays(TODAY, 1), 'ロゴの余白をもう少し広く'),
+  event('e3', 'review_requested', sugino, subDays(TODAY, 3)),
+  event('e4', 'sent_back', ishihara, subDays(TODAY, 4)),
+  event('e5', 'approved', ishihara, subDays(TODAY, 7)),
+  event('e6', 'tossed', yokoyama, subDays(TODAY, 30)),
+];
+
+const MEMBERS: ProjectMember[] = [sugino, ishihara, yokoyama, aoki].map((m, i) => ({
+  id: m.id,
+  userId: null,
+  name: m.name,
+  email: null,
+  organizationName: m.organizationName,
+  memberType: m.memberType,
+  jobTitle: null,
+  sortOrder: i,
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+}));
+
+const PROJECT: ProjectDetail = {
+  id: PROJECT_ID,
+  name: 'ブランドサイト制作',
+  clientName: '株式会社灯和食品',
+  startDate: iso(-30),
+  endDate: iso(60),
+  status: 'active',
+  archivedAt: null,
+  role: 'director',
+  createdBy: 'u1',
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+  progressManager: { id: yokoyama.id, name: yokoyama.name },
+  overdueCount: 0,
+  counts: { memberCount: 4, itemCount: 2 },
+};
+
+const noop = () => {};
+
+/**
+ * 実 API を叩かずに描画するため、キャッシュへ直接流し込む。
+ * `staleTime: Infinity` で再フェッチも起きない。
+ */
+function withSeededCache(detail: PlanDetail) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { staleTime: Infinity, retry: false } },
+  });
+  qc.setQueryData(plansQueryKey.detail(PROJECT_ID, ITEM_ID, PLAN_ID), detail);
+  qc.setQueryData(projectsQueryKey.detail(PROJECT_ID), PROJECT);
+  return qc;
+}
+
+const meta: Meta<typeof BallDetailModal> = {
+  title: 'plans/BallDetailModal',
+  component: BallDetailModal,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    projectId: PROJECT_ID,
+    itemId: ITEM_ID,
+    planId: PLAN_ID,
+    members: MEMBERS,
+    plans: [PLAN, SUCCESSOR],
+    onClose: noop,
+    onEdit: noop,
+    onCopied: noop,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BallDetailModal>;
+
+/** 概要タブ (Figma node 37:2)。確認待ち・後続あり。 */
+export const Overview: Story = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={withSeededCache({ plan: PLAN, events: EVENTS })}>
+        <div className="h-[900px]">
+          <Story />
+        </div>
+      </QueryClientProvider>
+    ),
+  ],
+};
+
+/** 履歴の無い予定 (作成直後)。空状態の見え方を確認する。 */
+export const NoEvents: Story = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={withSeededCache({ plan: PLAN, events: [] })}>
+        <div className="h-[900px]">
+          <Story />
+        </div>
+      </QueryClientProvider>
+    ),
+  ],
+};
+
+/** 完了済み・後続なし・メモありの予定。 */
+export const Completed: Story = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider
+        client={withSeededCache({
+          plan: {
+            ...PLAN,
+            status: 'completed',
+            ballState: 'completed',
+            successorPlanId: null,
+            memo: '色校正の結果は共有フォルダに格納済み。',
+            fromMember: sugino,
+            toMember: ishihara,
+            completedAt: TODAY.toISOString(),
+          },
+          events: EVENTS,
+        })}
+      >
+        <div className="h-[900px]">
+          <Story />
+        </div>
+      </QueryClientProvider>
+    ),
+  ],
+};

--- a/apps/web/src/features/plans/BallDetailModal.test.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.test.tsx
@@ -227,6 +227,33 @@ describe('BallDetailModal (integration)', () => {
     expect(await screen.findByText('TOSS')).toBeInTheDocument();
   });
 
+  it('概要タブのカードは履歴タブの一覧と同じ枠・行の作りを使う', async () => {
+    setupReads({
+      plan: makePlan({ ballState: 'tossed' }),
+      events: [makeEvent()],
+    });
+    renderModal();
+
+    await screen.findByText('デザインカンプ作成');
+
+    // 概要タブ: 見出しの隣に置くカードは「枠 + 罫線区切りの行」で組む
+    const cards = ['担当', 'スケジュール'].map(
+      (title) => screen.getByText(title).closest('section')!.lastElementChild!,
+    );
+    for (const card of cards) {
+      expect(card.className).toContain('rounded-xl');
+      expect(card.className).toContain('divide-y');
+      expect(card.firstElementChild!.className).toContain('px-4 py-3');
+    }
+
+    // 履歴タブの一覧も同じ枠・行の余白であること (両タブで見た目が揃う)
+    await userEvent.click(screen.getByRole('tab', { name: /履歴/ }));
+    const list = await screen.findByRole('list');
+    expect(list.className).toContain('rounded-xl');
+    expect(list.className).toContain('divide-y');
+    expect(list.firstElementChild!.className).toContain('px-4 py-3');
+  });
+
   it('履歴: 自動連鎖バッジと完了の取り消し/完了イベントを描画する', async () => {
     // ballHolder を他人にして完了/TOSS ボタンを出さず、履歴ラベルの衝突を避ける。
     setupReads({

--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -421,101 +421,117 @@ export function BallDetailModal({
                     </Section>
 
                     <Section title="担当">
-                      <div className="border-border flex flex-col gap-3 rounded-xl border bg-background p-4">
-                        <RoleRow
-                          variant="detail"
-                          role="executor"
-                          name={plan.executor?.name ?? '未設定'}
-                          caption={plan.executor?.organizationName ?? undefined}
-                        />
-                        <RoleRow
-                          variant="detail"
-                          role="approver"
-                          name={plan.approver?.name ?? '未設定（実施者が承認）'}
-                          caption={plan.approver?.organizationName ?? undefined}
-                        />
-                        <RoleRow
-                          variant="detail"
-                          role="manager"
-                          name={plan.progressManager?.name ?? '未設定'}
-                          caption={plan.progressManager?.organizationName ?? undefined}
-                        />
-                      </div>
+                      <DetailCard>
+                        <DetailRow>
+                          <RoleRow
+                            variant="detail"
+                            role="executor"
+                            name={plan.executor?.name ?? '未設定'}
+                            caption={plan.executor?.organizationName ?? undefined}
+                          />
+                        </DetailRow>
+                        <DetailRow>
+                          <RoleRow
+                            variant="detail"
+                            role="approver"
+                            name={plan.approver?.name ?? '未設定（実施者が承認）'}
+                            caption={plan.approver?.organizationName ?? undefined}
+                          />
+                        </DetailRow>
+                        <DetailRow>
+                          <RoleRow
+                            variant="detail"
+                            role="manager"
+                            name={plan.progressManager?.name ?? '未設定'}
+                            caption={plan.progressManager?.organizationName ?? undefined}
+                          />
+                        </DetailRow>
+                      </DetailCard>
                     </Section>
 
                     <Section title="スケジュール">
-                      <div className="border-border grid grid-cols-2 gap-x-4 gap-y-3 rounded-xl border bg-background p-4">
-                        <Field label="開始">
-                          {format(new Date(plan.scheduledDate), 'yyyy.M.d（E）', { locale: ja })}
-                        </Field>
-                        <Field label="終了">
-                          {plan.dueDate
-                            ? format(new Date(plan.dueDate), 'yyyy.M.d（E）', { locale: ja })
-                            : '—'}
-                        </Field>
-                        <Field label="工程">{theme.label}</Field>
-                        <Field label="状態" emphasis>
-                          {STATE_LABEL[s]}
-                        </Field>
-                      </div>
+                      {/* Figma node 38:29 も 2 行の間に罫線を持つ */}
+                      <DetailCard>
+                        <DetailRow className="grid grid-cols-2 gap-x-4">
+                          <Field label="開始">
+                            {format(new Date(plan.scheduledDate), 'yyyy.M.d（E）', { locale: ja })}
+                          </Field>
+                          <Field label="終了">
+                            {plan.dueDate
+                              ? format(new Date(plan.dueDate), 'yyyy.M.d（E）', { locale: ja })
+                              : '—'}
+                          </Field>
+                        </DetailRow>
+                        <DetailRow className="grid grid-cols-2 gap-x-4">
+                          <Field label="工程">{theme.label}</Field>
+                          <Field label="状態" emphasis>
+                            {STATE_LABEL[s]}
+                          </Field>
+                        </DetailRow>
+                      </DetailCard>
                     </Section>
 
                     {(plan.fromMember || plan.toMember) && (
                       <Section title="TOSS 履歴">
-                        <p className="text-body">
-                          {memberLabel(plan.fromMember)} <ArrowRight className="inline size-3.5" />{' '}
-                          {memberLabel(plan.toMember)}
-                        </p>
+                        <DetailCard>
+                          <DetailRow className="text-body">
+                            {memberLabel(plan.fromMember)}{' '}
+                            <ArrowRight className="inline size-3.5" />{' '}
+                            {memberLabel(plan.toMember)}
+                          </DetailRow>
+                        </DetailCard>
                       </Section>
                     )}
 
                     {plan.memo && (
                       <Section title="メモ">
-                        <p className="border-border rounded-xl border bg-background p-4 text-body whitespace-pre-wrap">
-                          {plan.memo}
-                        </p>
+                        <DetailCard>
+                          <DetailRow className="text-body whitespace-pre-wrap">{plan.memo}</DetailRow>
+                        </DetailCard>
                       </Section>
                     )}
 
                     {hasSuccessor && (
                       <Section title="次のTOSS">
-                        <div className="border-border bg-toss-line-subtle flex items-center gap-3 rounded-xl border p-4">
-                          <Send className="text-toss-line size-6 shrink-0" aria-hidden />
-                          <span className="flex min-w-0 flex-1 flex-col">
-                            <span className="truncate text-sm font-bold">
-                              {successor ? successor.title : '（別の制作物 / 取得中）'}
-                            </span>
-                            {successor && (
-                              <span className="text-text-secondary truncate text-xs">
-                                {format(new Date(successor.scheduledDate), 'M.d（E）', {
-                                  locale: ja,
-                                })}
-                                開始
-                                {successor.progressManager &&
-                                  ` ・ 進行責任者 ${successor.progressManager.name}`}
+                        <DetailCard className="bg-toss-line-subtle">
+                          <DetailRow className="flex items-center gap-3">
+                            <Send className="text-toss-line size-6 shrink-0" aria-hidden />
+                            <span className="flex min-w-0 flex-1 flex-col">
+                              <span className="truncate text-sm font-bold">
+                                {successor ? successor.title : '（別の制作物 / 取得中）'}
                               </span>
-                            )}
-                          </span>
-                          {plan.status === 'active' ? (
-                            <Button
-                              variant="ghost"
-                              size="icon-sm"
-                              className="shrink-0"
-                              onClick={handleUnlink}
-                              disabled={successorMut.isPending}
-                              aria-label="後続の紐づけを解除"
-                              title="後続の紐づけを解除"
-                            >
-                              {successorMut.isPending ? (
-                                <Loader2 className="size-4 animate-spin" />
-                              ) : (
-                                <Link2Off className="size-4" />
+                              {successor && (
+                                <span className="text-text-secondary truncate text-xs">
+                                  {format(new Date(successor.scheduledDate), 'M.d（E）', {
+                                    locale: ja,
+                                  })}
+                                  開始
+                                  {successor.progressManager &&
+                                    ` ・ 進行責任者 ${successor.progressManager.name}`}
+                                </span>
                               )}
-                            </Button>
-                          ) : (
-                            <ChevronRight className="text-toss-line size-5 shrink-0" aria-hidden />
-                          )}
-                        </div>
+                            </span>
+                            {plan.status === 'active' ? (
+                              <Button
+                                variant="ghost"
+                                size="icon-sm"
+                                className="shrink-0"
+                                onClick={handleUnlink}
+                                disabled={successorMut.isPending}
+                                aria-label="後続の紐づけを解除"
+                                title="後続の紐づけを解除"
+                              >
+                                {successorMut.isPending ? (
+                                  <Loader2 className="size-4 animate-spin" />
+                                ) : (
+                                  <Link2Off className="size-4" />
+                                )}
+                              </Button>
+                            ) : (
+                              <ChevronRight className="text-toss-line size-5 shrink-0" aria-hidden />
+                            )}
+                          </DetailRow>
+                        </DetailCard>
                       </Section>
                     )}
 
@@ -611,32 +627,53 @@ function BallHolderBanner({
   const completed = plan.status === 'completed';
   const holder = plan.ballHolder;
   return (
-    <div className="border-border bg-surface-subtle flex items-center gap-4 rounded-xl border p-4">
-      <span
-        aria-hidden
-        className={cn(
-          'flex size-8 shrink-0 items-center justify-center rounded-full text-body font-bold',
-          completed ? 'bg-success-subtle text-success' : 'bg-brand-subtle text-brand-strong',
-        )}
-      >
-        {completed ? <CheckCircle2 className="size-4" /> : (holder?.name.trim().charAt(0) ?? '—')}
-      </span>
-      <span className="flex min-w-0 flex-1 flex-col">
-        <span className="truncate text-[15px] font-bold">
-          {completed ? '完了済み' : (holder?.name ?? '—')}
+    <DetailCard className="bg-surface-subtle">
+      <DetailRow className="flex items-center gap-4">
+        <span
+          aria-hidden
+          className={cn(
+            'flex size-8 shrink-0 items-center justify-center rounded-full text-body font-bold',
+            completed ? 'bg-success-subtle text-success' : 'bg-brand-subtle text-brand-strong',
+          )}
+        >
+          {completed ? <CheckCircle2 className="size-4" /> : (holder?.name.trim().charAt(0) ?? '—')}
         </span>
-        {!completed && holder?.organizationName && (
-          <span className="text-text-secondary truncate text-xs">{holder.organizationName}</span>
-        )}
-      </span>
-      <StatusPill
-        status={completed ? 'completed' : plan.ballState}
-        hideIcon
-        size="lg"
-        className="shrink-0"
-      />
-    </div>
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-[15px] font-bold">
+            {completed ? '完了済み' : (holder?.name ?? '—')}
+          </span>
+          {!completed && holder?.organizationName && (
+            <span className="text-text-secondary truncate text-xs">{holder.organizationName}</span>
+          )}
+        </span>
+        {/* neutral の pill はカード面と同じ淡色なので、面に埋もれないよう背景を白に起こす */}
+        <StatusPill
+          status={completed ? 'completed' : plan.ballState}
+          hideIcon
+          size="lg"
+          className="bg-background shrink-0"
+        />
+      </DetailRow>
+    </DetailCard>
   );
+}
+
+/**
+ * 概要タブ・履歴タブで共有するカード外観 (枠 + 罫線区切りの行)。
+ * 概要側だけ「ラベル付きの箱が個別の作りで並ぶ」状態だったため、履歴の一覧に合わせて
+ * 外観をこの 2 定数に集約し、タブを行き来しても同じ部品に見えるようにする。
+ */
+const DETAIL_CARD =
+  'border-border divide-border divide-y overflow-hidden rounded-xl border bg-background';
+/** カード内 1 行の余白。左右 16px・上下 12px を両タブ共通にする。 */
+const DETAIL_ROW = 'px-4 py-3';
+
+function DetailCard({ className, children }: { className?: string; children: React.ReactNode }) {
+  return <div className={cn(DETAIL_CARD, className)}>{children}</div>;
+}
+
+function DetailRow({ className, children }: { className?: string; children: React.ReactNode }) {
+  return <div className={cn(DETAIL_ROW, className)}>{children}</div>;
 }
 
 /** サイドモーダルのタブ (Figma node 37:25)。下線だけのシンプルな見た目にする。 */
@@ -722,9 +759,9 @@ function EventTimeline({ events, compact }: { events: BallEvent[]; compact?: boo
   if (compact) {
     // 概要タブの「最近の履歴」(Figma node 39:2): ドット + 文 + 時刻の 1 行
     return (
-      <ol className="border-border flex flex-col gap-3 rounded-xl border bg-background p-4">
+      <ol className={DETAIL_CARD}>
         {events.map((e) => (
-          <li key={e.id} className="flex items-center gap-3 text-xs">
+          <li key={e.id} className={cn(DETAIL_ROW, 'flex items-center gap-3 text-xs')}>
             <span className="bg-toss-line size-2 shrink-0 rounded-full" aria-hidden />
             <span className="min-w-0 flex-1 truncate">
               {e.actor?.name ?? 'システム'}が{EVENT_LABEL[e.eventType]}しました
@@ -738,9 +775,9 @@ function EventTimeline({ events, compact }: { events: BallEvent[]; compact?: boo
     );
   }
   return (
-    <ol className="border-border flex flex-col divide-y divide-border rounded-xl border bg-background">
+    <ol className={DETAIL_CARD}>
       {events.map((e) => (
-        <li key={e.id} className="flex items-start gap-3 p-4 text-body">
+        <li key={e.id} className={cn(DETAIL_ROW, 'flex items-start gap-3 text-body')}>
           <EventIcon type={e.eventType} />
           <span className="flex min-w-0 flex-1 flex-col gap-0.5">
             <span className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## 背景

スケジュールのサイドモーダル (ボール詳細) で、概要タブだけブロックごとに組み方が
バラバラになっており、隣の履歴タブの一覧と見た目が揃っていませんでした。

Storybook に story を足して両タブを実描画したところ、次の点が具体的に確認できました。

- 概要タブ: 「枠 + 内側パディング + gap」で組んだ箱、素の段落 (TOSS履歴・メモ)、
  ドット付きリスト (最近の履歴) が混在。履歴タブは「枠 + 罫線区切りの行」の一覧。
- スケジュール欄に、Figma (node 38:29) にある 2 行の間の罫線が入っていない。
- 現在のボールの状態 pill が `neutral` のとき `bg-surface-subtle` で、
  同じ `bg-surface-subtle` のカード面に完全に埋もれて文字だけに見えていた。

## 変更

- 両タブで共有するカード外観 (`rounded-xl` + 枠 + `divide-y`) と行余白 (`px-4 py-3`) を
  定数に集約し、概要タブ・履歴タブの双方から参照する。今後片方だけずれない。
- 概要タブの全ブロック (現在のボール / 担当 / スケジュール / TOSS履歴 / メモ /
  次のTOSS / 最近の履歴) をその外観に統一。TOSS履歴とメモはカード無しだったので載せた。
- スケジュール欄に罫線が入るようになった (Figma と一致)。
- 現在のボールの pill の背景を白に起こして、面に埋もれないようにした。
- 担当欄の行はアバター (32px) に高さを揃えるため行間を詰めた (Figma node 38:12)。
  行の作りが「罫線区切り」に変わっても、カード全体の高さは従来 (166px) とほぼ同じ 172px。

## 確認

- Storybook `plans/BallDetailModal` に Overview / NoEvents / Completed を追加。
  React Query のキャッシュへ直接流し込むので実 API を叩かない。
- `BallDetailModal.test.tsx` に「概要タブのカードは履歴タブの一覧と同じ枠・行の作りを使う」を追加。
- `pnpm lint` / `pnpm type-check` / `pnpm test` (72 files / 686 tests) すべて通過。
  カバレッジ 88.58% (しきい値 88)。

## レビューで見てほしい点

- 「履歴と揃える」を優先した結果、担当欄には Figma に無い罫線が入っています
  (Figma は罫線なしで行間を広く取る形)。揃えることを優先しましたが、
  Figma どおり罫線なしに戻す判断もあり得ます。
- 概要タブに残っている Figma との差分 (今回スコープ外):
  担当欄のサブラベルが職種ではなく所属になっている (`MemberRef` に `jobTitle` が無いため
  API 変更が必要)、アバターが角丸四角ではなく円、次のTOSS のアイコンが矢印ではなく紙飛行機。

🤖 Generated with [Claude Code](https://claude.com/claude-code)