### PR TITLE
fix(web): サイドモーダルのタブの黒枠と太い下線を直す

### DIFF
--- a/apps/web/src/features/plans/BallDetailModal.test.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.test.tsx
@@ -254,6 +254,29 @@ describe('BallDetailModal (integration)', () => {
     expect(list.firstElementChild!.className).toContain('px-4 py-3');
   });
 
+  it('タブは選択中も枠を持たず、下線を罫線と同じ太さ・位置に重ねる', async () => {
+    setupReads({
+      plan: makePlan({ ballState: 'tossed' }),
+      events: [makeEvent()],
+    });
+    renderModal();
+
+    const overview = await screen.findByRole('tab', { name: '概要' });
+    const history = screen.getByRole('tab', { name: /履歴/ });
+
+    // TabsTrigger の基底は全辺 1px の枠を持つ。border-foreground だと 4 辺が着色されて
+    // 選択中のタブが黒枠で囲まれてしまうため、幅を落として下辺だけに色を当てる。
+    expect(overview.className).toContain('border-0');
+    expect(overview.className).not.toContain('data-[state=active]:border-foreground');
+    expect(overview.className).toContain('data-[state=active]:border-b-text-secondary');
+    // 下線は TabsList の罫線 (1px) と同じ太さ・位置に重ねる
+    expect(overview.className).toContain('border-b');
+    expect(overview.className).toContain('-mb-px');
+    // 選択中でも文字色は変えず、太字だけで示す (両タブのクラスは完全に同一)
+    expect(overview.className).toBe(history.className);
+    expect(overview.className).not.toContain('data-[state=active]:text-foreground');
+  });
+
   it('履歴: 自動連鎖バッジと完了の取り消し/完了イベントを描画する', async () => {
     // ballHolder を他人にして完了/TOSS ボタンを出さず、履歴ラベルの衝突を避ける。
     setupReads({

--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -676,12 +676,20 @@ function DetailRow({ className, children }: { className?: string; children: Reac
   return <div className={cn(DETAIL_ROW, className)}>{children}</div>;
 }
 
-/** サイドモーダルのタブ (Figma node 37:25)。下線だけのシンプルな見た目にする。 */
+/**
+ * サイドモーダルのタブ (Figma node 37:25)。下線だけのシンプルな見た目にする。
+ *
+ * TabsTrigger の基底は全辺 1px の枠を持つため、色は下辺だけに当てる
+ * (border-foreground だと 4 辺が着色されて選択中のタブが黒枠で囲まれる)。
+ * 下線は -mb-px で TabsList の罫線に重ね、太さ・位置とも罫線に揃える
+ * (Figma も 1px の全幅罫線と同じ位置に選択中の線を置いている)。
+ * 選択中は文字色を変えず太字だけで示す。
+ */
 function DrawerTab({ value, children }: { value: string; children: React.ReactNode }) {
   return (
     <TabsTrigger
       value={value}
-      className="data-[state=active]:border-foreground data-[state=active]:text-foreground text-text-secondary h-12 flex-none rounded-none border-b-2 border-transparent px-0 text-body font-medium data-[state=active]:bg-transparent data-[state=active]:font-bold"
+      className="text-text-secondary data-[state=active]:border-b-text-secondary h-12 flex-none rounded-none border-0 border-b border-b-transparent px-0 text-body font-medium -mb-px data-[state=active]:bg-transparent data-[state=active]:font-bold"
     >
       {children}
     </TabsTrigger>


### PR DESCRIPTION
## 背景

ボール詳細サイドモーダルで、選択中のタブ (「概要」) が黒い枠で囲まれ、下線も黒く太く見えていました。

## 原因

1. **黒枠**: `ui/tabs.tsx` の `TabsTrigger` は基底に `border border-transparent` (全辺 1px) を持ちます。
   そこへ `data-[state=active]:border-foreground` を当てていたため、下辺だけでなく
   **4 辺すべてが `#23231F` で着色**され、選択中のタブが黒枠で囲まれていました。
2. **太い下線**: 下線は `border-b-2` (2px) で、その 1px 下に `TabsList` の罫線 (1px, `--border`) が
   別にあり、**合計 3px の段差**になっていました。

Figma (node 37:25) を実測すると、選択中の線は **1px** で、全幅の 1px 罫線 (#E6E2DB) と
**同じ位置に重なって**います。

## 変更

- 枠の幅を落として (`border-0 border-b`)、色は下辺だけに当てる (`border-b-transparent` /
  `data-[state=active]:border-b-text-secondary`)。黒枠が消えます。
- 下線を 1px にし、`-mb-px` で `TabsList` の罫線にぴったり重ねる。太さ・位置とも罫線に揃います。
- 選択中の文字色を未選択と同じ `text-secondary` (#676862) に揃え、選択状態は太字だけで示す。
  下線の色も同じ `text-secondary` にしています。

結果、選択中／未選択で文字色は同一、選択中のみ太字 + 罫線と同じ位置の 1px グレー下線、という
落ち着いた見た目になります。

## 確認

- Storybook `plans/BallDetailModal` で両タブの選択状態を 4 倍拡大して目視。
  下線が全幅罫線と同じ y 位置・同じ 1px で、タブを切り替えると下線だけが移動することを確認。
- 計測値: 選択中タブの `border-width` = `0px/0px/1px/0px`、`border-bottom-color` = `rgb(103,104,98)`、
  タブの下端 (199.5) と `TabsList` の下端 (199.5) が一致。
- `BallDetailModal.test.tsx` に「タブは選択中も枠を持たず、下線を罫線と同じ太さ・位置に重ねる」を追加。
- `pnpm lint` / `pnpm type-check` / `pnpm test` (72 files / 687 tests) 通過。カバレッジ 88.57% (しきい値 88)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)