### PR TITLE
fix(web): サイドモーダルのタブ行の左右余白をヘッダー・本文に揃える

### DIFF
--- a/apps/web/src/features/plans/BallDetailModal.test.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.test.tsx
@@ -275,6 +275,11 @@ describe('BallDetailModal (integration)', () => {
     // 選択中でも文字色は変えず、太字だけで示す (両タブのクラスは完全に同一)
     expect(overview.className).toBe(history.className);
     expect(overview.className).not.toContain('data-[state=active]:text-foreground');
+
+    // タブ行の左右余白はヘッダー・本文と同じ 24px (p-0 を後ろに置くと px-6 が消える)
+    const list = overview.parentElement!;
+    expect(list.className).toContain('px-6');
+    expect(list.className).not.toContain('p-0');
   });
 
   it('履歴: 自動連鎖バッジと完了の取り消し/完了イベントを描画する', async () => {

--- a/apps/web/src/features/plans/BallDetailModal.tsx
+++ b/apps/web/src/features/plans/BallDetailModal.tsx
@@ -407,7 +407,9 @@ export function BallDetailModal({
                   onValueChange={setTab}
                   className="-mx-6 flex min-h-0 flex-1 flex-col"
                 >
-                  <TabsList className="border-border h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent px-6 p-0">
+                  {/* 左右の余白はヘッダー・本文と同じ 24px (Sheet の p-6) に揃える。
+                      p-0 を後ろに置くと px-6 が打ち消されるので py-0 で上下だけ落とす。 */}
+                  <TabsList className="border-border h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent px-6 py-0">
                     <DrawerTab value="overview">概要</DrawerTab>
                     <DrawerTab value="history">履歴 {events.length}</DrawerTab>
                   </TabsList>


### PR DESCRIPTION
## 背景

ボール詳細サイドモーダルで、タブ行 (概要 / 履歴) だけ左端に寄っていました。

## 原因

`TabsList` のクラスが `... px-6 p-0` の順になっており、tailwind-merge では
後ろの `p-0` が `px-6` を打ち消すため、**タブ行の左右余白が 0** になっていました。
ヘッダー・本文は `SheetContent` の `p-6` で 24px なので、タブだけ左に飛び出して見えていました。

## 変更

`p-0` を `py-0` に変え、上下の余白 (基底の `p-[3px]`) だけ落として `px-6` を効かせます。

## 確認

Storybook `plans/BallDetailModal` でドロワー左端からの距離を計測し、4 箇所が揃うことを確認:

| 要素 | 左端からの距離 |
|---|---|
| ヘッダーのチップ (デザイン) | 25px |
| タイトル (Webデザイン) | 25px |
| **タブ (概要)** | **25px** (変更前は 1px) |
| 本文の見出し (現在のボール) | 25px |

※ 24px の padding + Sheet の 1px 左枠。

`BallDetailModal.test.tsx` の既存のタブのテストに余白の確認を追加。
`pnpm lint` / `pnpm type-check` / `pnpm test` (72 files / 687 tests) 通過。カバレッジ 88.57% (しきい値 88)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)