### PR TITLE
feat(db,api): 課金の契約主体となる組織を追加し、プロジェクトを組織へ所属させる

### DIFF
--- a/apps/web/server/services/auth.test.ts
+++ b/apps/web/server/services/auth.test.ts
@@ -92,6 +92,50 @@ const auditTx = {
   }),
 };
 
+// 組織 (課金の契約主体)。サインアップ経路ごとに個人組織が 1 つ作られることを検証する。
+type MockOrganization = { id: string; name: string; ownerUserId: string };
+const organizationStore: Record<string, MockOrganization> = {};
+const organizationMemberStore: Array<{
+  organizationId: string;
+  userId: string;
+  orgRole: string;
+  isPrimary: boolean;
+}> = [];
+
+const organizationTx = {
+  findUnique: vi.fn(async ({ where }: { where: { ownerUserId: string } }) => {
+    return Object.values(organizationStore).find((o) => o.ownerUserId === where.ownerUserId) ?? null;
+  }),
+  create: vi.fn(async ({ data }: { data: { id?: string; name: string; ownerUserId: string } }) => {
+    const row: MockOrganization = {
+      id: data.id ?? `org-${data.ownerUserId}`,
+      name: data.name,
+      ownerUserId: data.ownerUserId,
+    };
+    organizationStore[row.id] = row;
+    return row;
+  }),
+};
+
+const organizationMemberTx = {
+  create: vi.fn(
+    async ({
+      data,
+    }: {
+      data: { organizationId: string; userId: string; orgRole?: string; isPrimary?: boolean };
+    }) => {
+      const row = {
+        organizationId: data.organizationId,
+        userId: data.userId,
+        orgRole: data.orgRole ?? 'member',
+        isPrimary: data.isPrimary ?? false,
+      };
+      organizationMemberStore.push(row);
+      return row;
+    },
+  ),
+};
+
 const prismaMock = {
   user: {
     findUnique: vi.fn(async ({ where }: { where: { authUserId: string } }) => {
@@ -108,6 +152,9 @@ const prismaMock = {
   },
   oAuthIdentity: { create: oauthTx.create, deleteMany: oauthTx.deleteMany },
   auditLog: { create: auditTx.create },
+  // サインアップ時に個人組織 + オーナーの会員行を作る (§7.3.1)。
+  organization: { findUnique: organizationTx.findUnique, create: organizationTx.create },
+  organizationMember: { create: organizationMemberTx.create },
   // 配列形式 ($transaction([...])) とコールバック形式 ($transaction(fn)) の両対応。
   $transaction: vi.fn(async (arg: unknown) => {
     if (Array.isArray(arg)) return Promise.all(arg);
@@ -115,6 +162,8 @@ const prismaMock = {
       user: userTx,
       oAuthIdentity: oauthTx,
       auditLog: auditTx,
+      organization: organizationTx,
+      organizationMember: organizationMemberTx,
     });
   }),
 };
@@ -164,6 +213,8 @@ beforeAll(async () => {
 
 afterEach(() => {
   for (const k of Object.keys(userStore)) delete userStore[k];
+  for (const k of Object.keys(organizationStore)) delete organizationStore[k];
+  organizationMemberStore.length = 0;
   oauthStore.length = 0;
   auditStore.length = 0;
   vi.clearAllMocks();
@@ -251,6 +302,9 @@ describe('syncUser', () => {
       expect(res.user.fullName).toBe('Gina Example');
       expect(res.user.displayName).toBe('Gina');
     }
+    // OAuth 経路でも個人組織を同時に作る (§7.3.1)
+    expect(Object.values(organizationStore)).toHaveLength(1);
+    expect(organizationMemberStore[0]).toMatchObject({ orgRole: 'owner', isPrimary: true });
     expect(oauthStore).toHaveLength(1);
     expect(oauthStore[0]).toMatchObject({
       provider: 'google',
@@ -385,6 +439,22 @@ describe('completeSignup', () => {
       resourceId: res.id,
       result: 'success',
     });
+  });
+
+  it('課金の契約主体となる個人組織をオーナー付きで同時に作る', async () => {
+    const res = await completeSignup(input);
+
+    const organizations = Object.values(organizationStore);
+    expect(organizations).toHaveLength(1);
+    expect(organizations[0]).toMatchObject({ name: 'Kawazu の組織', ownerUserId: res.id });
+    expect(organizationMemberStore).toEqual([
+      {
+        organizationId: organizations[0]?.id,
+        userId: res.id,
+        orgRole: 'owner',
+        isPrimary: true,
+      },
+    ]);
   });
 
   it('throws 409 ALREADY_COMPLETED when a users row already exists', async () => {

--- a/apps/web/server/services/auth.ts
+++ b/apps/web/server/services/auth.ts
@@ -3,6 +3,7 @@ import type { WithdrawalReason } from '@trakon/shared';
 import { uuidv7 } from 'uuidv7';
 
 import { ApiException } from '../lib/errors.js';
+import { defaultOrganizationName, ensureOrganizationForUser } from './organizations.js';
 import { getSupabaseAdmin } from '../lib/supabaseAdmin.js';
 
 /**
@@ -156,6 +157,9 @@ export async function syncUser(authUserId: string, jwtEmail: string): Promise<Sy
         email,
       },
     });
+    // 課金の契約主体となる個人組織を同時に作る (§7.3.1)。
+    // ここで作っておかないとプロジェクト作成 (organization_id NOT NULL) が通らない。
+    await ensureOrganizationForUser(tx, { userId: user.id, displayName: user.displayName });
     return user;
   });
 
@@ -262,6 +266,7 @@ export async function completeSignup(input: {
   // id をアプリ側で採番し、依存のないバッチ (配列) トランザクションで 1 往復に収める。
   step('transaction:start');
   const userId = uuidv7();
+  const organizationId = uuidv7();
   const [user] = await withTimeout(
     prisma.$transaction([
       prisma.user.create({
@@ -273,6 +278,18 @@ export async function completeSignup(input: {
           displayName: input.displayName,
           primaryAuthMethod: 'password',
         },
+      }),
+      // 課金の契約主体となる個人組織 (§7.3.1)。id をアプリ側で採番することで
+      // 対話的トランザクションを避け、バッチのまま 1 往復に収める。
+      prisma.organization.create({
+        data: {
+          id: organizationId,
+          name: defaultOrganizationName(input.displayName),
+          ownerUserId: userId,
+        },
+      }),
+      prisma.organizationMember.create({
+        data: { organizationId, userId, orgRole: 'owner', isPrimary: true },
       }),
       prisma.auditLog.create({
         data: {

--- a/apps/web/server/services/organizations.integration.test.ts
+++ b/apps/web/server/services/organizations.integration.test.ts
@@ -47,8 +47,10 @@ describe('ensureOrganizationForUser', () => {
       expect(await prisma.organizationMember.count({ where: { userId: user.id } })).toBe(1);
     });
 
-    it('表示名が長くても組織名の長さ制限に収まる', async () => {
-      const user = await createUser({ withOrganization: false, displayName: 'あ'.repeat(300) });
+    it('表示名が最大長でも組織名の長さ制限に収まる', async () => {
+      // users.display_name は 50 文字までなので、実際に来る最長ケースで確かめる。
+      // 想定外に長い表示名を切り詰める防御的な挙動は organizations.test.ts が見る
+      const user = await createUser({ withOrganization: false, displayName: 'あ'.repeat(50) });
 
       const { organizationId } = await ensureOrganizationForUser(prisma, {
         userId: user.id,
@@ -57,6 +59,7 @@ describe('ensureOrganizationForUser', () => {
 
       const org = await prisma.organization.findUniqueOrThrow({ where: { id: organizationId } });
       expect(org.name.length).toBeLessThanOrEqual(255);
+      expect(org.name).toBe(`${'あ'.repeat(50)} の組織`);
     });
   });
 });

--- a/apps/web/server/services/organizations.integration.test.ts
+++ b/apps/web/server/services/organizations.integration.test.ts
@@ -1,0 +1,236 @@
+import { prisma } from '@trakon/db';
+import { describe, expect, it } from 'vitest';
+
+import { createOrganization, createProject, createUser, primaryOrganizationId } from '../test/factories.js';
+import {
+  countActiveProjects,
+  countSeats,
+  defaultOrganizationName,
+  ensureOrganizationForUser,
+  ensureOrganizationMember,
+  resolvePrimaryOrganization,
+} from './organizations.js';
+
+describe('ensureOrganizationForUser', () => {
+  describe('正常系', () => {
+    it('個人組織とオーナーの会員行を作る', async () => {
+      const user = await createUser({ withOrganization: false });
+
+      const { organizationId } = await ensureOrganizationForUser(prisma, {
+        userId: user.id,
+        displayName: user.displayName,
+      });
+
+      const org = await prisma.organization.findUnique({ where: { id: organizationId } });
+      expect(org).toMatchObject({
+        ownerUserId: user.id,
+        name: defaultOrganizationName(user.displayName),
+      });
+      const member = await prisma.organizationMember.findFirst({ where: { organizationId } });
+      expect(member).toMatchObject({ userId: user.id, orgRole: 'owner', isPrimary: true });
+    });
+
+    it('二重に呼んでも組織は 1 つのまま (冪等)', async () => {
+      const user = await createUser({ withOrganization: false });
+
+      const first = await ensureOrganizationForUser(prisma, {
+        userId: user.id,
+        displayName: user.displayName,
+      });
+      const second = await ensureOrganizationForUser(prisma, {
+        userId: user.id,
+        displayName: user.displayName,
+      });
+
+      expect(second.organizationId).toBe(first.organizationId);
+      expect(await prisma.organization.count({ where: { ownerUserId: user.id } })).toBe(1);
+      expect(await prisma.organizationMember.count({ where: { userId: user.id } })).toBe(1);
+    });
+
+    it('表示名が長くても組織名の長さ制限に収まる', async () => {
+      const user = await createUser({ withOrganization: false, displayName: 'あ'.repeat(300) });
+
+      const { organizationId } = await ensureOrganizationForUser(prisma, {
+        userId: user.id,
+        displayName: user.displayName,
+      });
+
+      const org = await prisma.organization.findUniqueOrThrow({ where: { id: organizationId } });
+      expect(org.name.length).toBeLessThanOrEqual(255);
+    });
+  });
+});
+
+describe('ensureOrganizationMember', () => {
+  describe('正常系', () => {
+    it('会員を追加する', async () => {
+      const owner = await createUser();
+      const invitee = await createUser({ withOrganization: false });
+      const organizationId = await primaryOrganizationId(owner.id);
+
+      const result = await ensureOrganizationMember(prisma, {
+        organizationId,
+        userId: invitee.id,
+      });
+
+      expect(result.created).toBe(true);
+      const row = await prisma.organizationMember.findFirstOrThrow({
+        where: { organizationId, userId: invitee.id },
+      });
+      expect(row).toMatchObject({ orgRole: 'member', isPrimary: false, deletedAt: null });
+    });
+
+    it('既に会員なら何もしない', async () => {
+      const owner = await createUser();
+      const organizationId = await primaryOrganizationId(owner.id);
+
+      const result = await ensureOrganizationMember(prisma, {
+        organizationId,
+        userId: owner.id,
+      });
+
+      expect(result.created).toBe(false);
+      expect(await prisma.organizationMember.count({ where: { organizationId } })).toBe(1);
+    });
+
+    it('論理削除済みの会員行は復活させる (uq_om_org_user はフル UNIQUE のため)', async () => {
+      const owner = await createUser();
+      const invitee = await createUser({ withOrganization: false });
+      const organizationId = await primaryOrganizationId(owner.id);
+      const first = await ensureOrganizationMember(prisma, { organizationId, userId: invitee.id });
+      await prisma.organizationMember.update({
+        where: { id: first.id },
+        data: { deletedAt: new Date() },
+      });
+
+      const again = await ensureOrganizationMember(prisma, { organizationId, userId: invitee.id });
+
+      expect(again.id).toBe(first.id);
+      expect(again.created).toBe(true);
+      const row = await prisma.organizationMember.findUniqueOrThrow({ where: { id: first.id } });
+      expect(row.deletedAt).toBeNull();
+    });
+  });
+});
+
+describe('resolvePrimaryOrganization', () => {
+  describe('正常系', () => {
+    it('is_primary の組織を優先して返す', async () => {
+      const user = await createUser();
+      const otherOwner = await createUser();
+      const otherOrgId = await primaryOrganizationId(otherOwner.id);
+      await ensureOrganizationMember(prisma, { organizationId: otherOrgId, userId: user.id });
+
+      const resolved = await resolvePrimaryOrganization(prisma, user.id);
+
+      expect(resolved).toEqual({
+        organizationId: await primaryOrganizationId(user.id),
+        orgRole: 'owner',
+      });
+    });
+
+    it('is_primary が無ければ最初に参加した組織を返す', async () => {
+      const user = await createUser({ withOrganization: false });
+      const owner = await createUser();
+      const organizationId = await primaryOrganizationId(owner.id);
+      await ensureOrganizationMember(prisma, { organizationId, userId: user.id });
+
+      const resolved = await resolvePrimaryOrganization(prisma, user.id);
+
+      expect(resolved).toEqual({ organizationId, orgRole: 'member' });
+    });
+  });
+
+  describe('異常系', () => {
+    it('どこにも所属していなければ 404', async () => {
+      const user = await createUser({ withOrganization: false });
+
+      await expect(resolvePrimaryOrganization(prisma, user.id)).rejects.toMatchObject({
+        code: 'ORGANIZATION_NOT_FOUND',
+        status: 404,
+      });
+    });
+
+    it('論理削除された会員行は所属とみなさない', async () => {
+      const user = await createUser();
+      const organizationId = await primaryOrganizationId(user.id);
+      await prisma.organizationMember.updateMany({
+        where: { organizationId, userId: user.id },
+        data: { deletedAt: new Date() },
+      });
+
+      await expect(resolvePrimaryOrganization(prisma, user.id)).rejects.toMatchObject({
+        code: 'ORGANIZATION_NOT_FOUND',
+      });
+    });
+  });
+});
+
+describe('countSeats / countActiveProjects', () => {
+  it('有効な会員だけを座席として数える', async () => {
+    const owner = await createUser();
+    const invitee = await createUser({ withOrganization: false });
+    const organizationId = await primaryOrganizationId(owner.id);
+    const added = await ensureOrganizationMember(prisma, { organizationId, userId: invitee.id });
+
+    expect(await countSeats(prisma, organizationId)).toBe(2);
+
+    await prisma.organizationMember.update({
+      where: { id: added.id },
+      data: { deletedAt: new Date() },
+    });
+    expect(await countSeats(prisma, organizationId)).toBe(1);
+  });
+
+  it('アーカイブ済み・論理削除済みのプロジェクトは数えない (枠を空ける動線)', async () => {
+    const user = await createUser();
+    const organizationId = await primaryOrganizationId(user.id);
+    await createProject({ createdBy: user.id });
+    await createProject({ createdBy: user.id, archivedAt: new Date() });
+    const deleted = await createProject({ createdBy: user.id });
+    await prisma.project.update({ where: { id: deleted.id }, data: { deletedAt: new Date() } });
+
+    expect(await countActiveProjects(prisma, organizationId)).toBe(1);
+  });
+
+  it('別組織のプロジェクトは数えない', async () => {
+    const user = await createUser();
+    const other = await createUser();
+    await createProject({ createdBy: user.id });
+    await createProject({ createdBy: other.id });
+
+    expect(await countActiveProjects(prisma, await primaryOrganizationId(user.id))).toBe(1);
+  });
+});
+
+describe('projects.organization_id', () => {
+  it('組織を削除しようとするとプロジェクトが残っている限り拒否される (FR-BILL-09 の裏付け)', async () => {
+    const user = await createUser();
+    const organizationId = await primaryOrganizationId(user.id);
+    await createProject({ createdBy: user.id });
+
+    await expect(prisma.organization.delete({ where: { id: organizationId } })).rejects.toThrow();
+  });
+
+  it('明示的に組織を指定してプロジェクトを作れる', async () => {
+    const owner = await createUser();
+    const member = await createUser({ withOrganization: false });
+    const org = await prisma.organization.findFirstOrThrow({ where: { ownerUserId: owner.id } });
+    await ensureOrganizationMember(prisma, { organizationId: org.id, userId: member.id });
+
+    const project = await createProject({ createdBy: member.id, organizationId: org.id });
+
+    expect(project.organizationId).toBe(org.id);
+  });
+});
+
+describe('createOrganization ファクトリ', () => {
+  it('オーナー行つきで組織を作る', async () => {
+    const user = await createUser({ withOrganization: false });
+
+    const org = await createOrganization({ ownerUserId: user.id, name: 'テスト組織' });
+
+    expect(org.name).toBe('テスト組織');
+    expect(await countSeats(prisma, org.id)).toBe(1);
+  });
+});

--- a/apps/web/server/services/organizations.test.ts
+++ b/apps/web/server/services/organizations.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApiException } from '../lib/errors.js';
+import {
+  countActiveProjects,
+  countSeats,
+  defaultOrganizationName,
+  ensureOrganizationForUser,
+  ensureOrganizationMember,
+  resolvePrimaryOrganization,
+} from './organizations.js';
+
+// 実 DB を使う経路は organizations.integration.test.ts が見る。
+// ここでは DB を差し替えて、分岐 (既存/新規・論理削除からの復活・既定組織の解決) を固定する。
+
+type Db = Parameters<typeof countSeats>[0];
+
+function fakeDb(over: Record<string, unknown>): Db {
+  return over as unknown as Db;
+}
+
+describe('defaultOrganizationName', () => {
+  it('表示名から組織名を組み立てる', () => {
+    expect(defaultOrganizationName('川津')).toBe('川津 の組織');
+  });
+
+  it('長すぎる表示名は列の長さ制限に収まるよう切り詰める', () => {
+    const name = defaultOrganizationName('あ'.repeat(300));
+    expect(name.length).toBeLessThanOrEqual(255);
+    expect(name.endsWith(' の組織')).toBe(true);
+  });
+});
+
+describe('ensureOrganizationForUser', () => {
+  it('組織が無ければ組織とオーナー会員行を作る', async () => {
+    const organizationCreate = vi.fn().mockResolvedValue({ id: 'org-1' });
+    const memberCreate = vi.fn().mockResolvedValue({ id: 'om-1' });
+    const db = fakeDb({
+      organization: { findUnique: vi.fn().mockResolvedValue(null), create: organizationCreate },
+      organizationMember: { create: memberCreate },
+    });
+
+    const result = await ensureOrganizationForUser(db, { userId: 'u-1', displayName: '川津' });
+
+    expect(result).toEqual({ organizationId: 'org-1' });
+    expect(organizationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { name: '川津 の組織', ownerUserId: 'u-1' } }),
+    );
+    // オーナーは is_primary 付きで入る (既定の所属組織になる)
+    expect(memberCreate).toHaveBeenCalledWith({
+      data: { organizationId: 'org-1', userId: 'u-1', orgRole: 'owner', isPrimary: true },
+    });
+  });
+
+  it('既に組織があれば作り直さない (サインアップ経路が複数あるため冪等)', async () => {
+    const organizationCreate = vi.fn();
+    const db = fakeDb({
+      organization: {
+        findUnique: vi.fn().mockResolvedValue({ id: 'org-1' }),
+        create: organizationCreate,
+      },
+      organizationMember: {
+        findUnique: vi.fn().mockResolvedValue({ id: 'om-1', deletedAt: null }),
+        create: vi.fn(),
+      },
+    });
+
+    const result = await ensureOrganizationForUser(db, { userId: 'u-1', displayName: '川津' });
+
+    expect(result).toEqual({ organizationId: 'org-1' });
+    expect(organizationCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('ensureOrganizationMember', () => {
+  it('会員行が無ければ作る (既定は member かつ is_primary なし)', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'om-9' });
+    const db = fakeDb({
+      organizationMember: { findUnique: vi.fn().mockResolvedValue(null), create },
+    });
+
+    const result = await ensureOrganizationMember(db, { organizationId: 'org-1', userId: 'u-2' });
+
+    expect(result).toEqual({ id: 'om-9', created: true });
+    expect(create).toHaveBeenCalledWith({
+      data: { organizationId: 'org-1', userId: 'u-2', orgRole: 'member', isPrimary: false },
+      select: { id: true },
+    });
+  });
+
+  it('論理削除済みの行は復活させる (uq_om_org_user がフル UNIQUE のため INSERT できない)', async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const create = vi.fn();
+    const db = fakeDb({
+      organizationMember: {
+        findUnique: vi.fn().mockResolvedValue({ id: 'om-3', deletedAt: new Date() }),
+        update,
+        create,
+      },
+    });
+
+    const result = await ensureOrganizationMember(db, {
+      organizationId: 'org-1',
+      userId: 'u-2',
+      orgRole: 'admin',
+    });
+
+    expect(result).toEqual({ id: 'om-3', created: true });
+    expect(create).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'om-3' },
+        data: expect.objectContaining({ deletedAt: null, orgRole: 'admin' }),
+      }),
+    );
+  });
+
+  it('有効な行が既にあれば何もしない', async () => {
+    const update = vi.fn();
+    const create = vi.fn();
+    const db = fakeDb({
+      organizationMember: {
+        findUnique: vi.fn().mockResolvedValue({ id: 'om-3', deletedAt: null }),
+        update,
+        create,
+      },
+    });
+
+    const result = await ensureOrganizationMember(db, { organizationId: 'org-1', userId: 'u-2' });
+
+    expect(result).toEqual({ id: 'om-3', created: false });
+    expect(update).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolvePrimaryOrganization', () => {
+  it('is_primary を優先し、同点なら参加が早い順に選ぶ', async () => {
+    const findFirst = vi.fn().mockResolvedValue({ organizationId: 'org-1', orgRole: 'owner' });
+    const db = fakeDb({ organizationMember: { findFirst } });
+
+    const result = await resolvePrimaryOrganization(db, 'u-1');
+
+    expect(result).toEqual({ organizationId: 'org-1', orgRole: 'owner' });
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ isPrimary: 'desc' }, { joinedAt: 'asc' }],
+      }),
+    );
+  });
+
+  it('削除済みの組織は既定の所属先にしない', async () => {
+    const findFirst = vi.fn().mockResolvedValue({ organizationId: 'org-1', orgRole: 'member' });
+    const db = fakeDb({ organizationMember: { findFirst } });
+
+    await resolvePrimaryOrganization(db, 'u-1');
+
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: 'u-1', deletedAt: null, organization: { deletedAt: null } },
+      }),
+    );
+  });
+
+  it('どこにも所属していなければ 404', async () => {
+    const db = fakeDb({ organizationMember: { findFirst: vi.fn().mockResolvedValue(null) } });
+
+    await expect(resolvePrimaryOrganization(db, 'u-1')).rejects.toMatchObject({
+      code: 'ORGANIZATION_NOT_FOUND',
+      status: 404,
+    });
+    await expect(resolvePrimaryOrganization(db, 'u-1')).rejects.toBeInstanceOf(ApiException);
+  });
+});
+
+describe('カウント', () => {
+  it('座席は有効な組織メンバーだけを数える', async () => {
+    const count = vi.fn().mockResolvedValue(3);
+    const db = fakeDb({ organizationMember: { count } });
+
+    expect(await countSeats(db, 'org-1')).toBe(3);
+    expect(count).toHaveBeenCalledWith({ where: { organizationId: 'org-1', deletedAt: null } });
+  });
+
+  it('プロジェクト数はアーカイブ済みを除く (アーカイブが枠を空ける動線)', async () => {
+    const count = vi.fn().mockResolvedValue(2);
+    const db = fakeDb({ project: { count } });
+
+    expect(await countActiveProjects(db, 'org-1')).toBe(2);
+    expect(count).toHaveBeenCalledWith({
+      where: { organizationId: 'org-1', deletedAt: null, archivedAt: null },
+    });
+  });
+});

--- a/apps/web/server/services/organizations.ts
+++ b/apps/web/server/services/organizations.ts
@@ -1,0 +1,170 @@
+// -----------------------------------------------------------------------------
+// 組織 (課金の契約主体) — 設計書 §7.3 / §2.4.10 / §2.4.11
+//
+// ユーザー登録時に本人をオーナーとする「個人組織」を自動作成する。Personal も
+// 「会員 1 名の組織」として扱い、Personal と Team でデータモデルを分けない。
+//
+// 座席 (会員アカウント数) のカウントは organization_members だけでは足りない。
+// 未受諾かつ有効期限内の招待も 1 座席を消費する。そうしないと招待を大量に送って
+// から一斉に受諾させることで上限を超えられてしまう (§7.3.2)。
+// -----------------------------------------------------------------------------
+import type { Prisma } from '@prisma/client';
+
+import type { prisma } from '@trakon/db';
+import type { OrgRole } from '@trakon/shared';
+
+import { ApiException } from '../lib/errors.js';
+
+/** Prisma のトランザクションクライアント、または通常のクライアント */
+type Db = Prisma.TransactionClient | typeof prisma;
+
+export type OrganizationMembership = {
+  organizationId: string;
+  orgRole: OrgRole;
+};
+
+/** 組織名の既定値。表示名が長い場合は列の長さ制限 (255) に収まるよう切り詰める */
+export function defaultOrganizationName(displayName: string): string {
+  return `${displayName.slice(0, 240)} の組織`;
+}
+
+/**
+ * ユーザーの個人組織を作成する (存在すれば何もしない)。
+ *
+ * サインアップ経路が複数ある (complete-signup / OAuth sync) ため、
+ * どちらからも同じ関数を呼ぶ。呼び出し元のトランザクションに参加できるよう
+ * db を受け取る。
+ */
+export async function ensureOrganizationForUser(
+  db: Db,
+  input: { userId: string; displayName: string },
+): Promise<{ organizationId: string }> {
+  const existing = await db.organization.findUnique({
+    where: { ownerUserId: input.userId },
+    select: { id: true },
+  });
+  if (existing) {
+    await ensureOrganizationMember(db, {
+      organizationId: existing.id,
+      userId: input.userId,
+      orgRole: 'owner',
+      isPrimary: true,
+    });
+    return { organizationId: existing.id };
+  }
+
+  const organization = await db.organization.create({
+    data: {
+      name: defaultOrganizationName(input.displayName),
+      ownerUserId: input.userId,
+    },
+    select: { id: true },
+  });
+  await db.organizationMember.create({
+    data: {
+      organizationId: organization.id,
+      userId: input.userId,
+      orgRole: 'owner',
+      isPrimary: true,
+    },
+  });
+  return { organizationId: organization.id };
+}
+
+/**
+ * 組織へ会員を追加する。論理削除済みの行があれば復活させる。
+ *
+ * uq_om_org_user は deleted_at を含まないフル UNIQUE なので、再招待では
+ * INSERT ではなく既存行の復活になる (uq_pm_project_email と同じ流儀)。
+ */
+export async function ensureOrganizationMember(
+  db: Db,
+  input: {
+    organizationId: string;
+    userId: string;
+    orgRole?: OrgRole;
+    isPrimary?: boolean;
+  },
+): Promise<{ id: string; created: boolean }> {
+  const existing = await db.organizationMember.findUnique({
+    where: {
+      organizationId_userId: { organizationId: input.organizationId, userId: input.userId },
+    },
+    select: { id: true, deletedAt: true },
+  });
+
+  if (existing) {
+    if (existing.deletedAt) {
+      await db.organizationMember.update({
+        where: { id: existing.id },
+        data: {
+          deletedAt: null,
+          joinedAt: new Date(),
+          ...(input.orgRole ? { orgRole: input.orgRole } : {}),
+        },
+      });
+      return { id: existing.id, created: true };
+    }
+    return { id: existing.id, created: false };
+  }
+
+  const row = await db.organizationMember.create({
+    data: {
+      organizationId: input.organizationId,
+      userId: input.userId,
+      orgRole: input.orgRole ?? 'member',
+      isPrimary: input.isPrimary ?? false,
+    },
+    select: { id: true },
+  });
+  return { id: row.id, created: true };
+}
+
+/**
+ * ユーザーの既定の所属組織を解決する。
+ *
+ * is_primary が立っている行を優先し、無ければ最初に参加した組織を使う。
+ * どこにも所属していない場合は 404 (プロフィール未完了と同じ扱い)。
+ */
+export async function resolvePrimaryOrganization(
+  db: Db,
+  userId: string,
+): Promise<OrganizationMembership> {
+  const membership = await db.organizationMember.findFirst({
+    where: { userId, deletedAt: null, organization: { deletedAt: null } },
+    orderBy: [{ isPrimary: 'desc' }, { joinedAt: 'asc' }],
+    select: { organizationId: true, orgRole: true },
+  });
+  if (!membership) {
+    throw new ApiException(
+      'ORGANIZATION_NOT_FOUND',
+      404,
+      'No organization is associated with this user.',
+    );
+  }
+  return {
+    organizationId: membership.organizationId,
+    orgRole: membership.orgRole as OrgRole,
+  };
+}
+
+/**
+ * 座席 (会員アカウント) の消費数。
+ *
+ * 【未完】未受諾かつ有効期限内の招待も 1 座席を消費する (§7.3.2)。
+ * invitations.organization_id は招待作成 API と同じ変更で追加するため、
+ * その時点でここへ加算を足す。現時点は組織メンバーのみを数える。
+ */
+export async function countSeats(db: Db, organizationId: string): Promise<number> {
+  return db.organizationMember.count({ where: { organizationId, deletedAt: null } });
+}
+
+/**
+ * プロジェクト数。プランの上限判定に使う。
+ * アーカイブ済みは対象外 (= 枠を空ける正規の動線、§7.11.2)。
+ */
+export async function countActiveProjects(db: Db, organizationId: string): Promise<number> {
+  return db.project.count({
+    where: { organizationId, deletedAt: null, archivedAt: null },
+  });
+}

--- a/apps/web/server/services/projects.test.ts
+++ b/apps/web/server/services/projects.test.ts
@@ -179,6 +179,12 @@ const prismaMock = {
   plan: {
     findMany: vi.fn(async () => []),
   },
+  // 作成者の既定の所属組織を解決する (projects.organization_id は NOT NULL)。
+  organizationMember: {
+    findFirst: vi.fn(async ({ where }: { where: { userId: string } }) =>
+      userStore[where.userId] ? { organizationId: `org-${where.userId}`, orgRole: 'owner' } : null,
+    ),
+  },
   // コールバック形式 ($transaction(fn)) のみ service は使用。
   $transaction: vi.fn(async (arg: unknown) => {
     if (Array.isArray(arg)) return Promise.all(arg);

--- a/apps/web/server/services/projects.ts
+++ b/apps/web/server/services/projects.ts
@@ -2,6 +2,7 @@ import { prisma, type Prisma } from '@trakon/db';
 import { pickLatestBallEvent, type BallEventType } from '@trakon/shared';
 
 import { ApiException } from '../lib/errors.js';
+import { resolvePrimaryOrganization } from './organizations.js';
 import type { CreateProjectBody, UpdateProjectBody } from '../schemas/projects.js';
 
 export type ProjectSummaryDTO = {
@@ -199,6 +200,9 @@ export async function createProject(input: {
     throw new ApiException('PROFILE_NOT_COMPLETED', 404, 'Profile is required.');
   }
 
+  // プロジェクトは必ずいずれかの組織に属する (§7.3.1)。プロジェクト数上限の判定単位。
+  const { organizationId } = await resolvePrimaryOrganization(prisma, currentUserId);
+
   // 作成者のメールがメンバー入力に被ると uq_pm_project_email 違反になるため除外
   // (メール未登録の参加者は衝突しないためそのまま残す)。
   // 進行責任者は入力順 (index) で指されるため、元の位置も控えておく。
@@ -209,6 +213,7 @@ export async function createProject(input: {
   const created = await prisma.$transaction(async (tx) => {
     const project = await tx.project.create({
       data: {
+        organizationId,
         name: body.name,
         clientName: body.clientName ?? null,
         startDate: new Date(`${body.startDate}T00:00:00Z`),

--- a/apps/web/server/test/factories.ts
+++ b/apps/web/server/test/factories.ts
@@ -12,15 +12,21 @@ import { signTestJwt } from './auth.js';
 let seq = 0;
 const uniq = () => `${Date.now().toString(36)}-${seq++}`;
 
+/**
+ * ユーザーを作る。本番の登録フロー (complete-signup / OAuth sync) と同じく
+ * 個人組織 + オーナーの会員行も同時に作る (§7.3.1)。
+ * これを作らないと projects.organization_id (NOT NULL) を満たせない。
+ */
 export async function createUser(overrides: Partial<{
   authUserId: string;
   email: string;
   fullName: string;
   displayName: string;
   primaryAuthMethod: string;
+  withOrganization: boolean;
 }> = {}) {
   const tag = uniq();
-  return prisma.user.create({
+  const user = await prisma.user.create({
     data: {
       authUserId: overrides.authUserId ?? randomUUID(),
       email: overrides.email ?? `user-${tag}@example.test`,
@@ -29,23 +35,83 @@ export async function createUser(overrides: Partial<{
       primaryAuthMethod: overrides.primaryAuthMethod ?? 'password',
     },
   });
+  if (overrides.withOrganization !== false) {
+    await createOrganization({ ownerUserId: user.id, name: `${user.displayName} の組織` });
+  }
+  return user;
 }
 
+/** 組織 + オーナーの会員行を作る。 */
+export async function createOrganization(args: { ownerUserId: string; name?: string }) {
+  const organization = await prisma.organization.create({
+    data: {
+      name: args.name ?? `Org ${uniq()}`,
+      ownerUserId: args.ownerUserId,
+    },
+  });
+  await prisma.organizationMember.create({
+    data: {
+      organizationId: organization.id,
+      userId: args.ownerUserId,
+      orgRole: 'owner',
+      isPrimary: true,
+    },
+  });
+  return organization;
+}
+
+/** 既存組織に会員 (座席) を追加する。 */
+export async function createOrgMember(args: {
+  organizationId: string;
+  userId: string;
+  orgRole?: 'owner' | 'admin' | 'member';
+  isPrimary?: boolean;
+}) {
+  return prisma.organizationMember.create({
+    data: {
+      organizationId: args.organizationId,
+      userId: args.userId,
+      orgRole: args.orgRole ?? 'member',
+      isPrimary: args.isPrimary ?? false,
+    },
+  });
+}
+
+/** ユーザーの既定の所属組織 ID を引く。 */
+export async function primaryOrganizationId(userId: string): Promise<string> {
+  const row = await prisma.organizationMember.findFirst({
+    where: { userId, deletedAt: null },
+    orderBy: [{ isPrimary: 'desc' }, { joinedAt: 'asc' }],
+    select: { organizationId: true },
+  });
+  if (!row) throw new Error(`no organization for user ${userId}`);
+  return row.organizationId;
+}
+
+/**
+ * プロジェクトを作る。organizationId 未指定なら作成者の既定の所属組織を使う
+ * (projects.organization_id は NOT NULL)。
+ */
 export async function createProject(args: {
   createdBy: string;
+  organizationId?: string;
   name?: string;
   startDate?: Date;
   endDate?: Date;
   status?: string;
   archivedAt?: Date | null;
+  retainedAt?: Date | null;
 }) {
+  const organizationId = args.organizationId ?? (await primaryOrganizationId(args.createdBy));
   return prisma.project.create({
     data: {
+      organizationId,
       name: args.name ?? `Project ${uniq()}`,
       startDate: args.startDate ?? new Date('2026-01-01'),
       endDate: args.endDate ?? new Date('2026-12-31'),
       status: args.status ?? 'active',
       archivedAt: args.archivedAt ?? null,
+      retainedAt: args.retainedAt ?? null,
       createdBy: args.createdBy,
     },
   });

--- a/apps/web/server/test/integration.setup.ts
+++ b/apps/web/server/test/integration.setup.ts
@@ -39,6 +39,8 @@ const TABLES = [
   'project_items',
   'project_members',
   'projects',
+  'organization_members',
+  'organizations',
   'oauth_identities',
   'users',
 ];

--- a/packages/db/prisma/migrations/20260901000001_add_organizations/migration.sql
+++ b/packages/db/prisma/migrations/20260901000001_add_organizations/migration.sql
@@ -1,0 +1,114 @@
+-- =============================================================================
+-- Migration: 20260901000001_add_organizations
+-- Phase 0.5 (有料プラン): 課金の契約主体となる組織と、会員アカウント(座席)を追加する。
+-- 設計書: docs/design/02-database.md §2.4.10 / §2.4.11、07-billing.md §7.3
+--
+-- 【実データ影響（精査済み・破壊的操作なし）】
+--   - 追加のみ。既存テーブルの列・制約・データは一切変更しない。
+--   - 既存の全ユーザー (deleted_at が入った退会済みも含む) に対して個人組織を
+--     backfill する。退会済みを除外すると projects.organization_id の NOT NULL 化
+--     (次のマイグレーション) で NULL が残り失敗するため、意図的に全件を対象とする。
+--   - organizations に plan_code は持たせない。契約情報の唯一の正は
+--     billing_subscriptions とし、二重管理を作らない (設計書 §7.13 論点 2)。
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- CreateTable: organizations
+-- -----------------------------------------------------------------------------
+CREATE TABLE "organizations" (
+    "id" UUID NOT NULL DEFAULT uuidv7(),
+    "name" TEXT NOT NULL,
+    "owner_user_id" UUID NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMPTZ,
+
+    CONSTRAINT "organizations_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "ck_orgs_name_length" CHECK (char_length("name") BETWEEN 1 AND 255)
+);
+
+COMMENT ON TABLE "organizations" IS '組織 (課金の契約主体)。ユーザー登録時に個人組織を自動作成する';
+COMMENT ON COLUMN "organizations"."owner_user_id" IS 'オーナー。1 ユーザーにつきオーナー組織は 1 つ';
+
+ALTER TABLE "organizations"
+  ADD CONSTRAINT "fk_orgs_owner_user_id" FOREIGN KEY ("owner_user_id")
+  REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE UNIQUE INDEX "uq_orgs_owner_user_id" ON "organizations"("owner_user_id");
+
+CREATE TRIGGER trg_organizations_set_updated_at
+  BEFORE UPDATE ON "organizations"
+  FOR EACH ROW EXECUTE FUNCTION trakon_set_updated_at();
+
+-- -----------------------------------------------------------------------------
+-- CreateTable: organization_members (= 会員アカウント。課金の人数カウント対象)
+--
+-- project_members との違い:
+--   organization_members … user_id NOT NULL / 座席を消費する / 課金操作の権限
+--   project_members      … user_id NULL 可   / 座席を消費しない / 業務操作の権限
+-- -----------------------------------------------------------------------------
+CREATE TABLE "organization_members" (
+    "id" UUID NOT NULL DEFAULT uuidv7(),
+    "organization_id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "org_role" TEXT NOT NULL DEFAULT 'member',
+    "is_primary" BOOLEAN NOT NULL DEFAULT false,
+    "joined_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMPTZ,
+
+    CONSTRAINT "organization_members_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "ck_om_org_role" CHECK ("org_role" IN ('owner', 'admin', 'member'))
+);
+
+COMMENT ON TABLE "organization_members" IS '会員アカウント (座席)。課金の人数カウント対象';
+COMMENT ON COLUMN "organization_members"."is_primary" IS '既定の所属組織。プロジェクト作成先の決定に使う';
+
+ALTER TABLE "organization_members"
+  ADD CONSTRAINT "fk_om_organization_id" FOREIGN KEY ("organization_id")
+  REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "organization_members"
+  ADD CONSTRAINT "fk_om_user_id" FOREIGN KEY ("user_id")
+  REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 論理削除を含むフル UNIQUE。再招待時は既存行を復活させる (uq_pm_project_email と同じ流儀)
+CREATE UNIQUE INDEX "uq_om_org_user" ON "organization_members"("organization_id", "user_id");
+
+-- 既定の所属組織は 1 ユーザーにつき 1 つ (部分 UNIQUE)
+CREATE UNIQUE INDEX "uq_om_user_primary" ON "organization_members"("user_id")
+  WHERE "is_primary" AND "deleted_at" IS NULL;
+
+CREATE INDEX "idx_om_user" ON "organization_members"("user_id");
+CREATE INDEX "idx_om_org_active" ON "organization_members"("organization_id")
+  WHERE "deleted_at" IS NULL;
+
+CREATE TRIGGER trg_organization_members_set_updated_at
+  BEFORE UPDATE ON "organization_members"
+  FOR EACH ROW EXECUTE FUNCTION trakon_set_updated_at();
+
+-- -----------------------------------------------------------------------------
+-- Backfill: 全ユーザーに個人組織を作成する
+--
+-- 退会済み (deleted_at IS NOT NULL) も対象にする。そのユーザーが作成した
+-- プロジェクトが残っている可能性があり、除外すると次のマイグレーションで
+-- projects.organization_id に NULL が残って NOT NULL 化に失敗するため。
+-- -----------------------------------------------------------------------------
+INSERT INTO "organizations" ("name", "owner_user_id", "created_at", "updated_at")
+SELECT
+  left(u."display_name", 240) || ' の組織',
+  u."id",
+  u."created_at",
+  u."created_at"
+FROM "users" u
+WHERE NOT EXISTS (SELECT 1 FROM "organizations" o WHERE o."owner_user_id" = u."id");
+
+INSERT INTO "organization_members"
+  ("organization_id", "user_id", "org_role", "is_primary", "joined_at", "created_at", "updated_at")
+SELECT o."id", o."owner_user_id", 'owner', true, o."created_at", o."created_at", o."created_at"
+FROM "organizations" o
+WHERE NOT EXISTS (
+  SELECT 1 FROM "organization_members" m
+  WHERE m."organization_id" = o."id" AND m."user_id" = o."owner_user_id"
+);

--- a/packages/db/prisma/migrations/20260901000002_projects_organization_not_null/migration.sql
+++ b/packages/db/prisma/migrations/20260901000002_projects_organization_not_null/migration.sql
@@ -1,0 +1,51 @@
+-- =============================================================================
+-- Migration: 20260901000002_projects_organization_not_null
+-- Phase 0.5 (有料プラン): projects を組織に所属させ、プロジェクト数上限の
+-- 判定単位を確定する。あわせて上限超過時の「維持指定」列を追加する。
+-- 設計書: docs/design/02-database.md §2.2.6 / §2.4.2、07-billing.md §7.11
+--
+-- 【実データ影響（精査済み・破壊的操作あり）】
+--   - projects.organization_id を作成者の個人組織で backfill してから NOT NULL 化する。
+--     SET NOT NULL は ACCESS EXCLUSIVE ロック + 全表スキャンを伴う。
+--   - backfill が 1 行でも漏れると SET NOT NULL が失敗して全体がロールバックする
+--     （＝安全側に倒れる）。20260901000001_add_organizations の先行適用が必須。
+--   - FK は ON DELETE RESTRICT。組織の削除でプロジェクトが道連れに消えないことを
+--     DB レベルで保証する（FR-BILL-09「解約時にプロジェクトを削除しない」の裏付け）。
+--   - retained_at は既存行すべて NULL のまま（未指定＝作成が古い順に維持）。
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1) backfill: 作成者の個人組織へ割り当てる
+-- -----------------------------------------------------------------------------
+UPDATE "projects" p
+SET "organization_id" = o."id"
+FROM "organizations" o
+WHERE p."organization_id" IS NULL
+  AND o."owner_user_id" = p."created_by";
+
+-- -----------------------------------------------------------------------------
+-- 2) FK と NOT NULL 化
+-- -----------------------------------------------------------------------------
+ALTER TABLE "projects"
+  ADD CONSTRAINT "fk_projects_organization_id" FOREIGN KEY ("organization_id")
+  REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "projects" ALTER COLUMN "organization_id" SET NOT NULL;
+
+COMMENT ON COLUMN "projects"."organization_id" IS '所属組織。プロジェクト数上限の判定単位';
+
+-- -----------------------------------------------------------------------------
+-- 3) 上限超過時に「維持する」と選ばれた日時
+--    凍結状態そのものは保存せず都度計算する。ユーザーの選択だけを永続化する。
+-- -----------------------------------------------------------------------------
+ALTER TABLE "projects" ADD COLUMN "retained_at" TIMESTAMPTZ;
+
+COMMENT ON COLUMN "projects"."retained_at" IS
+  '上限超過時に維持対象として選択された日時。未指定なら作成が古い順に維持される';
+
+-- -----------------------------------------------------------------------------
+-- 4) プロジェクト数上限の判定に使う部分インデックス
+--    アーカイブ済みはカウント対象外（＝枠を空ける正規の動線）
+-- -----------------------------------------------------------------------------
+CREATE INDEX "idx_projects_org_active" ON "projects"("organization_id")
+  WHERE "deleted_at" IS NULL AND "archived_at" IS NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -39,14 +39,66 @@ model User {
   updatedAt         DateTime  @default(now()) @map("updated_at") @db.Timestamptz
   deletedAt         DateTime? @map("deleted_at") @db.Timestamptz
 
-  oauthIdentities OAuthIdentity[]
-  auditLogs       AuditLog[]
-  projectsCreated Project[]       @relation("ProjectsCreatedBy")
-  memberships     ProjectMember[]
-  ballEvents      BallEvent[]
+  oauthIdentities    OAuthIdentity[]
+  auditLogs          AuditLog[]
+  projectsCreated    Project[]            @relation("ProjectsCreatedBy")
+  memberships        ProjectMember[]
+  ballEvents         BallEvent[]
+  organizationsOwned Organization[]       @relation("OrganizationOwner")
+  orgMemberships     OrganizationMember[]
 
   @@index([authUserId], map: "idx_users_auth_user_id")
   @@map("users")
+}
+
+// -----------------------------------------------------------------------------
+// organizations — 組織 (課金の契約主体)
+// 設計書 §2.4.10 / §7.3.1
+//
+// プランは本テーブルに持たせない。契約情報の唯一の正は BillingSubscription。
+// -----------------------------------------------------------------------------
+model Organization {
+  id          String    @id @default(uuid(7)) @db.Uuid
+  name        String
+  ownerUserId String    @unique(map: "uq_orgs_owner_user_id") @map("owner_user_id") @db.Uuid
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime  @default(now()) @map("updated_at") @db.Timestamptz
+  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz
+
+  owner    User                 @relation("OrganizationOwner", fields: [ownerUserId], references: [id], onDelete: Restrict, map: "fk_orgs_owner_user_id")
+  members  OrganizationMember[]
+  projects Project[]
+
+  @@map("organizations")
+}
+
+// -----------------------------------------------------------------------------
+// organization_members — 会員アカウント (座席)。課金の人数カウント対象
+// 設計書 §2.4.11
+//
+// ProjectMember との違い:
+//   OrganizationMember … userId 必須 / 座席を消費する / 課金操作の権限
+//   ProjectMember      … userId 任意 / 座席を消費しない / 業務操作の権限
+// -----------------------------------------------------------------------------
+model OrganizationMember {
+  id             String    @id @default(uuid(7)) @db.Uuid
+  organizationId String    @map("organization_id") @db.Uuid
+  userId         String    @map("user_id") @db.Uuid
+  /// 'owner' | 'admin' | 'member' (CHECK 制約)。課金操作の可否を決める
+  orgRole        String    @default("member") @map("org_role")
+  /// 既定の所属組織か。プロジェクト作成先の決定に使う
+  isPrimary      Boolean   @default(false) @map("is_primary")
+  joinedAt       DateTime  @default(now()) @map("joined_at") @db.Timestamptz
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt      DateTime  @default(now()) @map("updated_at") @db.Timestamptz
+  deletedAt      DateTime? @map("deleted_at") @db.Timestamptz
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, map: "fk_om_organization_id")
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade, map: "fk_om_user_id")
+
+  @@unique([organizationId, userId], map: "uq_om_org_user")
+  @@index([userId], map: "idx_om_user")
+  @@map("organization_members")
 }
 
 // -----------------------------------------------------------------------------
@@ -55,7 +107,8 @@ model User {
 // -----------------------------------------------------------------------------
 model Project {
   id                      String    @id @default(uuid(7)) @db.Uuid
-  organizationId          String?   @map("organization_id") @db.Uuid
+  /// 所属組織。プロジェクト数上限の判定単位 (Phase 0.5 で NOT NULL 化)
+  organizationId          String    @map("organization_id") @db.Uuid
   name                    String
   /// クライアント名 (#147)。表示専用で、組織テーブルとは紐づかない
   clientName              String?   @map("client_name")
@@ -69,9 +122,12 @@ model Project {
   closedAt                DateTime? @map("closed_at") @db.Timestamptz
   archivedAt              DateTime? @map("archived_at") @db.Timestamptz
   deletedAt               DateTime? @map("deleted_at") @db.Timestamptz
+  /// 上限超過時に「維持する」と選択された日時。未指定なら作成が古い順に維持される (§7.11)
+  retainedAt              DateTime? @map("retained_at") @db.Timestamptz
   createdAt               DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt               DateTime  @default(now()) @map("updated_at") @db.Timestamptz
 
+  organization    Organization    @relation(fields: [organizationId], references: [id], onDelete: Restrict, map: "fk_projects_organization_id")
   creator         User            @relation("ProjectsCreatedBy", fields: [createdBy], references: [id], onDelete: Restrict, map: "fk_projects_created_by")
   progressManager ProjectMember?  @relation("ProjectProgressManager", fields: [progressManagerMemberId], references: [id], onDelete: Restrict, map: "fk_projects_progress_manager_member_id")
   members         ProjectMember[]


### PR DESCRIPTION
設計書 §7.3 / §2.4.10 / §2.4.11。PRD で Phase 2 予定だった `organizations` を Phase 0.5 へ前倒しで最小実装します。**API の挙動は変わりません。**

有料プラン導入シリーズの 3/13。前段は #161（ドキュメント）、#162（shared ドメイン）。

## なぜ組織を先に作るか

Team は「組織」が契約主体です。Personal も**会員 1 名の組織**として扱い、Personal と Team でデータモデルを分けません。課金・上限・凍結の判定をすべて組織 1 点に寄せるためです。

## マイグレーション

**M101 `add_organizations`** — `organizations` / `organization_members` を作成し、既存の全ユーザーへ個人組織を backfill します。**退会済みユーザーも対象に含めています**。除外すると次の NOT NULL 化で NULL が残るためです。

**M102 `projects_organization_not_null`** — `projects.organization_id` を作成者の組織で backfill → FK → NOT NULL 化。`retained_at` と、プロジェクト数上限の判定に使う部分インデックスも追加します。

FK は **`ON DELETE RESTRICT`** です。「解約してもプロジェクトを削除しない」という確定要件を DB 側で担保します。

`organizations` にプラン列は持たせません。契約の正は `billing_subscriptions` の 1 箇所に集約します（二重管理の芽を潰すため）。

## サービス層

`services/organizations.ts` に `ensureOrganizationForUser` / `ensureOrganizationMember` / `resolvePrimaryOrganization` / `countSeats` / `countActiveProjects`。

会員行の復活は `upsert` ではなく `update` で行います。`uq_om_org_user` が `deleted_at` を含まないフル UNIQUE なので、再招待は INSERT ではなく既存行の復活になるためです（`uq_pm_project_email` と同じ流儀）。

complete-signup と OAuth sync の**両経路**で、個人組織を同一トランザクション内に作ります。`createProject` は作成者の既定の所属組織へプロジェクトを紐づけます。

## テスト

`test/factories.ts` の `createUser` が個人組織も作り、`createProject` が組織を解決するよう改修しました。**これを先に直さないと NOT NULL 化で既存の統合テストが全滅します。**

`services/organizations.test.ts` は CI のカバレッジ下限を満たすために追加したものですが、単に到達させるのではなく壊れると気付きにくい分岐（個人組織作成の冪等性・論理削除からの復活・既定組織の解決順）を固定しています。

## 確認

ローカルの開発 DB で backfill を検証済み：users=1 / projects=1 / plans=3 / members=3 は不変、organizations=1 / organization_members=1 が生成され、`organization_id` の NULL は 0 件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
