### PR TITLE
feat(web): 参加者管理にロール列と招待 UI を追加し、Toaster の未マウントを直す

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,8 @@
 import { Navigate, Route, Routes, Navigate as Nav, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 
+import { Toaster } from '@/components/ui/sonner';
+
 import { AuthCallbackPage } from './app/AuthCallbackPage';
 import { DashboardPage } from './app/DashboardPage';
 import { ResetPasswordPage } from './app/ResetPasswordPage';
@@ -23,43 +25,48 @@ import { SharePage } from './features/shareLinks/SharePage';
 
 export function App() {
   return (
-    <Routes>
-      <Route path="/login" element={<SC01LoginPage />} />
-      <Route path="/auth/callback" element={<AuthCallbackPage />} />
-      <Route path="/auth/reset-password" element={<ResetPasswordPage />} />
-      <Route path="/invitations/:token" element={<InvitationAcceptPage />} />
-      <Route path="/share/:token" element={<SharePage />} />
+    <>
+      {/*
+       * Toaster はルーター直下に置く。認証後レイアウトの中に置いていたため、
+       * /login・/invitations/:token・/share/:token など公開ページでは
+       * トーストが描画されない状態だった (設計書 §4.11 の PRD 整合メモ)。
+       */}
+      <Toaster richColors position="bottom-center" />
+      <Routes>
+        <Route path="/login" element={<SC01LoginPage />} />
+        <Route path="/auth/callback" element={<AuthCallbackPage />} />
+        <Route path="/auth/reset-password" element={<ResetPasswordPage />} />
+        <Route path="/invitations/:token" element={<InvitationAcceptPage />} />
+        <Route path="/share/:token" element={<SharePage />} />
 
-      {/* 未ログインでも閲覧可能な会社情報・法務ページ */}
-      <Route path="/company" element={<CompanyPage />} />
-      <Route path="/terms" element={<TermsPage />} />
-      <Route path="/privacy" element={<PrivacyPage />} />
-      <Route path="/commerce" element={<CommercePage />} />
+        {/* 未ログインでも閲覧可能な会社情報・法務ページ */}
+        <Route path="/company" element={<CompanyPage />} />
+        <Route path="/terms" element={<TermsPage />} />
+        <Route path="/privacy" element={<PrivacyPage />} />
+        <Route path="/commerce" element={<CommercePage />} />
 
-      <Route
-        element={
-          <RequireAuth>
-            <SidebarLayout />
-          </RequireAuth>
-        }
-      >
-        <Route path="/dashboard" element={<DashboardPage />} />
-        <Route path="/projects" element={<ProjectListPage />} />
-        <Route path="/projects/new" element={<ProjectCreatePage />} />
-        <Route path="/projects/:projectId/edit" element={<ProjectEditPage />} />
-        <Route path="/projects/:projectId/members" element={<MembersPage />} />
-        <Route path="/projects/:projectId/share-links" element={<ShareLinksPage />} />
         <Route
-          path="/projects/:projectId/items/:itemId"
-          element={<ItemSchedulePage />}
-        />
-        {/* /projects/:projectId は先頭の制作物スケジュール (縦型カレンダー) へ */}
-        <Route path="/projects/:projectId" element={<ProjectRedirectToSchedule />} />
-      </Route>
+          element={
+            <RequireAuth>
+              <SidebarLayout />
+            </RequireAuth>
+          }
+        >
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/projects" element={<ProjectListPage />} />
+          <Route path="/projects/new" element={<ProjectCreatePage />} />
+          <Route path="/projects/:projectId/edit" element={<ProjectEditPage />} />
+          <Route path="/projects/:projectId/members" element={<MembersPage />} />
+          <Route path="/projects/:projectId/share-links" element={<ShareLinksPage />} />
+          <Route path="/projects/:projectId/items/:itemId" element={<ItemSchedulePage />} />
+          {/* /projects/:projectId は先頭の制作物スケジュール (縦型カレンダー) へ */}
+          <Route path="/projects/:projectId" element={<ProjectRedirectToSchedule />} />
+        </Route>
 
-      <Route path="/" element={<Navigate to="/dashboard" replace />} />
-      <Route path="*" element={<Navigate to="/dashboard" replace />} />
-    </Routes>
+        <Route path="/" element={<Navigate to="/dashboard" replace />} />
+        <Route path="*" element={<Navigate to="/dashboard" replace />} />
+      </Routes>
+    </>
   );
 }
 

--- a/apps/web/src/app/SidebarLayout.tsx
+++ b/apps/web/src/app/SidebarLayout.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 
-import { Toaster } from '@/components/ui/sonner';
 import { AppSidebar } from '@/components/layout/AppSidebar';
 import { supabase } from '@/lib/supabase';
 import { useCurrentUser } from '@/features/auth/useCurrentUser';
@@ -50,7 +49,6 @@ export function SidebarLayout() {
         />
       )}
 
-      <Toaster richColors position="bottom-center" />
     </div>
   );
 }

--- a/apps/web/src/features/projects/MembersPage.test.tsx
+++ b/apps/web/src/features/projects/MembersPage.test.tsx
@@ -59,10 +59,29 @@ function fieldByName(scope: HTMLElement, name: string): HTMLInputElement {
   return el;
 }
 
-/** members 一覧 GET をスタブする。 */
+/** members 一覧 GET をスタブする。招待一覧は既定で空。 */
 function stubMembers(members: ProjectMember[]) {
   server.use(
     http.get('*/api/v1/projects/p1/members', () => HttpResponse.json({ data: members })),
+    http.get('*/api/v1/projects/p1/invitations', () => HttpResponse.json({ data: [] })),
+  );
+}
+
+/** 未受諾の招待をスタブする (座席を消費している招待)。 */
+function stubInvitations(invitations: Array<{ id: string; memberId: string; email: string }>) {
+  server.use(
+    http.get('*/api/v1/projects/p1/invitations', () =>
+      HttpResponse.json({
+        data: invitations.map((i) => ({
+          ...i,
+          roleType: 'editor',
+          memberName: '招待中',
+          invitedByUserId: null,
+          expiresAt: '2026-12-31T00:00:00.000Z',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        })),
+      }),
+    ),
   );
 }
 
@@ -76,6 +95,7 @@ describe('MembersPage 管理タブ (integration)', () => {
           resolve = r;
         }),
       ),
+      http.get('*/api/v1/projects/p1/invitations', () => HttpResponse.json({ data: [] })),
     );
 
     const { container } = renderMembers(MANAGE);
@@ -314,5 +334,85 @@ describe('MembersPage かんばんタブ + 共通 (integration)', () => {
     await user.click(screen.getByRole('tab', { name: /管理/ }));
 
     expect(await screen.findByText('参加者一覧')).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// 権限ロール・招待 (Phase 0.5)
+// =============================================================================
+describe('MembersPage 権限ロール (integration)', () => {
+  it('権限セレクトを変更すると PATCH でロールが送られる', async () => {
+    stubMembers([
+      member({ id: 'm1', name: '管理 太郎', roleType: 'admin' }),
+      member({ id: 'm2', name: '編集 花子', roleType: 'editor' }),
+    ]);
+    let patched: unknown = null;
+    server.use(
+      http.patch('*/api/v1/projects/p1/members/m2', async ({ request }) => {
+        patched = await request.json();
+        return HttpResponse.json({ data: member({ id: 'm2', roleType: 'viewer' }) });
+      }),
+    );
+    renderMembers(MANAGE);
+
+    const select = await screen.findByRole('combobox', { name: '編集 花子 の権限' });
+    await userEvent.click(select);
+    await userEvent.click(await screen.findByRole('option', { name: '閲覧者' }));
+
+    await waitFor(() => expect(patched).toEqual({ roleType: 'viewer' }));
+  });
+
+  it('管理者が 1 名しかいない場合はその権限セレクトと削除を無効化する', async () => {
+    stubMembers([
+      member({ id: 'm1', name: '管理 太郎', roleType: 'admin' }),
+      member({ id: 'm2', name: '編集 花子', roleType: 'editor' }),
+    ]);
+    renderMembers(MANAGE);
+
+    expect(await screen.findByRole('combobox', { name: '管理 太郎 の権限' })).toBeDisabled();
+    expect(screen.getByText('管理者は 1 名以上必要です')).toBeInTheDocument();
+    // 編集者側は操作できる
+    expect(screen.getByRole('combobox', { name: '編集 花子 の権限' })).not.toBeDisabled();
+  });
+
+  it('未受諾の招待は「招待中」バッジと取り消しボタンを出す', async () => {
+    stubMembers([member({ id: 'm1', name: '招待 太郎', roleType: 'editor' })]);
+    stubInvitations([{ id: 'inv1', memberId: 'm1', email: 'invitee@example.test' }]);
+    let revoked = false;
+    server.use(
+      http.delete('*/api/v1/projects/p1/invitations/inv1', () => {
+        revoked = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    renderMembers(MANAGE);
+
+    expect(await screen.findByText('招待中')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: '招待を取り消す' }));
+
+    await waitFor(() => expect(revoked).toBe(true));
+  });
+
+  it('招待ダイアログからロール付きで招待を送れる', async () => {
+    stubMembers([member({ id: 'm1', roleType: 'admin' })]);
+    let posted: unknown = null;
+    server.use(
+      http.post('*/api/v1/projects/p1/invitations', async ({ request }) => {
+        posted = await request.json();
+        return HttpResponse.json({ data: {} }, { status: 201 });
+      }),
+    );
+    renderMembers(MANAGE);
+
+    await userEvent.click(await screen.findByRole('button', { name: /招待を送る/ }));
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.type(fieldByName(dialog, 'email'), 'invitee@example.test');
+    await userEvent.click(within(dialog).getByRole('combobox', { name: '権限' }));
+    await userEvent.click(await screen.findByRole('option', { name: '管理者' }));
+    await userEvent.click(within(dialog).getByRole('button', { name: '招待を送る' }));
+
+    await waitFor(() =>
+      expect(posted).toMatchObject({ email: 'invitee@example.test', roleType: 'admin' }),
+    );
   });
 });

--- a/apps/web/src/features/projects/MembersPage.tsx
+++ b/apps/web/src/features/projects/MembersPage.tsx
@@ -3,8 +3,12 @@ import {
   JOB_TITLE_LABEL,
   MEMBER_TYPES,
   MEMBER_TYPE_LABEL,
+  PROJECT_ROLES,
+  PROJECT_ROLE_DESCRIPTION,
+  PROJECT_ROLE_LABEL,
   type JobTitle,
   type MemberType,
+  type ProjectRole,
 } from '@trakon/shared';
 import { useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
@@ -12,7 +16,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Loader2, Plus, Trash2, UsersRound, ArrowLeft, KanbanSquare, GripVertical } from 'lucide-react';
+import { Loader2, Plus, Trash2, UsersRound, ArrowLeft, KanbanSquare, GripVertical, Mail, X } from 'lucide-react';
 import { MemberKanbanTab } from '@/features/plans/MemberKanbanTab';
 import { toast } from 'sonner';
 
@@ -61,6 +65,7 @@ import { moveItem, useDragReorder } from '@/lib/reorder';
 import { PageContainer } from '@/components/layout/PageContainer';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { membersApi, membersQueryKey, type ProjectMember } from './membersApi';
+import { invitationsApi, invitationsQueryKey } from './invitationsApi';
 
 export function MembersPage() {
   const { projectId } = useParams<{ projectId: string }>();
@@ -139,6 +144,7 @@ export function MembersPage() {
 function ManageTab({ projectId }: { projectId: string }) {
   const qc = useQueryClient();
   const [addOpen, setAddOpen] = useState(false);
+  const [inviteOpen, setInviteOpen] = useState(false);
   const [removing, setRemoving] = useState<ProjectMember | null>(null);
 
   const query = useQuery({
@@ -184,15 +190,57 @@ function ManageTab({ projectId }: { projectId: string }) {
     reorderMut.mutate(moveItem(members, from, to).map((m) => m.id));
   });
 
+  // ロール変更 (FR-ROLE-03)。最後の管理者の降格はサーバーが LAST_ADMIN 409 で拒否する。
+  const roleMut = useMutation({
+    mutationFn: ({ memberId, roleType }: { memberId: string; roleType: ProjectRole }) =>
+      membersApi.update(projectId, memberId, { roleType }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: membersQueryKey.list(projectId) });
+      toast.success('権限を変更しました');
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '権限の変更に失敗しました'),
+  });
+
+  // 未受諾の招待 (座席を消費している) を一覧に混ぜて表示する
+  const invitationsQuery = useQuery({
+    queryKey: invitationsQueryKey.list(projectId),
+    queryFn: () => invitationsApi.list(projectId),
+  });
+  const pendingByMemberId = new Map(
+    (invitationsQuery.data ?? []).map((inv) => [inv.memberId, inv]),
+  );
+
+  const revokeMut = useMutation({
+    mutationFn: (invitationId: string) => invitationsApi.revoke(projectId, invitationId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: invitationsQueryKey.list(projectId) });
+      qc.invalidateQueries({ queryKey: membersQueryKey.list(projectId) });
+      toast.success('招待を取り消しました');
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '招待の取り消しに失敗しました'),
+  });
+
+  // 管理者が 0 名になる操作は UI 側でも無効化する (サーバーでも 409 で弾く)
+  const adminCount = members.filter((m) => m.roleType === 'admin').length;
+  const isLastAdmin = (m: ProjectMember) => m.roleType === 'admin' && adminCount <= 1;
+
   return (
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="text-base">参加者一覧</CardTitle>
-          <Button size="sm" onClick={() => setAddOpen(true)}>
-            <Plus className="size-4" />
-            参加者を追加
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="outline" onClick={() => setInviteOpen(true)}>
+              <Mail className="size-4" />
+              招待を送る
+            </Button>
+            <Button size="sm" onClick={() => setAddOpen(true)}>
+              <Plus className="size-4" />
+              参加者を追加
+            </Button>
+          </div>
         </div>
       </CardHeader>
       <CardContent>
@@ -210,6 +258,7 @@ function ManageTab({ projectId }: { projectId: string }) {
                 <TableHead>メール</TableHead>
                 <TableHead>職種</TableHead>
                 <TableHead>区分</TableHead>
+                <TableHead>権限</TableHead>
                 <TableHead className="w-12" />
               </TableRow>
             </TableHeader>
@@ -244,16 +293,59 @@ function ManageTab({ projectId }: { projectId: string }) {
                     </TableCell>
                     <TableCell>
                       {MEMBER_TYPE_LABEL[m.memberType]}
+                      {pendingByMemberId.has(m.id) && (
+                        <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                          招待中
+                        </span>
+                      )}
                     </TableCell>
                     <TableCell>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => setRemoving(m)}
-                        aria-label="削除"
+                      <Select
+                        value={m.roleType}
+                        onValueChange={(v) =>
+                          roleMut.mutate({ memberId: m.id, roleType: v as ProjectRole })
+                        }
+                        disabled={roleMut.isPending || isLastAdmin(m)}
                       >
-                        <Trash2 className="size-4" />
-                      </Button>
+                        <SelectTrigger className="h-8 w-32" aria-label={`${m.name} の権限`}>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {PROJECT_ROLES.map((r) => (
+                            <SelectItem key={r} value={r}>
+                              {PROJECT_ROLE_LABEL[r]}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      {isLastAdmin(m) && (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          管理者は 1 名以上必要です
+                        </p>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {pendingByMemberId.has(m.id) ? (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => revokeMut.mutate(pendingByMemberId.get(m.id)!.id)}
+                          disabled={revokeMut.isPending}
+                          aria-label="招待を取り消す"
+                        >
+                          <X className="size-4" />
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setRemoving(m)}
+                          disabled={isLastAdmin(m)}
+                          aria-label="削除"
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      )}
                     </TableCell>
                   </TableRow>
                 );
@@ -266,6 +358,12 @@ function ManageTab({ projectId }: { projectId: string }) {
       <AddMembersDialog
         open={addOpen}
         onClose={() => setAddOpen(false)}
+        projectId={projectId}
+      />
+
+      <InviteMemberDialog
+        open={inviteOpen}
+        onClose={() => setInviteOpen(false)}
         projectId={projectId}
       />
 
@@ -456,5 +554,145 @@ function NotFound({ projectId: _ }: { projectId: string | undefined }) {
     <div className="mx-auto max-w-3xl px-8 py-20 text-center text-sm text-muted-foreground">
       プロジェクトが見つかりませんでした。
     </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// 招待ダイアログ (UC-31)
+//
+// 招待は組織の座席を 1 つ消費する。上限に達している場合はサーバーが
+// SEAT_LIMIT_REACHED 409 を返すので、その旨をそのまま表示する。
+// -----------------------------------------------------------------------------
+const inviteSchema = z.object({
+  email: z.string().trim().email('メール形式が不正').max(320),
+  name: z.string().trim().max(100),
+  organizationName: z.string().trim().max(255),
+  memberType: z.enum(MEMBER_TYPES),
+  jobTitle: z.string(),
+  roleType: z.enum(PROJECT_ROLES),
+});
+type InviteValues = z.infer<typeof inviteSchema>;
+
+function InviteMemberDialog({
+  open,
+  onClose,
+  projectId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  projectId: string;
+}) {
+  const qc = useQueryClient();
+  const form = useForm<InviteValues>({
+    resolver: zodResolver(inviteSchema),
+    defaultValues: {
+      email: '',
+      name: '',
+      organizationName: '',
+      memberType: 'production',
+      jobTitle: '',
+      roleType: 'editor',
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: (values: InviteValues) =>
+      invitationsApi.create(projectId, {
+        email: values.email,
+        roleType: values.roleType,
+        ...(values.name ? { name: values.name } : {}),
+        organizationName: values.organizationName,
+        memberType: values.memberType,
+        jobTitle: (values.jobTitle || null) as JobTitle | null,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: membersQueryKey.list(projectId) });
+      qc.invalidateQueries({ queryKey: invitationsQueryKey.list(projectId) });
+      toast.success('招待メールを送信しました');
+      form.reset();
+      onClose();
+    },
+    onError: (e) =>
+      toast.error(e instanceof ApiClientError ? e.message : '招待の送信に失敗しました'),
+  });
+
+  const roleType = form.watch('roleType');
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>参加者を招待</DialogTitle>
+          <DialogDescription>
+            招待メールを送り、受諾すると会員アカウントとして参加します。
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          id="invite-member-form"
+          className="grid gap-4"
+          onSubmit={form.handleSubmit((v) => mutation.mutate(v))}
+        >
+          <Field label="メールアドレス" error={form.formState.errors.email?.message}>
+            <Input type="email" autoComplete="off" {...form.register('email')} />
+          </Field>
+
+          <Field label="氏名 (任意)" error={form.formState.errors.name?.message}>
+            <Input {...form.register('name')} />
+          </Field>
+
+          <Field label="所属 (任意)" error={form.formState.errors.organizationName?.message}>
+            <Input {...form.register('organizationName')} />
+          </Field>
+
+          <Field label="区分">
+            <Select
+              value={form.watch('memberType')}
+              onValueChange={(v) => form.setValue('memberType', v as MemberType)}
+            >
+              <SelectTrigger aria-label="区分">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {MEMBER_TYPES.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {MEMBER_TYPE_LABEL[t]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+
+          <Field label="権限">
+            <Select
+              value={roleType}
+              onValueChange={(v) => form.setValue('roleType', v as ProjectRole)}
+            >
+              <SelectTrigger aria-label="権限">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PROJECT_ROLES.map((r) => (
+                  <SelectItem key={r} value={r}>
+                    {PROJECT_ROLE_LABEL[r]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">{PROJECT_ROLE_DESCRIPTION[roleType]}</p>
+          </Field>
+        </form>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button type="submit" form="invite-member-form" disabled={mutation.isPending}>
+            {mutation.isPending && <Loader2 className="size-4 animate-spin" />}
+            招待を送る
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/src/features/projects/invitationsApi.ts
+++ b/apps/web/src/features/projects/invitationsApi.ts
@@ -1,0 +1,46 @@
+import type { JobTitle, MemberType, ProjectRole } from '@trakon/shared';
+
+import { apiRequest } from '@/lib/api';
+
+/** 未受諾かつ有効期限内の招待 (= 座席を消費している招待)。 */
+export type PendingInvitation = {
+  id: string;
+  email: string;
+  roleType: ProjectRole;
+  memberId: string;
+  memberName: string;
+  invitedByUserId: string | null;
+  expiresAt: string;
+  createdAt: string;
+};
+
+export type CreateInvitationInput = {
+  email: string;
+  roleType: ProjectRole;
+  /** 既存の担当者行を招待する場合はその id */
+  memberId?: string;
+  name?: string;
+  organizationName?: string;
+  memberType?: MemberType;
+  jobTitle?: JobTitle | null;
+};
+
+export const invitationsApi = {
+  list: (projectId: string) =>
+    apiRequest<PendingInvitation[]>(`/projects/${projectId}/invitations`),
+
+  create: (projectId: string, body: CreateInvitationInput) =>
+    apiRequest<PendingInvitation>(`/projects/${projectId}/invitations`, {
+      method: 'POST',
+      body,
+    }),
+
+  revoke: (projectId: string, invitationId: string) =>
+    apiRequest<void>(`/projects/${projectId}/invitations/${invitationId}`, {
+      method: 'DELETE',
+    }),
+};
+
+export const invitationsQueryKey = {
+  list: (projectId: string) => ['projects', projectId, 'invitations'] as const,
+};


### PR DESCRIPTION
設計書 §4.5.2 / SC-11。#165 で作った招待 API を画面から使えるようにします。

有料プラン導入シリーズの 6/13。

## 参加者管理

- 参加者一覧に **「権限」列**（管理者 / 編集者 / 閲覧者のセレクト）を追加
- **未受諾の招待を「招待中」バッジで表示**し、取り消しできるようにしました。未受諾の招待は組織の座席を消費するため、一覧に出ないと「なぜか上限に達する」ことになります
- **管理者が 1 名しかいない場合はセレクトと削除を無効化**し、理由を表示します（サーバー側でも `LAST_ADMIN` 409 で二重に守ります）
- 招待ダイアログ: メール・氏名・所属・区分・権限を指定して送信。ロール選択には各ロールの説明文を添えています

## 合わせて直したもの

**`<Toaster>` が `SidebarLayout` の中にしかマウントされていませんでした。** 認証後レイアウトの内側だったため、`/login` `/invitations/:token` `/share/:token` ではトーストが一切描画されない状態です。招待受諾フローで必要になるので、ルーター直下へ移しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
