### PR TITLE
feat(api): Checkout / Customer Portal / プラン変更 / 解約を実装する

### DIFF
--- a/apps/web/server/app.ts
+++ b/apps/web/server/app.ts
@@ -5,6 +5,7 @@ import { secureHeaders } from 'hono/secure-headers';
 import { errorMiddleware, notFoundHandler } from './middleware/error.js';
 import { initSentryServer } from './lib/sentry.js';
 import { authRoute } from './routes/v1/auth.js';
+import { billingRoute } from './routes/v1/billing.js';
 import { dashboardRoute } from './routes/v1/dashboard.js';
 import { healthRoute } from './routes/v1/healthz.js';
 import { invitationsRoute } from './routes/v1/invitations.js';
@@ -31,6 +32,7 @@ export function createApp() {
 
   app.route('/api/v1', healthRoute);
   app.route('/api/v1/auth', authRoute);
+  app.route('/api/v1/billing', billingRoute);
   app.route('/api/v1/projects', projectsRoute);
   app.route('/api/v1/invitations', invitationsRoute);
   app.route('/api/v1/users/me', dashboardRoute);

--- a/apps/web/server/middleware/orgAuth.ts
+++ b/apps/web/server/middleware/orgAuth.ts
@@ -1,0 +1,56 @@
+import type { Context, MiddlewareHandler } from 'hono';
+
+import { prisma } from '@trakon/db';
+import { canManageBilling, type OrgRole } from '@trakon/shared';
+
+import { ApiException } from '../lib/errors.js';
+import { resolvePrimaryOrganization } from '../services/organizations.js';
+
+export type OrganizationContext = {
+  organizationId: string;
+  orgRole: OrgRole;
+};
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    organization: OrganizationContext;
+  }
+}
+
+/**
+ * 既定の所属組織を解決して `c.var.organization` にセットする (設計書 §3.3.3)。
+ * `requireAuth()` + `attachCurrentUserId()` の後段で使う。
+ */
+export function requireOrgMember(): MiddlewareHandler {
+  return async (c, next) => {
+    const userId = c.get('currentUserId');
+    const membership = await resolvePrimaryOrganization(prisma, userId);
+    c.set('organization', membership);
+    await next();
+  };
+}
+
+/**
+ * 課金操作 (プラン契約・変更・解約・支払方法変更・組織メンバー管理) を
+ * 組織のオーナー / 管理者に限定する (PRD SR-AUTHZ-06)。
+ *
+ * プロジェクトロールとは別系統なので、同じ判定関数に混ぜない。
+ */
+export function requireOrgBillingRole(): MiddlewareHandler {
+  return async (c, next) => {
+    const organization = c.get('organization');
+    if (!canManageBilling(organization.orgRole)) {
+      throw forbidden(c);
+    }
+    await next();
+  };
+}
+
+function forbidden(c: Context) {
+  return new ApiException(
+    'FORBIDDEN',
+    403,
+    'この操作は組織のオーナーまたは管理者のみが実行できます。',
+    { path: c.req.path },
+  );
+}

--- a/apps/web/server/routes/v1/billing.integration.test.ts
+++ b/apps/web/server/routes/v1/billing.integration.test.ts
@@ -11,6 +11,7 @@ import {
   setBillingSubscription,
 } from '../../test/factories.js';
 import { signTestJwt } from '../../test/auth.js';
+import { TEST_STRIPE } from '../../test/integration.setup.js';
 import { api } from '../../test/request.js';
 
 // =============================================================================
@@ -39,19 +40,14 @@ let ownerToken: string;
 let organizationId: string;
 let ownerUserId: string;
 
+// Stripe の env は integration.setup.ts で設定済み (getServerEnv() のキャッシュ対策)。
 beforeEach(async () => {
-  process.env.STRIPE_SECRET_KEY = 'sk_test_dummy';
-  process.env.STRIPE_PERSONAL_MONTHLY_PRICE_ID = 'price_personal';
-  process.env.STRIPE_TEAM_MONTHLY_PRICE_ID = 'price_team';
-  process.env.STRIPE_JP_TAX_RATE_ID = 'txr_jp';
-  process.env.STRIPE_PORTAL_CONFIGURATION_ID = 'bpc_test';
-
   vi.clearAllMocks();
   checkoutCreate.mockResolvedValue({ id: 'cs_1', url: 'https://checkout.stripe.test/cs_1' });
   portalCreate.mockResolvedValue({ url: 'https://portal.stripe.test/ps_1' });
   subscriptionsRetrieve.mockResolvedValue({
     id: 'sub_1',
-    items: { data: [{ id: 'si_1', price: { id: 'price_team' }, current_period_end: 1_762_000_000 }] },
+    items: { data: [{ id: 'si_1', price: { id: TEST_STRIPE.teamPriceId }, current_period_end: 1_762_000_000 }] },
   });
   subscriptionsUpdate.mockResolvedValue({
     id: 'sub_1',
@@ -136,14 +132,14 @@ describe('POST /billing/checkout-session', () => {
       expect(params).toMatchObject({
         mode: 'subscription',
         // quantity は常に 1 (人数課金しない)
-        line_items: [{ price: 'price_team', quantity: 1 }],
+        line_items: [{ price: TEST_STRIPE.teamPriceId, quantity: 1 }],
         automatic_tax: { enabled: false },
         payment_method_collection: 'always',
       });
       // trial_end は使わない (§7.4.1)
       expect(params.subscription_data).toMatchObject({
         trial_period_days: 5,
-        default_tax_rates: ['txr_jp'],
+        default_tax_rates: [TEST_STRIPE.taxRateId],
       });
       expect(params.subscription_data.trial_end).toBeUndefined();
       expect(params.metadata).toMatchObject({
@@ -236,7 +232,7 @@ describe('POST /billing/portal-session', () => {
 
     expect(res.body.data.url).toBe('https://portal.stripe.test/ps_1');
     // プラン変更を無効化した構成を明示指定する
-    expect(portalCreate.mock.calls[0]?.[0]).toMatchObject({ configuration: 'bpc_test' });
+    expect(portalCreate.mock.calls[0]?.[0]).toMatchObject({ configuration: TEST_STRIPE.portalConfigurationId });
     // URL は DB に残さない
     const sub = await prisma.billingSubscription.findUniqueOrThrow({ where: { organizationId } });
     expect(JSON.stringify(sub)).not.toContain('portal.stripe.test');

--- a/apps/web/server/routes/v1/billing.integration.test.ts
+++ b/apps/web/server/routes/v1/billing.integration.test.ts
@@ -1,0 +1,394 @@
+import { prisma } from '@trakon/db';
+import type Stripe from 'stripe';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { __setStripeForTest } from '../../services/billing/stripeClient.js';
+import {
+  createOrgMember,
+  createProject,
+  createUser,
+  primaryOrganizationId,
+  setBillingSubscription,
+} from '../../test/factories.js';
+import { signTestJwt } from '../../test/auth.js';
+import { api } from '../../test/request.js';
+
+// =============================================================================
+// Checkout / Portal / プラン変更 / 解約 (設計書 §7.4 / §7.7 / §7.8)
+//
+// Stripe SDK はモックする。CI から実 Stripe へは接続しない。
+// =============================================================================
+
+const checkoutCreate = vi.fn();
+const portalCreate = vi.fn();
+const subscriptionsRetrieve = vi.fn();
+const subscriptionsUpdate = vi.fn();
+const scheduleCreate = vi.fn();
+const scheduleUpdate = vi.fn();
+
+function stubStripe() {
+  __setStripeForTest({
+    checkout: { sessions: { create: checkoutCreate } },
+    billingPortal: { sessions: { create: portalCreate } },
+    subscriptions: { retrieve: subscriptionsRetrieve, update: subscriptionsUpdate },
+    subscriptionSchedules: { create: scheduleCreate, update: scheduleUpdate },
+  } as unknown as Stripe);
+}
+
+let ownerToken: string;
+let organizationId: string;
+let ownerUserId: string;
+
+beforeEach(async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_dummy';
+  process.env.STRIPE_PERSONAL_MONTHLY_PRICE_ID = 'price_personal';
+  process.env.STRIPE_TEAM_MONTHLY_PRICE_ID = 'price_team';
+  process.env.STRIPE_JP_TAX_RATE_ID = 'txr_jp';
+  process.env.STRIPE_PORTAL_CONFIGURATION_ID = 'bpc_test';
+
+  vi.clearAllMocks();
+  checkoutCreate.mockResolvedValue({ id: 'cs_1', url: 'https://checkout.stripe.test/cs_1' });
+  portalCreate.mockResolvedValue({ url: 'https://portal.stripe.test/ps_1' });
+  subscriptionsRetrieve.mockResolvedValue({
+    id: 'sub_1',
+    items: { data: [{ id: 'si_1', price: { id: 'price_team' }, current_period_end: 1_762_000_000 }] },
+  });
+  subscriptionsUpdate.mockResolvedValue({
+    id: 'sub_1',
+    items: { data: [{ id: 'si_1', current_period_end: 1_762_000_000 }] },
+  });
+  scheduleCreate.mockResolvedValue({ id: 'sub_sched_1', current_phase: { start_date: 1_760_000_000 } });
+  scheduleUpdate.mockResolvedValue({ id: 'sub_sched_1' });
+  stubStripe();
+
+  const owner = await createUser();
+  ownerUserId = owner.id;
+  organizationId = await primaryOrganizationId(owner.id);
+  ownerToken = await signTestJwt({ authUserId: owner.authUserId, email: owner.email });
+});
+
+afterEach(() => {
+  __setStripeForTest(undefined);
+});
+
+describe('GET /billing/subscription', () => {
+  describe('正常系', () => {
+    it('Free の契約状態と上限・利用状況を返す', async () => {
+      await createProject({ createdBy: ownerUserId });
+
+      const res = await api<{
+        data: {
+          subscription: { planCode: string; status: string };
+          entitlement: { level: string; limits: { projectLimit: number }; usage: { projectCount: number } };
+          frozenProjectIds: string[];
+          orgRole: string;
+        };
+      }>('/api/v1/billing/subscription', { token: ownerToken });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.subscription).toMatchObject({ planCode: 'free', status: 'none' });
+      expect(res.body.data.entitlement.limits.projectLimit).toBe(2);
+      expect(res.body.data.entitlement.usage.projectCount).toBe(1);
+      expect(res.body.data.frozenProjectIds).toEqual([]);
+      expect(res.body.data.orgRole).toBe('owner');
+    });
+
+    it('上限超過分が凍結として返る', async () => {
+      await createProject({ createdBy: ownerUserId });
+      await createProject({ createdBy: ownerUserId });
+      const third = await createProject({ createdBy: ownerUserId });
+
+      const res = await api<{ data: { frozenProjectIds: string[] } }>(
+        '/api/v1/billing/subscription',
+        { token: ownerToken },
+      );
+
+      expect(res.body.data.frozenProjectIds).toEqual([third.id]);
+    });
+
+    it('組織メンバー (非管理者) も閲覧できる', async () => {
+      const member = await createUser({ withOrganization: false });
+      await createOrgMember({ organizationId, userId: member.id, isPrimary: true });
+      const token = await signTestJwt({ authUserId: member.authUserId, email: member.email });
+
+      const res = await api('/api/v1/billing/subscription', { token });
+
+      expect(res.status).toBe(200);
+    });
+  });
+});
+
+describe('POST /billing/checkout-session', () => {
+  describe('正常系', () => {
+    it('トライアル付きの Checkout を作り URL を返す', async () => {
+      const res = await api<{ data: { url: string; trialApplied: boolean } }>(
+        '/api/v1/billing/checkout-session',
+        { method: 'POST', token: ownerToken, body: { planCode: 'team' } },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toMatchObject({
+        url: 'https://checkout.stripe.test/cs_1',
+        trialApplied: true,
+      });
+
+      const params = checkoutCreate.mock.calls[0]?.[0];
+      expect(params).toMatchObject({
+        mode: 'subscription',
+        // quantity は常に 1 (人数課金しない)
+        line_items: [{ price: 'price_team', quantity: 1 }],
+        automatic_tax: { enabled: false },
+        payment_method_collection: 'always',
+      });
+      // trial_end は使わない (§7.4.1)
+      expect(params.subscription_data).toMatchObject({
+        trial_period_days: 5,
+        default_tax_rates: ['txr_jp'],
+      });
+      expect(params.subscription_data.trial_end).toBeUndefined();
+      expect(params.metadata).toMatchObject({
+        organization_id: organizationId,
+        user_id: ownerUserId,
+        plan_code: 'team',
+      });
+      expect(params.success_url).toContain('/settings/billing?checkout=success');
+
+      expect(await prisma.auditLog.count({ where: { action: 'checkout_started' } })).toBe(1);
+    });
+
+    it('トライアル済みなら trial_period_days を付けず trial_blocked を記録する', async () => {
+      await prisma.billingTrialClaim.create({
+        data: {
+          organizationId,
+          userId: ownerUserId,
+          emailNormalized: 'x@example.test',
+          emailDomain: 'example.test',
+        },
+      });
+
+      const res = await api<{ data: { trialApplied: boolean } }>(
+        '/api/v1/billing/checkout-session',
+        { method: 'POST', token: ownerToken, body: { planCode: 'personal' } },
+      );
+
+      expect(res.body.data.trialApplied).toBe(false);
+      expect(checkoutCreate.mock.calls[0]?.[0].subscription_data.trial_period_days).toBeUndefined();
+      expect(await prisma.auditLog.count({ where: { action: 'trial_blocked' } })).toBe(1);
+    });
+
+    it('既存の顧客 ID があれば再利用する', async () => {
+      await setBillingSubscription({ organizationId, stripeCustomerId: 'cus_existing' });
+
+      await api('/api/v1/billing/checkout-session', {
+        method: 'POST',
+        token: ownerToken,
+        body: { planCode: 'team' },
+      });
+
+      expect(checkoutCreate.mock.calls[0]?.[0].customer).toBe('cus_existing');
+    });
+  });
+
+  describe('異常系', () => {
+    it('既に有効な契約があれば 409', async () => {
+      await setBillingSubscription({
+        organizationId,
+        status: 'active',
+        planCode: 'team',
+        stripeSubscriptionId: 'sub_1',
+      });
+
+      const res = await api<{ error: { code: string } }>('/api/v1/billing/checkout-session', {
+        method: 'POST',
+        token: ownerToken,
+        body: { planCode: 'team' },
+      });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error.code).toBe('SUBSCRIPTION_ALREADY_ACTIVE');
+    });
+
+    it('組織メンバー (非管理者) は 403', async () => {
+      const member = await createUser({ withOrganization: false });
+      await createOrgMember({ organizationId, userId: member.id, isPrimary: true });
+      const token = await signTestJwt({ authUserId: member.authUserId, email: member.email });
+
+      const res = await api<{ error: { code: string } }>('/api/v1/billing/checkout-session', {
+        method: 'POST',
+        token,
+        body: { planCode: 'team' },
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('FORBIDDEN');
+    });
+  });
+});
+
+describe('POST /billing/portal-session', () => {
+  it('顧客がいれば都度セッションを生成する (URL は保存しない)', async () => {
+    await setBillingSubscription({ organizationId, stripeCustomerId: 'cus_1' });
+
+    const res = await api<{ data: { url: string } }>('/api/v1/billing/portal-session', {
+      method: 'POST',
+      token: ownerToken,
+    });
+
+    expect(res.body.data.url).toBe('https://portal.stripe.test/ps_1');
+    // プラン変更を無効化した構成を明示指定する
+    expect(portalCreate.mock.calls[0]?.[0]).toMatchObject({ configuration: 'bpc_test' });
+    // URL は DB に残さない
+    const sub = await prisma.billingSubscription.findUniqueOrThrow({ where: { organizationId } });
+    expect(JSON.stringify(sub)).not.toContain('portal.stripe.test');
+  });
+
+  it('顧客が未作成なら 409', async () => {
+    const res = await api<{ error: { code: string } }>('/api/v1/billing/portal-session', {
+      method: 'POST',
+      token: ownerToken,
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('NO_STRIPE_CUSTOMER');
+  });
+});
+
+describe('POST /billing/plan — Personal → Team', () => {
+  beforeEach(async () => {
+    await setBillingSubscription({
+      organizationId,
+      planCode: 'personal',
+      status: 'active',
+      stripeSubscriptionId: 'sub_1',
+    });
+  });
+
+  it('即時変更を要求するが、権限は決済成功の確認まで付与しない', async () => {
+    const res = await api<{ data: { appliedImmediately: boolean; pendingPlanCode: string } }>(
+      '/api/v1/billing/plan',
+      { method: 'POST', token: ownerToken, body: { planCode: 'team' } },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ appliedImmediately: false, pendingPlanCode: 'team' });
+
+    expect(subscriptionsUpdate.mock.calls[0]?.[1]).toMatchObject({
+      proration_behavior: 'always_invoice',
+      payment_behavior: 'pending_if_incomplete',
+    });
+
+    // plan_code はまだ personal のまま
+    const sub = await prisma.billingSubscription.findUniqueOrThrow({ where: { organizationId } });
+    expect(sub.planCode).toBe('personal');
+    expect(sub.pendingPlanCode).toBe('team');
+  });
+});
+
+describe('POST /billing/plan — Team → Personal', () => {
+  beforeEach(async () => {
+    await setBillingSubscription({
+      organizationId,
+      planCode: 'team',
+      status: 'active',
+      stripeSubscriptionId: 'sub_1',
+    });
+  });
+
+  it('条件を満たせば次回更新時に適用する', async () => {
+    const res = await api<{ data: { pendingPlanCode: string } }>('/api/v1/billing/plan', {
+      method: 'POST',
+      token: ownerToken,
+      body: { planCode: 'personal' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.pendingPlanCode).toBe('personal');
+    expect(scheduleCreate).toHaveBeenCalledWith({ from_subscription: 'sub_1' });
+
+    const sub = await prisma.billingSubscription.findUniqueOrThrow({ where: { organizationId } });
+    expect(sub.planCode).toBe('team');
+    expect(sub.pendingPlanCode).toBe('personal');
+  });
+
+  it('プロジェクトが上限超過なら 409 で整理対象を返す', async () => {
+    for (let i = 0; i < 11; i += 1) {
+      await createProject({ createdBy: ownerUserId, name: `P${i}` });
+    }
+
+    const res = await api<{
+      error: { code: string; details?: { excessProjects: Array<{ id: string }> } };
+    }>('/api/v1/billing/plan', {
+      method: 'POST',
+      token: ownerToken,
+      body: { planCode: 'personal' },
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('PLAN_DOWNGRADE_BLOCKED');
+    expect(res.body.error.details?.excessProjects).toHaveLength(1);
+    expect(scheduleCreate).not.toHaveBeenCalled();
+  });
+
+  it('会員が上限超過なら 409', async () => {
+    const extra = await createUser({ withOrganization: false });
+    await createOrgMember({ organizationId, userId: extra.id });
+
+    const res = await api<{ error: { code: string } }>('/api/v1/billing/plan', {
+      method: 'POST',
+      token: ownerToken,
+      body: { planCode: 'personal' },
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('PLAN_DOWNGRADE_BLOCKED');
+  });
+});
+
+describe('POST /billing/cancel と /resume', () => {
+  beforeEach(async () => {
+    await setBillingSubscription({
+      organizationId,
+      planCode: 'team',
+      status: 'active',
+      stripeSubscriptionId: 'sub_1',
+    });
+  });
+
+  it('解約予約を設定し、プロジェクトは削除しない', async () => {
+    const project = await createProject({ createdBy: ownerUserId });
+
+    const res = await api<{ data: { cancelAtPeriodEnd: boolean } }>('/api/v1/billing/cancel', {
+      method: 'POST',
+      token: ownerToken,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.cancelAtPeriodEnd).toBe(true);
+    expect(subscriptionsUpdate.mock.calls[0]?.[1]).toMatchObject({ cancel_at_period_end: true });
+
+    const sub = await prisma.billingSubscription.findUniqueOrThrow({ where: { organizationId } });
+    expect(sub.cancelAtPeriodEnd).toBe(true);
+
+    // 【確定要件】解約でプロジェクト・メンバーを削除してはならない
+    expect(await prisma.project.count({ where: { id: project.id, deletedAt: null } })).toBe(1);
+    expect(await prisma.organizationMember.count({ where: { organizationId } })).toBe(1);
+  });
+
+  it('解約予約を取り消せる', async () => {
+    await api('/api/v1/billing/cancel', { method: 'POST', token: ownerToken });
+
+    const res = await api('/api/v1/billing/resume', { method: 'POST', token: ownerToken });
+
+    expect(res.status).toBe(200);
+    const sub = await prisma.billingSubscription.findUniqueOrThrow({ where: { organizationId } });
+    expect(sub.cancelAtPeriodEnd).toBe(false);
+    expect(sub.canceledAt).toBeNull();
+  });
+});
+
+describe('認可', () => {
+  it('未認証は 401', async () => {
+    const res = await api('/api/v1/billing/subscription');
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/web/server/routes/v1/billing.ts
+++ b/apps/web/server/routes/v1/billing.ts
@@ -1,0 +1,83 @@
+import { Hono } from 'hono';
+
+import { requireAuth } from '../../middleware/auth.js';
+import { requireOrgBillingRole, requireOrgMember } from '../../middleware/orgAuth.js';
+import { attachCurrentUserId } from '../../middleware/projectAuth.js';
+import { resolveRequestOrigin } from '../../lib/requestOrigin.js';
+import {
+  changePlanBodySchema,
+  createCheckoutSessionBodySchema,
+} from '../../schemas/billing.js';
+import { createCheckoutSession, createPortalSession } from '../../services/billing/checkout.js';
+import { getOrganizationBilling } from '../../services/billing/entitlement.js';
+import {
+  cancelSubscription,
+  changePlan,
+  resumeSubscription,
+} from '../../services/billing/planChange.js';
+
+/**
+ * `/api/v1/billing` — 設計書 §3.4b / 章7
+ *
+ * 契約状態の閲覧は組織メンバー全員、変更操作はオーナー / 管理者のみ。
+ */
+export const billingRoute = new Hono()
+  .use('*', requireAuth())
+  .use('*', attachCurrentUserId())
+  .use('*', requireOrgMember())
+
+  .get('/subscription', async (c) => {
+    const { organizationId } = c.get('organization');
+    const data = await getOrganizationBilling(organizationId);
+    return c.json({ data: { ...data, orgRole: c.get('organization').orgRole } });
+  })
+
+  .post('/checkout-session', requireOrgBillingRole(), async (c) => {
+    const { organizationId } = c.get('organization');
+    const body = createCheckoutSessionBodySchema.parse(await c.req.json());
+    const result = await createCheckoutSession({
+      organizationId,
+      userId: c.get('currentUserId'),
+      planCode: body.planCode,
+      origin: resolveRequestOrigin(c),
+    });
+    return c.json({ data: result });
+  })
+
+  .post('/portal-session', requireOrgBillingRole(), async (c) => {
+    const { organizationId } = c.get('organization');
+    const result = await createPortalSession({
+      organizationId,
+      origin: resolveRequestOrigin(c),
+    });
+    return c.json({ data: result });
+  })
+
+  .post('/plan', requireOrgBillingRole(), async (c) => {
+    const { organizationId } = c.get('organization');
+    const body = changePlanBodySchema.parse(await c.req.json());
+    const result = await changePlan({
+      organizationId,
+      actorUserId: c.get('currentUserId'),
+      planCode: body.planCode,
+    });
+    return c.json({ data: result });
+  })
+
+  .post('/cancel', requireOrgBillingRole(), async (c) => {
+    const { organizationId } = c.get('organization');
+    const result = await cancelSubscription({
+      organizationId,
+      actorUserId: c.get('currentUserId'),
+    });
+    return c.json({ data: result });
+  })
+
+  .post('/resume', requireOrgBillingRole(), async (c) => {
+    const { organizationId } = c.get('organization');
+    const result = await resumeSubscription({
+      organizationId,
+      actorUserId: c.get('currentUserId'),
+    });
+    return c.json({ data: result });
+  });

--- a/apps/web/server/routes/v1/stripeWebhook.integration.test.ts
+++ b/apps/web/server/routes/v1/stripeWebhook.integration.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { __setMailerForTest } from '../../lib/mailer.js';
 import { __setStripeForTest } from '../../services/billing/stripeClient.js';
 import { createUser, primaryOrganizationId, setBillingSubscription } from '../../test/factories.js';
+import { TEST_STRIPE } from '../../test/integration.setup.js';
 
 // =============================================================================
 // Stripe Webhook (設計書 §7.5)
@@ -19,11 +20,11 @@ import { createUser, primaryOrganizationId, setBillingSubscription } from '../..
 // subscriptions.retrieve だけをスタブする。
 // =============================================================================
 
-const WEBHOOK_SECRET = 'whsec_test_secret_value';
-const PERSONAL_PRICE = 'price_test_personal';
-const TEAM_PRICE = 'price_test_team';
+// 値は integration.setup.ts に集約する (getServerEnv() のキャッシュ対策)。
+const WEBHOOK_SECRET = TEST_STRIPE.webhookSecret;
+const TEAM_PRICE = TEST_STRIPE.teamPriceId;
 
-const signer = new Stripe('sk_test_dummy_key_for_signing');
+const signer = new Stripe(TEST_STRIPE.secretKey);
 
 /** Stripe が付ける署名ヘッダを自作する。 */
 function signed(payload: unknown): { body: string; signature: string } {
@@ -110,11 +111,6 @@ function stubStripe(retrieve: () => unknown) {
 let organizationId: string;
 
 beforeEach(async () => {
-  process.env.STRIPE_SECRET_KEY = 'sk_test_dummy_key_for_signing';
-  process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
-  process.env.STRIPE_PERSONAL_MONTHLY_PRICE_ID = PERSONAL_PRICE;
-  process.env.STRIPE_TEAM_MONTHLY_PRICE_ID = TEAM_PRICE;
-
   __setMailerForTest({});
 
   const user = await createUser();

--- a/apps/web/server/schemas/billing.ts
+++ b/apps/web/server/schemas/billing.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+/** Checkout / プラン変更の対象は Personal と Team のみ (Free と Enterprise は対象外)。 */
+export const checkoutablePlanSchema = z.enum(['personal', 'team']);
+
+export const createCheckoutSessionBodySchema = z.object({
+  planCode: checkoutablePlanSchema,
+});
+export type CreateCheckoutSessionBody = z.infer<typeof createCheckoutSessionBodySchema>;
+
+export const changePlanBodySchema = z.object({
+  planCode: checkoutablePlanSchema,
+});
+export type ChangePlanBody = z.infer<typeof changePlanBodySchema>;
+
+/** 上限超過時に維持するプロジェクトの選択 (FR-BILL-11)。 */
+export const retainedProjectsBodySchema = z.object({
+  projectIds: z.array(z.string().uuid()).max(100),
+});
+export type RetainedProjectsBody = z.infer<typeof retainedProjectsBodySchema>;

--- a/apps/web/server/services/billing/checkout.test.ts
+++ b/apps/web/server/services/billing/checkout.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiException } from '../../lib/errors.js';
+import { createCheckoutSession, createPortalSession } from './checkout.js';
+import { __setStripeForTest } from './stripeClient.js';
+
+// =============================================================================
+// Checkout / Customer Portal (設計書 §7.4 / §7.8)
+// 実 Stripe には接続せず、送信するパラメータそのものを固定する。
+// =============================================================================
+
+const prismaMock = vi.hoisted(() => ({
+  billingSubscription: { findUnique: vi.fn() },
+  user: { findUniqueOrThrow: vi.fn() },
+  billingTrialClaim: { findFirst: vi.fn() },
+  auditLog: { create: vi.fn() },
+}));
+vi.mock('@trakon/db', () => ({ prisma: prismaMock }));
+
+const envState: Record<string, unknown> = {};
+vi.mock('../../lib/env.js', () => ({ getServerEnv: () => envState }));
+
+const setEnv = (patch: Record<string, unknown>) => {
+  for (const k of Object.keys(envState)) delete envState[k];
+  Object.assign(envState, patch);
+};
+
+const FULL_ENV = {
+  STRIPE_PERSONAL_MONTHLY_PRICE_ID: 'price_personal',
+  STRIPE_TEAM_MONTHLY_PRICE_ID: 'price_team',
+  STRIPE_JP_TAX_RATE_ID: 'txr_jp',
+  STRIPE_PORTAL_CONFIGURATION_ID: 'bpc_1',
+};
+
+const checkoutCreate = vi.fn();
+const portalCreate = vi.fn();
+
+function stubStripe() {
+  __setStripeForTest({
+    checkout: { sessions: { create: checkoutCreate } },
+    billingPortal: { sessions: { create: portalCreate } },
+  } as never);
+}
+
+const input = {
+  organizationId: 'org-1',
+  userId: 'u-1',
+  planCode: 'team' as const,
+  origin: 'https://app.trakon.test',
+};
+
+type CheckoutParams = {
+  line_items: unknown;
+  automatic_tax: unknown;
+  payment_method_collection: string;
+  success_url: string;
+  cancel_url: string;
+  metadata: Record<string, string>;
+  subscription_data: Record<string, unknown>;
+  customer?: string;
+  customer_email?: string;
+};
+
+/** createCheckoutSession に渡された Stripe パラメータ。 */
+function params(): CheckoutParams {
+  const call = checkoutCreate.mock.calls.at(-1);
+  if (!call) throw new Error('Checkout セッションが作られていない');
+  return call[0] as CheckoutParams;
+}
+
+beforeEach(() => {
+  setEnv(FULL_ENV);
+  stubStripe();
+  checkoutCreate.mockReset().mockResolvedValue({ url: 'https://checkout.stripe.test/s' });
+  portalCreate.mockReset().mockResolvedValue({ url: 'https://portal.stripe.test/s' });
+  prismaMock.billingSubscription.findUnique.mockReset().mockResolvedValue(null);
+  prismaMock.user.findUniqueOrThrow.mockReset().mockResolvedValue({ email: 'owner@example.test' });
+  prismaMock.billingTrialClaim.findFirst.mockReset().mockResolvedValue(null);
+  prismaMock.auditLog.create.mockReset().mockResolvedValue({});
+});
+
+afterEach(() => {
+  __setStripeForTest(undefined);
+});
+
+describe('createCheckoutSession', () => {
+  describe('確定要件', () => {
+    it('quantity は常に 1 (人数課金は行わない)', async () => {
+      await createCheckoutSession(input);
+
+      expect(params().line_items).toEqual([{ price: 'price_team', quantity: 1 }]);
+    });
+
+    it('自動税計算は使わず、税込 Price + 手動 Tax Rate で組む', async () => {
+      await createCheckoutSession(input);
+
+      expect(params().automatic_tax).toEqual({ enabled: false });
+      expect(params().subscription_data.default_tax_rates).toEqual(['txr_jp']);
+    });
+
+    it('トライアルは trial_period_days で渡す (trial_end は使わない)', async () => {
+      await createCheckoutSession(input);
+
+      // trial_end だと Session 作成〜申込完了の時間差だけトライアルが短くなる
+      expect(params().subscription_data.trial_period_days).toBe(5);
+      expect(params().subscription_data).not.toHaveProperty('trial_end');
+    });
+
+    it('トライアル中でもカード登録を必須にする', async () => {
+      await createCheckoutSession(input);
+
+      expect(params().payment_method_collection).toBe('always');
+    });
+
+    it('復帰後に反映待ちを出せるよう success/cancel URL を渡す', async () => {
+      await createCheckoutSession(input);
+
+      expect(params().success_url).toBe(
+        'https://app.trakon.test/settings/billing?checkout=success&session_id={CHECKOUT_SESSION_ID}',
+      );
+      expect(params().cancel_url).toBe('https://app.trakon.test/settings/billing?checkout=canceled');
+    });
+  });
+
+  describe('metadata', () => {
+    it('Webhook から組織を引けるよう metadata を積む', async () => {
+      await createCheckoutSession(input);
+
+      expect(params().metadata).toMatchObject({
+        user_id: 'u-1',
+        organization_id: 'org-1',
+        plan_code: 'team',
+        email: 'owner@example.test',
+      });
+      // subscription 側にも同じものを載せる (契約系イベントで参照するため)
+      expect(params().subscription_data.metadata).toEqual(params().metadata);
+    });
+  });
+
+  describe('顧客の扱い', () => {
+    it('既存の顧客があれば再利用する', async () => {
+      prismaMock.billingSubscription.findUnique.mockResolvedValue({
+        stripeCustomerId: 'cus_1',
+        status: 'canceled',
+        stripeSubscriptionId: 'sub_1',
+      });
+
+      await createCheckoutSession(input);
+
+      expect(params().customer).toBe('cus_1');
+      expect(params()).not.toHaveProperty('customer_email');
+    });
+
+    it('顧客がなければメールアドレスを渡す', async () => {
+      await createCheckoutSession(input);
+
+      expect(params().customer_email).toBe('owner@example.test');
+      expect(params()).not.toHaveProperty('customer');
+    });
+  });
+
+  describe('トライアル重複', () => {
+    it('履歴があればトライアルを付けずに申し込ませる', async () => {
+      prismaMock.billingTrialClaim.findFirst.mockResolvedValue({
+        userId: 'u-1',
+        emailNormalized: 'owner@example.test',
+        organizationId: 'org-1',
+        stripeCustomerId: null,
+      });
+
+      const result = await createCheckoutSession(input);
+
+      expect(result.trialApplied).toBe(false);
+      expect(params().subscription_data).not.toHaveProperty('trial_period_days');
+      expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ action: 'trial_blocked' }),
+        }),
+      );
+    });
+
+    it('付与できるときは checkout_started として記録する', async () => {
+      const result = await createCheckoutSession(input);
+
+      expect(result.trialApplied).toBe(true);
+      expect(prismaMock.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ action: 'checkout_started', resourceId: 'org-1' }),
+        }),
+      );
+    });
+  });
+
+  describe('異常系', () => {
+    it('既に有効な契約があれば 409 (プラン変更へ誘導する)', async () => {
+      prismaMock.billingSubscription.findUnique.mockResolvedValue({
+        stripeSubscriptionId: 'sub_1',
+        status: 'active',
+        stripeCustomerId: 'cus_1',
+      });
+
+      await expect(createCheckoutSession(input)).rejects.toMatchObject({
+        code: 'SUBSCRIPTION_ALREADY_ACTIVE',
+        status: 409,
+      });
+      expect(checkoutCreate).not.toHaveBeenCalled();
+    });
+
+    it('Price ID が未設定なら 503 BILLING_NOT_CONFIGURED', async () => {
+      setEnv({});
+
+      await expect(createCheckoutSession(input)).rejects.toMatchObject({
+        code: 'BILLING_NOT_CONFIGURED',
+        status: 503,
+      });
+    });
+
+    it('Stripe が URL を返さなければ 502', async () => {
+      checkoutCreate.mockResolvedValue({ url: null });
+
+      await expect(createCheckoutSession(input)).rejects.toBeInstanceOf(ApiException);
+      // 監査ログも書かない (申し込みは成立していない)
+      expect(prismaMock.auditLog.create).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('createPortalSession', () => {
+  it('構成 ID を明示指定する (ダッシュボードの既定に依存しない)', async () => {
+    prismaMock.billingSubscription.findUnique.mockResolvedValue({ stripeCustomerId: 'cus_1' });
+
+    const result = await createPortalSession({
+      organizationId: 'org-1',
+      origin: 'https://app.trakon.test',
+    });
+
+    // 構成側でプラン変更を無効化しているため、既定任せにしてはならない
+    expect(portalCreate).toHaveBeenCalledWith({
+      customer: 'cus_1',
+      return_url: 'https://app.trakon.test/settings/billing',
+      configuration: 'bpc_1',
+    });
+    expect(result.url).toBe('https://portal.stripe.test/s');
+  });
+
+  it('構成 ID が未設定なら渡さない', async () => {
+    setEnv({});
+    prismaMock.billingSubscription.findUnique.mockResolvedValue({ stripeCustomerId: 'cus_1' });
+
+    await createPortalSession({ organizationId: 'org-1', origin: 'https://app.trakon.test' });
+
+    expect(portalCreate.mock.calls[0]![0]).not.toHaveProperty('configuration');
+  });
+
+  it('顧客が未登録なら 409 (先に申し込みへ誘導する)', async () => {
+    prismaMock.billingSubscription.findUnique.mockResolvedValue(null);
+
+    await expect(
+      createPortalSession({ organizationId: 'org-1', origin: 'https://app.trakon.test' }),
+    ).rejects.toMatchObject({ code: 'NO_STRIPE_CUSTOMER', status: 409 });
+  });
+});

--- a/apps/web/server/services/billing/checkout.ts
+++ b/apps/web/server/services/billing/checkout.ts
@@ -1,0 +1,156 @@
+// -----------------------------------------------------------------------------
+// Checkout / Customer Portal — 設計書 §7.4 / §7.8
+//
+// 【確定要件】
+//   - quantity は常に 1。Team の人数上限は TRAKON 側で判定する
+//   - trial_period_days = 5 (= 120 時間)。trial_end は使わない
+//     (Checkout Session 作成〜申込完了の時間差だけトライアルが短縮されるため)
+//   - payment_method_collection = 'always' (トライアル開始時もカード登録必須)
+//   - automatic_tax は無効。税込 Price + 手動 Tax Rate で内訳を表示する
+//   - success URL への遷移だけを根拠に有料権限を付与してはならない
+//   - Portal Session URL は保存せず都度生成する
+// -----------------------------------------------------------------------------
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@trakon/db';
+import { TRIAL_PERIOD_DAYS, type BillingPlanCode } from '@trakon/shared';
+
+import { getServerEnv } from '../../lib/env.js';
+import { ApiException } from '../../lib/errors.js';
+import { getStripe } from './stripeClient.js';
+import { checkTrialEligibility } from './trialEligibility.js';
+
+export type CheckoutablePlan = Extract<BillingPlanCode, 'personal' | 'team'>;
+
+/** プランに対応する Price ID を env から引く。ID はコードに書かない (§7.3.3)。 */
+function priceIdFor(plan: CheckoutablePlan): string {
+  const env = getServerEnv();
+  const priceId =
+    plan === 'team' ? env.STRIPE_TEAM_MONTHLY_PRICE_ID : env.STRIPE_PERSONAL_MONTHLY_PRICE_ID;
+  if (!priceId) {
+    throw new ApiException(
+      'BILLING_NOT_CONFIGURED',
+      503,
+      `Price ID for ${plan} is not configured.`,
+    );
+  }
+  return priceId;
+}
+
+function taxRateIds(): string[] {
+  const id = getServerEnv().STRIPE_JP_TAX_RATE_ID;
+  return id ? [id] : [];
+}
+
+export async function createCheckoutSession(input: {
+  organizationId: string;
+  userId: string;
+  planCode: CheckoutablePlan;
+  origin: string;
+}): Promise<{ url: string; trialApplied: boolean }> {
+  const [subscription, user] = await Promise.all([
+    prisma.billingSubscription.findUnique({ where: { organizationId: input.organizationId } }),
+    prisma.user.findUniqueOrThrow({
+      where: { id: input.userId },
+      select: { email: true },
+    }),
+  ]);
+
+  if (subscription?.stripeSubscriptionId && subscription.status === 'active') {
+    throw new ApiException(
+      'SUBSCRIPTION_ALREADY_ACTIVE',
+      409,
+      '既に有効な契約があります。プラン変更をご利用ください。',
+    );
+  }
+
+  const eligibility = await checkTrialEligibility({
+    userId: input.userId,
+    organizationId: input.organizationId,
+    email: user.email,
+    stripeCustomerId: subscription?.stripeCustomerId ?? null,
+  });
+
+  const checkoutAttemptId = randomUUID();
+  const metadata = {
+    user_id: input.userId,
+    organization_id: input.organizationId,
+    plan_code: input.planCode,
+    checkout_attempt_id: checkoutAttemptId,
+    email: user.email,
+  };
+
+  const session = await getStripe().checkout.sessions.create({
+    mode: 'subscription',
+    // quantity は常に 1。人数課金は行わない (§7.2.1)
+    line_items: [{ price: priceIdFor(input.planCode), quantity: 1 }],
+    automatic_tax: { enabled: false },
+    payment_method_collection: 'always',
+    subscription_data: {
+      // trial_end は使わない (§7.4.1)
+      ...(eligibility.eligible ? { trial_period_days: TRIAL_PERIOD_DAYS } : {}),
+      default_tax_rates: taxRateIds(),
+      metadata,
+    },
+    metadata,
+    ...(subscription?.stripeCustomerId
+      ? { customer: subscription.stripeCustomerId }
+      : { customer_email: user.email }),
+    success_url: `${input.origin}/settings/billing?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${input.origin}/settings/billing?checkout=canceled`,
+  });
+
+  if (!session.url) {
+    throw new ApiException('CHECKOUT_FAILED', 502, 'Stripe did not return a checkout URL.');
+  }
+
+  await prisma.auditLog.create({
+    data: {
+      actorUserId: input.userId,
+      action: eligibility.eligible ? 'checkout_started' : 'trial_blocked',
+      resourceType: 'subscription',
+      resourceId: input.organizationId,
+      result: 'success',
+      extra: {
+        planCode: input.planCode,
+        checkoutAttemptId,
+        trialApplied: eligibility.eligible,
+        ...(eligibility.reason ? { trialBlockedReason: eligibility.reason } : {}),
+      },
+    },
+  });
+
+  return { url: session.url, trialApplied: eligibility.eligible };
+}
+
+/**
+ * Customer Portal のセッションを都度生成する。
+ *
+ * URL は保存しない (PRD SR-BILL-07)。プラン変更の無効化は Portal Configuration
+ * 側の設定なので、構成 ID を明示指定してダッシュボードの既定に依存しない。
+ */
+export async function createPortalSession(input: {
+  organizationId: string;
+  origin: string;
+}): Promise<{ url: string }> {
+  const subscription = await prisma.billingSubscription.findUnique({
+    where: { organizationId: input.organizationId },
+    select: { stripeCustomerId: true },
+  });
+  if (!subscription?.stripeCustomerId) {
+    throw new ApiException(
+      'NO_STRIPE_CUSTOMER',
+      409,
+      'お支払い情報がまだ登録されていません。先にプランをお申し込みください。',
+    );
+  }
+
+  const configuration = getServerEnv().STRIPE_PORTAL_CONFIGURATION_ID;
+  const session = await getStripe().billingPortal.sessions.create({
+    customer: subscription.stripeCustomerId,
+    return_url: `${input.origin}/settings/billing`,
+    ...(configuration ? { configuration } : {}),
+  });
+
+  return { url: session.url };
+}

--- a/apps/web/server/services/billing/entitlement.test.ts
+++ b/apps/web/server/services/billing/entitlement.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getEntitlement, getOrganizationBilling } from './entitlement.js';
+
+// 判定そのものは packages/shared の evaluateEntitlement が持つ (単体テスト済み)。
+// ここは「DB から入力を正しく組み立てて渡すか」「DTO に何を出すか」だけを見る。
+
+const prismaMock = vi.hoisted(() => ({
+  organization: { findUniqueOrThrow: vi.fn() },
+  billingSubscription: { findUnique: vi.fn() },
+  organizationMember: { count: vi.fn() },
+  project: { count: vi.fn(), findMany: vi.fn() },
+}));
+vi.mock('@trakon/db', () => ({ prisma: prismaMock }));
+
+beforeEach(() => {
+  prismaMock.organization.findUniqueOrThrow
+    .mockReset()
+    .mockResolvedValue({ id: 'org-1', name: 'テスト組織' });
+  prismaMock.billingSubscription.findUnique.mockReset().mockResolvedValue(null);
+  prismaMock.organizationMember.count.mockReset().mockResolvedValue(1);
+  prismaMock.project.count.mockReset().mockResolvedValue(0);
+  prismaMock.project.findMany.mockReset().mockResolvedValue([]);
+});
+
+const db = () => prismaMock as unknown as Parameters<typeof getEntitlement>[0];
+
+describe('getEntitlement', () => {
+  it('契約行が無ければ Free として扱う', async () => {
+    const entitlement = await getEntitlement(db(), 'org-1');
+
+    expect(entitlement).toMatchObject({
+      level: 'full',
+      effectivePlanCode: 'free',
+      limits: { seatLimit: 1, projectLimit: 2 },
+    });
+  });
+
+  it('契約の状態と上限を DB から組み立てる', async () => {
+    prismaMock.billingSubscription.findUnique.mockResolvedValue({
+      planCode: 'team',
+      status: 'active',
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: new Date('2026-10-01T00:00:00Z'),
+      gracePeriodEndsAt: null,
+    });
+    prismaMock.organizationMember.count.mockResolvedValue(5);
+    prismaMock.project.count.mockResolvedValue(30);
+
+    const entitlement = await getEntitlement(db(), 'org-1');
+
+    expect(entitlement).toMatchObject({
+      level: 'full',
+      effectivePlanCode: 'team',
+      usage: { seatCount: 5, projectCount: 30 },
+      canInviteMember: false,
+      canCreateProject: true,
+    });
+  });
+
+  it('未払いは閲覧のみに落とす', async () => {
+    prismaMock.billingSubscription.findUnique.mockResolvedValue({
+      planCode: 'team',
+      status: 'unpaid',
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: null,
+      gracePeriodEndsAt: null,
+    });
+
+    expect((await getEntitlement(db(), 'org-1')).level).toBe('read_only');
+  });
+});
+
+describe('getOrganizationBilling', () => {
+  it('アーカイブ済みは利用数に数えないが、一覧には含める', async () => {
+    prismaMock.project.findMany.mockResolvedValue([
+      { id: 'p1', createdAt: new Date('2026-01-01'), archivedAt: null, retainedAt: null },
+      { id: 'p2', createdAt: new Date('2026-01-02'), archivedAt: null, retainedAt: null },
+      { id: 'p3', createdAt: new Date('2026-01-03'), archivedAt: new Date(), retainedAt: null },
+    ]);
+
+    const dto = await getOrganizationBilling('org-1');
+
+    // Free は 2 件まで。アーカイブ済みは枠を空ける
+    expect(dto.entitlement.usage.projectCount).toBe(2);
+    expect(dto.frozenProjectIds).toEqual([]);
+  });
+
+  it('上限超過分を凍結対象として返す', async () => {
+    prismaMock.project.findMany.mockResolvedValue([
+      { id: 'p1', createdAt: new Date('2026-01-01'), archivedAt: null, retainedAt: null },
+      { id: 'p2', createdAt: new Date('2026-01-02'), archivedAt: null, retainedAt: null },
+      { id: 'p3', createdAt: new Date('2026-01-03'), archivedAt: null, retainedAt: null },
+    ]);
+
+    const dto = await getOrganizationBilling('org-1');
+
+    expect(dto.frozenProjectIds).toEqual(['p3']);
+  });
+
+  it('カード情報はブランドと下 4 桁だけを返す (SR-BILL-02)', async () => {
+    prismaMock.billingSubscription.findUnique.mockResolvedValue({
+      planCode: 'team',
+      status: 'active',
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: new Date('2026-10-01T00:00:00Z'),
+      trialEnd: null,
+      gracePeriodEndsAt: null,
+      pendingPlanCode: null,
+      pendingPlanEffectiveAt: null,
+      defaultPaymentMethodBrand: 'visa',
+      defaultPaymentMethodLast4: '4242',
+      stripeCustomerId: 'cus_1',
+    });
+
+    const dto = await getOrganizationBilling('org-1');
+
+    expect(dto.subscription.paymentMethod).toEqual({ brand: 'visa', last4: '4242' });
+    expect(dto.subscription.hasStripeCustomer).toBe(true);
+    // 顧客 ID や契約 ID は画面へ出さない
+    expect(JSON.stringify(dto.subscription)).not.toContain('cus_1');
+  });
+
+  it('カード未登録なら支払い方法は null', async () => {
+    const dto = await getOrganizationBilling('org-1');
+
+    expect(dto.subscription.paymentMethod).toBeNull();
+    expect(dto.subscription.hasStripeCustomer).toBe(false);
+    expect(dto.subscription.planCode).toBe('free');
+    expect(dto.subscription.status).toBe('none');
+  });
+
+  it('日時は ISO 文字列で返す', async () => {
+    prismaMock.billingSubscription.findUnique.mockResolvedValue({
+      planCode: 'team',
+      status: 'past_due',
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd: new Date('2026-10-01T00:00:00Z'),
+      trialEnd: new Date('2026-09-06T00:00:00Z'),
+      gracePeriodEndsAt: new Date('2026-09-08T00:00:00Z'),
+      pendingPlanCode: 'personal',
+      pendingPlanEffectiveAt: new Date('2026-10-01T00:00:00Z'),
+      defaultPaymentMethodBrand: null,
+      defaultPaymentMethodLast4: null,
+      stripeCustomerId: 'cus_1',
+    });
+
+    const dto = await getOrganizationBilling('org-1');
+
+    expect(dto.subscription).toMatchObject({
+      currentPeriodEnd: '2026-10-01T00:00:00.000Z',
+      trialEnd: '2026-09-06T00:00:00.000Z',
+      gracePeriodEndsAt: '2026-09-08T00:00:00.000Z',
+      pendingPlanCode: 'personal',
+      pendingPlanEffectiveAt: '2026-10-01T00:00:00.000Z',
+    });
+    expect(dto.organizationName).toBe('テスト組織');
+  });
+});

--- a/apps/web/server/services/billing/entitlement.ts
+++ b/apps/web/server/services/billing/entitlement.ts
@@ -1,0 +1,125 @@
+// -----------------------------------------------------------------------------
+// 利用権限の解決 — 設計書 §7.6
+//
+// 判定ロジックそのものは packages/shared の evaluateEntitlement が持つ。
+// ここは DB から入力を組み立てて渡すだけにする。
+// 「アプリ全体で単一の判定関数を共用する」という【確定】要件を守るため、
+// 条件分岐をここに書かない。
+// -----------------------------------------------------------------------------
+import type { Prisma } from '@prisma/client';
+
+import { prisma } from '@trakon/db';
+import {
+  evaluateEntitlement,
+  FREE_SUBSCRIPTION_DEFAULTS,
+  selectFrozenProjectIds,
+  type BillingPlanCode,
+  type Entitlement,
+  type SubscriptionStatus,
+} from '@trakon/shared';
+
+import { countActiveProjects, countSeats } from '../organizations.js';
+
+type Db = Prisma.TransactionClient | typeof prisma;
+
+export type BillingSubscriptionSummary = {
+  planCode: BillingPlanCode;
+  status: SubscriptionStatus;
+  cancelAtPeriodEnd: boolean;
+  currentPeriodEnd: string | null;
+  trialEnd: string | null;
+  gracePeriodEndsAt: string | null;
+  pendingPlanCode: BillingPlanCode | null;
+  pendingPlanEffectiveAt: string | null;
+  paymentMethod: { brand: string | null; last4: string | null } | null;
+  hasStripeCustomer: boolean;
+};
+
+export type OrganizationBillingDTO = {
+  organizationId: string;
+  organizationName: string;
+  subscription: BillingSubscriptionSummary;
+  entitlement: Entitlement;
+  /** 上限超過で閲覧のみになっているプロジェクト */
+  frozenProjectIds: string[];
+};
+
+/**
+ * 組織の利用権限を求める。
+ *
+ * 座席数・プロジェクト数のカウントを伴うので、書き込み系エンドポイントの
+ * 上限チェックなど**必要なときだけ**呼ぶ (全リクエストでは呼ばない、§7.11.1)。
+ */
+export async function getEntitlement(db: Db, organizationId: string): Promise<Entitlement> {
+  const [subscription, seatCount, projectCount] = await Promise.all([
+    db.billingSubscription.findUnique({ where: { organizationId } }),
+    countSeats(db, organizationId),
+    countActiveProjects(db, organizationId),
+  ]);
+
+  return evaluateEntitlement({
+    planCode: (subscription?.planCode as BillingPlanCode) ?? FREE_SUBSCRIPTION_DEFAULTS.planCode,
+    status: (subscription?.status as SubscriptionStatus) ?? FREE_SUBSCRIPTION_DEFAULTS.status,
+    cancelAtPeriodEnd: subscription?.cancelAtPeriodEnd ?? false,
+    currentPeriodEnd: subscription?.currentPeriodEnd ?? null,
+    gracePeriodEndsAt: subscription?.gracePeriodEndsAt ?? null,
+    seatCount,
+    projectCount,
+  });
+}
+
+/** 画面表示用に、契約情報と利用権限・凍結状態をまとめて返す。 */
+export async function getOrganizationBilling(
+  organizationId: string,
+): Promise<OrganizationBillingDTO> {
+  const [organization, subscription, seatCount, projects] = await Promise.all([
+    prisma.organization.findUniqueOrThrow({
+      where: { id: organizationId },
+      select: { id: true, name: true },
+    }),
+    prisma.billingSubscription.findUnique({ where: { organizationId } }),
+    countSeats(prisma, organizationId),
+    prisma.project.findMany({
+      where: { organizationId, deletedAt: null },
+      select: { id: true, createdAt: true, archivedAt: true, retainedAt: true },
+    }),
+  ]);
+
+  const activeProjects = projects.filter((p) => p.archivedAt === null);
+
+  const entitlement = evaluateEntitlement({
+    planCode: (subscription?.planCode as BillingPlanCode) ?? FREE_SUBSCRIPTION_DEFAULTS.planCode,
+    status: (subscription?.status as SubscriptionStatus) ?? FREE_SUBSCRIPTION_DEFAULTS.status,
+    cancelAtPeriodEnd: subscription?.cancelAtPeriodEnd ?? false,
+    currentPeriodEnd: subscription?.currentPeriodEnd ?? null,
+    gracePeriodEndsAt: subscription?.gracePeriodEndsAt ?? null,
+    seatCount,
+    projectCount: activeProjects.length,
+  });
+
+  const { frozenIds } = selectFrozenProjectIds(projects, entitlement.limits.projectLimit);
+
+  return {
+    organizationId: organization.id,
+    organizationName: organization.name,
+    subscription: {
+      planCode: (subscription?.planCode as BillingPlanCode) ?? 'free',
+      status: (subscription?.status as SubscriptionStatus) ?? 'none',
+      cancelAtPeriodEnd: subscription?.cancelAtPeriodEnd ?? false,
+      currentPeriodEnd: subscription?.currentPeriodEnd?.toISOString() ?? null,
+      trialEnd: subscription?.trialEnd?.toISOString() ?? null,
+      gracePeriodEndsAt: subscription?.gracePeriodEndsAt?.toISOString() ?? null,
+      pendingPlanCode: (subscription?.pendingPlanCode as BillingPlanCode | null) ?? null,
+      pendingPlanEffectiveAt: subscription?.pendingPlanEffectiveAt?.toISOString() ?? null,
+      paymentMethod: subscription?.defaultPaymentMethodLast4
+        ? {
+            brand: subscription.defaultPaymentMethodBrand,
+            last4: subscription.defaultPaymentMethodLast4,
+          }
+        : null,
+      hasStripeCustomer: Boolean(subscription?.stripeCustomerId),
+    },
+    entitlement,
+    frozenProjectIds: frozenIds,
+  };
+}

--- a/apps/web/server/services/billing/freeze.test.ts
+++ b/apps/web/server/services/billing/freeze.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getFrozenProjectIds, isProjectFrozen, setRetainedProjects } from './freeze.js';
+
+// 凍結状態は保存せず都度計算する (設計書 §7.11)。
+// ここでは「何を凍結対象と判断するか」「維持指定をどう採番するか」を固定する。
+
+const prismaMock = vi.hoisted(() => ({
+  billingSubscription: { findUnique: vi.fn() },
+  organizationMember: { count: vi.fn() },
+  project: { count: vi.fn(), findMany: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
+  auditLog: { create: vi.fn() },
+  $transaction: vi.fn(),
+}));
+vi.mock('@trakon/db', () => ({ prisma: prismaMock }));
+
+const project = (id: string, over: Record<string, unknown> = {}) => ({
+  id,
+  createdAt: new Date(`2026-01-0${id.at(-1)}`),
+  archivedAt: null,
+  retainedAt: null,
+  ...over,
+});
+
+beforeEach(() => {
+  prismaMock.billingSubscription.findUnique.mockReset().mockResolvedValue(null);
+  prismaMock.organizationMember.count.mockReset().mockResolvedValue(1);
+  prismaMock.project.count.mockReset().mockResolvedValue(0);
+  prismaMock.project.findMany.mockReset().mockResolvedValue([]);
+  prismaMock.project.update.mockReset().mockReturnValue({});
+  prismaMock.project.updateMany.mockReset().mockReturnValue({});
+  prismaMock.auditLog.create.mockReset().mockReturnValue({});
+  prismaMock.$transaction.mockReset().mockResolvedValue([]);
+});
+
+describe('getFrozenProjectIds', () => {
+  it('Free の上限 (2 件) を超えた分を凍結対象にする', async () => {
+    prismaMock.project.findMany.mockResolvedValue([project('p1'), project('p2'), project('p3')]);
+    prismaMock.project.count.mockResolvedValue(3);
+
+    expect(await getFrozenProjectIds('org-1')).toEqual(['p3']);
+  });
+
+  it('アーカイブ済みは凍結対象にしない (枠を空ける正規の動線)', async () => {
+    prismaMock.project.findMany.mockResolvedValue([
+      project('p1'),
+      project('p2'),
+      project('p3', { archivedAt: new Date() }),
+    ]);
+
+    expect(await getFrozenProjectIds('org-1')).toEqual([]);
+  });
+
+  it('維持指定があるものを優先して残す', async () => {
+    prismaMock.project.findMany.mockResolvedValue([
+      project('p1'),
+      project('p2'),
+      project('p3', { retainedAt: new Date('2026-06-01') }),
+    ]);
+
+    expect(await getFrozenProjectIds('org-1')).toEqual(['p2']);
+  });
+
+  it('上限が無いプランでは何も凍結しない', async () => {
+    prismaMock.billingSubscription.findUnique.mockResolvedValue({
+      planCode: 'team',
+      status: 'active',
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: new Date('2026-10-01T00:00:00Z'),
+      gracePeriodEndsAt: null,
+    });
+    prismaMock.project.findMany.mockResolvedValue([project('p1'), project('p2'), project('p3')]);
+
+    expect(await getFrozenProjectIds('org-1')).toEqual([]);
+  });
+});
+
+describe('isProjectFrozen', () => {
+  beforeEach(() => {
+    prismaMock.project.findMany.mockResolvedValue([project('p1'), project('p2'), project('p3')]);
+  });
+
+  it('超過分は凍結されている', async () => {
+    expect(await isProjectFrozen('org-1', 'p3')).toBe(true);
+  });
+
+  it('上限内は凍結されていない', async () => {
+    expect(await isProjectFrozen('org-1', 'p1')).toBe(false);
+  });
+});
+
+describe('setRetainedProjects', () => {
+  beforeEach(() => {
+    prismaMock.project.findMany.mockResolvedValue([project('p1'), project('p2'), project('p3')]);
+  });
+
+  it('一度すべてクリアしてから、指定順に新しい時刻を振る', async () => {
+    await setRetainedProjects({
+      organizationId: 'org-1',
+      projectIds: ['p3', 'p1'],
+      actorUserId: 'u-1',
+    });
+
+    expect(prismaMock.project.updateMany).toHaveBeenCalledWith({
+      where: { organizationId: 'org-1' },
+      data: { retainedAt: null },
+    });
+    const [first, second] = prismaMock.project.update.mock.calls.map(
+      (c) => c[0] as { where: { id: string }; data: { retainedAt: Date } },
+    );
+    expect(first!.where.id).toBe('p3');
+    expect(second!.where.id).toBe('p1');
+    // 先頭ほど新しい = 維持指定が新しい順に並ぶ
+    expect(first!.data.retainedAt.getTime()).toBeGreaterThan(second!.data.retainedAt.getTime());
+  });
+
+  it('選び直した結果の凍結対象を返す', async () => {
+    // 1 回目 = 所有チェック、2 回目 = 採番後の凍結判定
+    prismaMock.project.findMany
+      .mockResolvedValueOnce([project('p1'), project('p2'), project('p3')])
+      .mockResolvedValueOnce([
+        project('p1', { retainedAt: new Date('2026-07-01') }),
+        project('p2'),
+        project('p3', { retainedAt: new Date('2026-07-02') }),
+      ]);
+
+    const result = await setRetainedProjects({
+      organizationId: 'org-1',
+      projectIds: ['p3', 'p1'],
+      actorUserId: 'u-1',
+    });
+
+    expect(result.retainedIds).toEqual(['p3', 'p1']);
+    expect(result.frozenIds).toEqual(['p2']);
+  });
+
+  it('監査ログを残す', async () => {
+    await setRetainedProjects({ organizationId: 'org-1', projectIds: ['p1'], actorUserId: 'u-1' });
+
+    expect(prismaMock.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: 'retained_projects_changed',
+        resourceType: 'organization',
+        resourceId: 'org-1',
+      }),
+    });
+  });
+
+  it('上限を超える件数の維持指定は 409', async () => {
+    await expect(
+      setRetainedProjects({
+        organizationId: 'org-1',
+        projectIds: ['p1', 'p2', 'p3'],
+        actorUserId: 'u-1',
+      }),
+    ).rejects.toMatchObject({ code: 'PROJECT_LIMIT_REACHED', status: 409 });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('他組織のプロジェクトを指定されたら 404', async () => {
+    await expect(
+      setRetainedProjects({ organizationId: 'org-1', projectIds: ['p9'], actorUserId: 'u-1' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND', status: 404 });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('プロジェクトを削除しない (超過分は閲覧のみにする)', async () => {
+    await setRetainedProjects({ organizationId: 'org-1', projectIds: ['p1'], actorUserId: 'u-1' });
+
+    expect(prismaMock.project).not.toHaveProperty('delete');
+    expect(prismaMock.project).not.toHaveProperty('deleteMany');
+  });
+});

--- a/apps/web/server/services/billing/freeze.ts
+++ b/apps/web/server/services/billing/freeze.ts
@@ -1,0 +1,97 @@
+// -----------------------------------------------------------------------------
+// プロジェクトの凍結 — 設計書 §7.11
+//
+// 【確定要件】上限を超えたプロジェクトは削除せず「新規編集不可・閲覧のみ」に
+// する。どれを維持するかはユーザーが選べる。
+//
+// 凍結状態は DB に永続化せず**都度計算する**。プラン変更・Webhook の遅延・
+// アーカイブ操作と自動的に整合し、定期バッチも不要になる。
+// この設計の結果として、超過分を削除するコードがそもそも存在しない。
+// -----------------------------------------------------------------------------
+import { prisma } from '@trakon/db';
+import { selectFrozenProjectIds } from '@trakon/shared';
+
+import { ApiException } from '../../lib/errors.js';
+import { getEntitlement } from './entitlement.js';
+
+/** 凍結されているプロジェクト ID を求める。 */
+export async function getFrozenProjectIds(organizationId: string): Promise<string[]> {
+  const [entitlement, projects] = await Promise.all([
+    getEntitlement(prisma, organizationId),
+    prisma.project.findMany({
+      where: { organizationId, deletedAt: null },
+      select: { id: true, createdAt: true, archivedAt: true, retainedAt: true },
+    }),
+  ]);
+  return selectFrozenProjectIds(projects, entitlement.limits.projectLimit).frozenIds;
+}
+
+export async function isProjectFrozen(
+  organizationId: string,
+  projectId: string,
+): Promise<boolean> {
+  return (await getFrozenProjectIds(organizationId)).includes(projectId);
+}
+
+/**
+ * 維持するプロジェクトを選び直す (FR-BILL-11)。
+ *
+ * 指定された順に retained_at を採番し、それ以外はクリアする。
+ * 上限を超える件数を指定された場合は受け付けない。
+ */
+export async function setRetainedProjects(input: {
+  organizationId: string;
+  projectIds: string[];
+  actorUserId: string;
+}): Promise<{ retainedIds: string[]; frozenIds: string[] }> {
+  const entitlement = await getEntitlement(prisma, input.organizationId);
+  const limit = entitlement.limits.projectLimit;
+
+  if (limit !== null && input.projectIds.length > limit) {
+    throw new ApiException(
+      'PROJECT_LIMIT_REACHED',
+      409,
+      `維持できるプロジェクトは ${limit} 件までです。`,
+      { limit, requested: input.projectIds.length },
+    );
+  }
+
+  const owned = await prisma.project.findMany({
+    where: { organizationId: input.organizationId, deletedAt: null },
+    select: { id: true },
+  });
+  const ownedIds = new Set(owned.map((p) => p.id));
+  const unknown = input.projectIds.filter((id) => !ownedIds.has(id));
+  if (unknown.length > 0) {
+    throw new ApiException('NOT_FOUND', 404, 'Project not found.', { projectIds: unknown });
+  }
+
+  const now = Date.now();
+  await prisma.$transaction([
+    // 一度すべてクリアしてから、指定順に採番し直す
+    prisma.project.updateMany({
+      where: { organizationId: input.organizationId },
+      data: { retainedAt: null },
+    }),
+    ...input.projectIds.map((id, index) =>
+      // 「維持指定が新しい順」に並ぶよう、先頭ほど新しい時刻にする
+      prisma.project.update({
+        where: { id },
+        data: { retainedAt: new Date(now + (input.projectIds.length - index)) },
+      }),
+    ),
+    prisma.auditLog.create({
+      data: {
+        actorUserId: input.actorUserId,
+        action: 'retained_projects_changed',
+        resourceType: 'organization',
+        resourceId: input.organizationId,
+        result: 'success',
+        extra: { projectIds: input.projectIds },
+      },
+    }),
+  ]);
+
+  const frozenIds = await getFrozenProjectIds(input.organizationId);
+  return { retainedIds: input.projectIds, frozenIds };
+}

--- a/apps/web/server/services/billing/planChange.test.ts
+++ b/apps/web/server/services/billing/planChange.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cancelSubscription, changePlan, resumeSubscription } from './planChange.js';
+import { __setStripeForTest } from './stripeClient.js';
+
+// =============================================================================
+// プラン変更・解約 (設計書 §7.7)
+//
+// 最重要の不変条件:
+//   - Personal → Team は「追加請求の決済成功を Webhook で確認するまで」
+//     Team 権限を与えない。ここでは pending にしか書かない
+//   - 解約でプロジェクトやメンバーを削除しない
+// =============================================================================
+
+const prismaMock = vi.hoisted(() => ({
+  billingSubscription: { findUnique: vi.fn(), update: vi.fn() },
+  organizationMember: { count: vi.fn() },
+  project: { count: vi.fn(), findMany: vi.fn() },
+  auditLog: { create: vi.fn() },
+  $transaction: vi.fn(),
+}));
+vi.mock('@trakon/db', () => ({ prisma: prismaMock }));
+
+const envState: Record<string, unknown> = {
+  STRIPE_PERSONAL_MONTHLY_PRICE_ID: 'price_personal',
+  STRIPE_TEAM_MONTHLY_PRICE_ID: 'price_team',
+};
+vi.mock('../../lib/env.js', () => ({ getServerEnv: () => envState }));
+
+const retrieve = vi.fn();
+const update = vi.fn();
+const scheduleCreate = vi.fn();
+const scheduleUpdate = vi.fn();
+
+const PERIOD_END = Math.floor(new Date('2026-10-01T00:00:00Z').getTime() / 1000);
+
+function stubStripe() {
+  __setStripeForTest({
+    subscriptions: { retrieve, update },
+    subscriptionSchedules: { create: scheduleCreate, update: scheduleUpdate },
+  } as never);
+}
+
+/** $transaction([...]) に積まれた prisma 呼び出しの引数を覗く。 */
+const txCalls = () => prismaMock.$transaction.mock.calls.at(-1)?.[0] as unknown[];
+const subscriptionUpdateData = () =>
+  prismaMock.billingSubscription.update.mock.calls.at(-1)?.[0].data as Record<string, unknown>;
+const auditData = () =>
+  prismaMock.auditLog.create.mock.calls.at(-1)?.[0].data as Record<string, unknown>;
+
+beforeEach(() => {
+  stubStripe();
+  retrieve.mockReset().mockResolvedValue({
+    id: 'sub_1',
+    items: { data: [{ id: 'si_1', price: { id: 'price_personal' }, current_period_end: PERIOD_END }] },
+  });
+  update.mockReset().mockResolvedValue({
+    items: { data: [{ id: 'si_1', current_period_end: PERIOD_END }] },
+  });
+  scheduleCreate.mockReset().mockResolvedValue({ id: 'sub_sched_1', current_phase: { start_date: 1 } });
+  scheduleUpdate.mockReset().mockResolvedValue({});
+  prismaMock.billingSubscription.findUnique.mockReset().mockResolvedValue({
+    organizationId: 'org-1',
+    planCode: 'personal',
+    stripeSubscriptionId: 'sub_1',
+  });
+  prismaMock.billingSubscription.update.mockReset().mockReturnValue({});
+  prismaMock.auditLog.create.mockReset().mockReturnValue({});
+  prismaMock.organizationMember.count.mockReset().mockResolvedValue(1);
+  prismaMock.project.count.mockReset().mockResolvedValue(3);
+  prismaMock.project.findMany.mockReset().mockResolvedValue([]);
+  prismaMock.$transaction.mockReset().mockResolvedValue([]);
+});
+
+afterEach(() => {
+  __setStripeForTest(undefined);
+});
+
+const actor = { organizationId: 'org-1', actorUserId: 'u-1' };
+
+describe('Personal → Team (即時・日割り)', () => {
+  it('残期間分を日割り請求し、決済完了まで契約を保留にする', async () => {
+    await changePlan({ ...actor, planCode: 'team' });
+
+    expect(update).toHaveBeenCalledWith('sub_1', {
+      items: [{ id: 'si_1', price: 'price_team' }],
+      proration_behavior: 'always_invoice',
+      payment_behavior: 'pending_if_incomplete',
+    });
+  });
+
+  it('この時点では Team 権限を与えない (FR-BILL-07)', async () => {
+    const result = await changePlan({ ...actor, planCode: 'team' });
+
+    // 昇格は invoice.paid / active な subscription.updated を受けてから
+    expect(subscriptionUpdateData()).toEqual({
+      pendingPlanCode: 'team',
+      pendingPlanEffectiveAt: null,
+    });
+    expect(subscriptionUpdateData()).not.toHaveProperty('planCode');
+    expect(result).toEqual({ appliedImmediately: false, pendingPlanCode: 'team' });
+  });
+
+  it('保留であることを監査ログに残す', async () => {
+    await changePlan({ ...actor, planCode: 'team' });
+
+    expect(auditData()).toMatchObject({
+      action: 'plan_changed',
+      resourceId: 'org-1',
+      extra: { from: 'personal', to: 'team', pending: true },
+    });
+  });
+
+  it('契約明細が取れなければ 502', async () => {
+    retrieve.mockResolvedValue({ id: 'sub_1', items: { data: [] } });
+
+    await expect(changePlan({ ...actor, planCode: 'team' })).rejects.toMatchObject({
+      code: 'SUBSCRIPTION_ITEM_NOT_FOUND',
+      status: 502,
+    });
+  });
+});
+
+describe('Team → Personal (次回更新時)', () => {
+  beforeEach(() => {
+    prismaMock.billingSubscription.findUnique.mockResolvedValue({
+      organizationId: 'org-1',
+      planCode: 'team',
+      stripeSubscriptionId: 'sub_1',
+    });
+    retrieve.mockResolvedValue({
+      id: 'sub_1',
+      items: { data: [{ id: 'si_1', price: { id: 'price_team' }, current_period_end: PERIOD_END }] },
+    });
+  });
+
+  it('現行 Price の期間が終わってから Personal に切り替える予約を作る', async () => {
+    const result = await changePlan({ ...actor, planCode: 'personal' });
+
+    expect(scheduleCreate).toHaveBeenCalledWith({ from_subscription: 'sub_1' });
+    const phases = scheduleUpdate.mock.calls[0]![1].phases;
+    expect(phases[0].items).toEqual([{ price: 'price_team', quantity: 1 }]);
+    expect(phases[0].end_date).toBe(PERIOD_END);
+    expect(phases[1].items).toEqual([{ price: 'price_personal', quantity: 1 }]);
+    expect(result).toEqual({ appliedImmediately: false, pendingPlanCode: 'personal' });
+  });
+
+  it('適用時刻を保留として記録する', async () => {
+    await changePlan({ ...actor, planCode: 'personal' });
+
+    expect(subscriptionUpdateData()).toEqual({
+      pendingPlanCode: 'personal',
+      pendingPlanEffectiveAt: new Date('2026-10-01T00:00:00Z'),
+    });
+  });
+
+  it('会員数が Personal の上限を超えていれば受け付けない', async () => {
+    prismaMock.organizationMember.count.mockResolvedValue(3);
+
+    await expect(changePlan({ ...actor, planCode: 'personal' })).rejects.toMatchObject({
+      code: 'PLAN_DOWNGRADE_BLOCKED',
+      status: 409,
+      details: { seatCount: 3, seatLimit: 1 },
+    });
+    expect(scheduleCreate).not.toHaveBeenCalled();
+  });
+
+  it('プロジェクト数超過では、整理すべきプロジェクトを添えて返す', async () => {
+    prismaMock.project.count.mockResolvedValue(12);
+    prismaMock.project.findMany.mockResolvedValue([{ id: 'p-11', name: '超過1' }]);
+
+    await expect(changePlan({ ...actor, planCode: 'personal' })).rejects.toMatchObject({
+      code: 'PLAN_DOWNGRADE_BLOCKED',
+      details: { projectCount: 12, projectLimit: 10, excessProjects: [{ id: 'p-11' }] },
+    });
+  });
+});
+
+describe('changePlan の前提', () => {
+  it('同じプランへの変更は 409', async () => {
+    prismaMock.billingSubscription.findUnique.mockResolvedValue({
+      organizationId: 'org-1',
+      planCode: 'team',
+      stripeSubscriptionId: 'sub_1',
+    });
+
+    await expect(changePlan({ ...actor, planCode: 'team' })).rejects.toMatchObject({
+      code: 'PLAN_UNCHANGED',
+      status: 409,
+    });
+  });
+
+  it('Stripe 契約が無ければ 409 (先に申し込みへ誘導する)', async () => {
+    prismaMock.billingSubscription.findUnique.mockResolvedValue({
+      organizationId: 'org-1',
+      planCode: 'free',
+      stripeSubscriptionId: null,
+    });
+
+    await expect(changePlan({ ...actor, planCode: 'team' })).rejects.toMatchObject({
+      code: 'NO_ACTIVE_SUBSCRIPTION',
+      status: 409,
+    });
+  });
+});
+
+describe('解約', () => {
+  it('期間終了時の解約を予約し、支払済み期間は使える', async () => {
+    const result = await cancelSubscription(actor);
+
+    expect(update).toHaveBeenCalledWith('sub_1', { cancel_at_period_end: true });
+    expect(subscriptionUpdateData()).toMatchObject({
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd: new Date('2026-10-01T00:00:00Z'),
+    });
+    expect(result.cancelAtPeriodEnd).toBe(true);
+    expect(result.currentPeriodEnd).toBe('2026-10-01T00:00:00.000Z');
+  });
+
+  it('プロジェクトやメンバーを削除しない', async () => {
+    await cancelSubscription(actor);
+
+    // 凍結は計算で表現するため、削除処理はコード上に存在しない
+    expect(prismaMock.project).not.toHaveProperty('deleteMany');
+    const written = JSON.stringify(txCalls());
+    expect(written).not.toMatch(/delete/i);
+  });
+
+  it('解約を監査ログに残す', async () => {
+    await cancelSubscription(actor);
+
+    expect(auditData()).toMatchObject({
+      action: 'subscription_canceled',
+      extra: { cancelAtPeriodEnd: true },
+    });
+  });
+
+  it('契約が無ければ 409', async () => {
+    prismaMock.billingSubscription.findUnique.mockResolvedValue({
+      organizationId: 'org-1',
+      planCode: 'free',
+      stripeSubscriptionId: null,
+    });
+
+    await expect(cancelSubscription(actor)).rejects.toMatchObject({
+      code: 'NO_ACTIVE_SUBSCRIPTION',
+    });
+  });
+});
+
+describe('解約の取り消し', () => {
+  it('期間終了前なら継続できる', async () => {
+    const result = await resumeSubscription(actor);
+
+    expect(update).toHaveBeenCalledWith('sub_1', { cancel_at_period_end: false });
+    expect(subscriptionUpdateData()).toEqual({ cancelAtPeriodEnd: false, canceledAt: null });
+    expect(result).toEqual({ cancelAtPeriodEnd: false });
+    expect(auditData()).toMatchObject({
+      action: 'subscription_updated',
+      extra: { cancelAtPeriodEnd: false, resumed: true },
+    });
+  });
+});

--- a/apps/web/server/services/billing/planChange.ts
+++ b/apps/web/server/services/billing/planChange.ts
@@ -1,0 +1,283 @@
+// -----------------------------------------------------------------------------
+// プラン変更・解約 — 設計書 §7.7
+//
+// Personal → Team: 即時。残期間分を日割りで差額請求する。
+//   **追加請求の決済成功を Webhook で確認するまで Team 権限を付与しない。**
+//   DB には保留中のプラン変更としてのみ記録する。
+//
+// Team → Personal: 次回更新時に適用。返金しない。
+//   会員 1 名以下・プロジェクト 10 件以下を条件とし、満たさなければ受け付けない。
+//
+// 解約: 期間終了時に解約する予約。返金しない。
+//   **プロジェクトやメンバーを削除してはならない。** 本設計では凍結を計算で
+//   表現するため、そもそも削除処理がコード上に存在しない。
+// -----------------------------------------------------------------------------
+import { prisma } from '@trakon/db';
+import { BILLING_PLANS, type BillingPlanCode } from '@trakon/shared';
+
+import { getServerEnv } from '../../lib/env.js';
+import { ApiException } from '../../lib/errors.js';
+import { countActiveProjects, countSeats } from '../organizations.js';
+import { getStripe } from './stripeClient.js';
+
+export type ChangeablePlan = Extract<BillingPlanCode, 'personal' | 'team'>;
+
+type SubscriptionRow = NonNullable<
+  Awaited<ReturnType<typeof prisma.billingSubscription.findUnique>>
+>;
+
+async function loadActiveSubscription(organizationId: string): Promise<SubscriptionRow> {
+  const subscription = await prisma.billingSubscription.findUnique({
+    where: { organizationId },
+  });
+  if (!subscription?.stripeSubscriptionId) {
+    throw new ApiException(
+      'NO_ACTIVE_SUBSCRIPTION',
+      409,
+      '有効な契約がありません。先にプランをお申し込みください。',
+    );
+  }
+  return subscription;
+}
+
+function priceIdFor(plan: ChangeablePlan): string {
+  const env = getServerEnv();
+  const priceId =
+    plan === 'team' ? env.STRIPE_TEAM_MONTHLY_PRICE_ID : env.STRIPE_PERSONAL_MONTHLY_PRICE_ID;
+  if (!priceId) {
+    throw new ApiException('BILLING_NOT_CONFIGURED', 503, `Price ID for ${plan} is not configured.`);
+  }
+  return priceId;
+}
+
+export async function changePlan(input: {
+  organizationId: string;
+  actorUserId: string;
+  planCode: ChangeablePlan;
+}): Promise<{ appliedImmediately: boolean; pendingPlanCode: BillingPlanCode }> {
+  const subscription = await loadActiveSubscription(input.organizationId);
+
+  if (subscription.planCode === input.planCode) {
+    throw new ApiException('PLAN_UNCHANGED', 409, '既に同じプランをご利用中です。');
+  }
+
+  return input.planCode === 'team'
+    ? upgradeToTeam({ ...input, subscription })
+    : downgradeToPersonal({ ...input, subscription });
+}
+
+/** Personal → Team。即時変更・日割り差額請求。権限は決済成功の確認後に付与する。 */
+async function upgradeToTeam(input: {
+  organizationId: string;
+  actorUserId: string;
+  subscription: SubscriptionRow;
+}): Promise<{ appliedImmediately: boolean; pendingPlanCode: BillingPlanCode }> {
+  const stripe = getStripe();
+  const current = await stripe.subscriptions.retrieve(input.subscription.stripeSubscriptionId!);
+  const itemId = current.items?.data?.[0]?.id;
+  if (!itemId) {
+    throw new ApiException('SUBSCRIPTION_ITEM_NOT_FOUND', 502, 'Subscription item not found.');
+  }
+
+  await stripe.subscriptions.update(input.subscription.stripeSubscriptionId!, {
+    items: [{ id: itemId, price: priceIdFor('team') }],
+    // 残期間分の差額を日割りで請求する
+    proration_behavior: 'always_invoice',
+    // 追加請求の決済が完了するまで契約を保留状態にする
+    payment_behavior: 'pending_if_incomplete',
+  });
+
+  // **plan_code はここで昇格させない。** invoice.paid か active な
+  // subscription.updated を Webhook で受け取った時点で確定する (§7.7.1)。
+  await prisma.$transaction([
+    prisma.billingSubscription.update({
+      where: { organizationId: input.organizationId },
+      data: { pendingPlanCode: 'team', pendingPlanEffectiveAt: null },
+    }),
+    prisma.auditLog.create({
+      data: {
+        actorUserId: input.actorUserId,
+        action: 'plan_changed',
+        resourceType: 'subscription',
+        resourceId: input.organizationId,
+        result: 'success',
+        extra: { from: input.subscription.planCode, to: 'team', pending: true },
+      },
+    }),
+  ]);
+
+  return { appliedImmediately: false, pendingPlanCode: 'team' };
+}
+
+/** Team → Personal。次回更新時に適用。上限条件を満たさなければ受け付けない。 */
+async function downgradeToPersonal(input: {
+  organizationId: string;
+  actorUserId: string;
+  subscription: SubscriptionRow;
+}): Promise<{ appliedImmediately: boolean; pendingPlanCode: BillingPlanCode }> {
+  const target = BILLING_PLANS.personal;
+  const [seatCount, projectCount] = await Promise.all([
+    countSeats(prisma, input.organizationId),
+    countActiveProjects(prisma, input.organizationId),
+  ]);
+
+  const overSeats = target.seatLimit !== null && seatCount > target.seatLimit;
+  const overProjects = target.projectLimit !== null && projectCount > target.projectLimit;
+
+  if (overSeats || overProjects) {
+    // 何を整理すればよいか分かるよう、超過しているものを詳細で返す (§7.7.2)
+    const excessProjects = overProjects
+      ? await prisma.project.findMany({
+          where: { organizationId: input.organizationId, deletedAt: null, archivedAt: null },
+          orderBy: [{ retainedAt: 'desc' }, { createdAt: 'asc' }],
+          skip: target.projectLimit ?? 0,
+          select: { id: true, name: true },
+        })
+      : [];
+
+    throw new ApiException(
+      'PLAN_DOWNGRADE_BLOCKED',
+      409,
+      'Personal プランの上限を超えているため変更できません。メンバーまたはプロジェクトを整理してください。',
+      {
+        seatCount,
+        seatLimit: target.seatLimit,
+        projectCount,
+        projectLimit: target.projectLimit,
+        excessProjects,
+      },
+    );
+  }
+
+  const stripe = getStripe();
+  const current = await stripe.subscriptions.retrieve(input.subscription.stripeSubscriptionId!);
+  const item = current.items?.data?.[0];
+  if (!item) {
+    throw new ApiException('SUBSCRIPTION_ITEM_NOT_FOUND', 502, 'Subscription item not found.');
+  }
+
+  const periodEnd = readPeriodEnd(current, item);
+
+  // 次回更新時に切り替える。返金は行わない (§7.7.2)
+  await stripe.subscriptionSchedules
+    .create({ from_subscription: input.subscription.stripeSubscriptionId! })
+    .then((schedule) =>
+      stripe.subscriptionSchedules.update(schedule.id, {
+        end_behavior: 'release',
+        phases: [
+          {
+            items: [{ price: item.price.id, quantity: 1 }],
+            start_date: schedule.current_phase?.start_date ?? 'now',
+            end_date: periodEnd ?? undefined,
+          },
+          {
+            items: [{ price: priceIdFor('personal'), quantity: 1 }],
+          },
+        ],
+      }),
+    );
+
+  await prisma.$transaction([
+    prisma.billingSubscription.update({
+      where: { organizationId: input.organizationId },
+      data: {
+        pendingPlanCode: 'personal',
+        pendingPlanEffectiveAt: periodEnd ? new Date(periodEnd * 1000) : null,
+      },
+    }),
+    prisma.auditLog.create({
+      data: {
+        actorUserId: input.actorUserId,
+        action: 'plan_changed',
+        resourceType: 'subscription',
+        resourceId: input.organizationId,
+        result: 'success',
+        extra: { from: input.subscription.planCode, to: 'personal', pending: true },
+      },
+    }),
+  ]);
+
+  return { appliedImmediately: false, pendingPlanCode: 'personal' };
+}
+
+/** 解約予約。支払済み期間の終了まで利用できる。データは削除しない。 */
+export async function cancelSubscription(input: {
+  organizationId: string;
+  actorUserId: string;
+}): Promise<{ cancelAtPeriodEnd: true; currentPeriodEnd: string | null }> {
+  const subscription = await loadActiveSubscription(input.organizationId);
+
+  const updated = await getStripe().subscriptions.update(subscription.stripeSubscriptionId!, {
+    cancel_at_period_end: true,
+  });
+
+  const periodEnd = readPeriodEnd(updated, updated.items?.data?.[0]);
+
+  await prisma.$transaction([
+    prisma.billingSubscription.update({
+      where: { organizationId: input.organizationId },
+      data: {
+        cancelAtPeriodEnd: true,
+        canceledAt: new Date(),
+        ...(periodEnd ? { currentPeriodEnd: new Date(periodEnd * 1000) } : {}),
+      },
+    }),
+    prisma.auditLog.create({
+      data: {
+        actorUserId: input.actorUserId,
+        action: 'subscription_canceled',
+        resourceType: 'subscription',
+        resourceId: input.organizationId,
+        result: 'success',
+        extra: { cancelAtPeriodEnd: true },
+      },
+    }),
+  ]);
+
+  return {
+    cancelAtPeriodEnd: true,
+    currentPeriodEnd: periodEnd ? new Date(periodEnd * 1000).toISOString() : null,
+  };
+}
+
+/** 解約予約の取り消し。期間終了前であれば継続できる。 */
+export async function resumeSubscription(input: {
+  organizationId: string;
+  actorUserId: string;
+}): Promise<{ cancelAtPeriodEnd: false }> {
+  const subscription = await loadActiveSubscription(input.organizationId);
+
+  await getStripe().subscriptions.update(subscription.stripeSubscriptionId!, {
+    cancel_at_period_end: false,
+  });
+
+  await prisma.$transaction([
+    prisma.billingSubscription.update({
+      where: { organizationId: input.organizationId },
+      data: { cancelAtPeriodEnd: false, canceledAt: null },
+    }),
+    prisma.auditLog.create({
+      data: {
+        actorUserId: input.actorUserId,
+        action: 'subscription_updated',
+        resourceType: 'subscription',
+        resourceId: input.organizationId,
+        result: 'success',
+        extra: { cancelAtPeriodEnd: false, resumed: true },
+      },
+    }),
+  ]);
+
+  return { cancelAtPeriodEnd: false };
+}
+
+/**
+ * 請求期間の終了は Stripe の API バージョンにより Subscription 直下か
+ * Subscription Item 側に置かれる。どちらでも読めるようにする。
+ */
+function readPeriodEnd(subscription: unknown, item?: unknown): number | null {
+  const fromItem = (item as Record<string, unknown> | undefined)?.current_period_end;
+  if (typeof fromItem === 'number') return fromItem;
+  const fromSub = (subscription as Record<string, unknown> | undefined)?.current_period_end;
+  return typeof fromSub === 'number' ? fromSub : null;
+}

--- a/apps/web/server/services/billing/trialEligibility.test.ts
+++ b/apps/web/server/services/billing/trialEligibility.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  checkTrialEligibility,
+  emailDomain,
+  normalizeEmail,
+} from './trialEligibility.js';
+
+const prismaMock = vi.hoisted(() => ({
+  billingTrialClaim: { findFirst: vi.fn() },
+}));
+vi.mock('@trakon/db', () => ({ prisma: prismaMock }));
+
+beforeEach(() => {
+  prismaMock.billingTrialClaim.findFirst.mockReset().mockResolvedValue(null);
+});
+
+describe('normalizeEmail', () => {
+  it('大小文字と前後の空白を吸収する', () => {
+    expect(normalizeEmail('  User@Example.TEST ')).toBe('user@example.test');
+  });
+
+  it('+タグを落とす (同一人物の再取得を防ぐ)', () => {
+    expect(normalizeEmail('user+trial2@example.test')).toBe('user@example.test');
+  });
+
+  it('Gmail 系はドットも無視する', () => {
+    expect(normalizeEmail('first.last@gmail.com')).toBe('firstlast@gmail.com');
+    expect(normalizeEmail('first.last@googlemail.com')).toBe('firstlast@googlemail.com');
+  });
+
+  it('Gmail 以外のドットは意味を持つので残す', () => {
+    expect(normalizeEmail('first.last@example.test')).toBe('first.last@example.test');
+  });
+
+  it('メールとして壊れていても落ちない', () => {
+    expect(normalizeEmail('not-an-email')).toBe('not-an-email');
+  });
+});
+
+describe('emailDomain', () => {
+  it('ドメイン部を取り出す', () => {
+    expect(emailDomain('User@Example.test')).toBe('example.test');
+  });
+
+  it('ドメインが無ければ空文字', () => {
+    expect(emailDomain('broken')).toBe('');
+  });
+});
+
+describe('checkTrialEligibility', () => {
+  const input = {
+    userId: 'u-1',
+    organizationId: 'org-1',
+    email: 'user@example.test',
+    stripeCustomerId: null,
+  };
+
+  it('履歴が無ければトライアルを付与する', async () => {
+    expect(await checkTrialEligibility(input)).toEqual({ eligible: true, reason: null });
+  });
+
+  it('同一ユーザーの履歴があれば拒否する', async () => {
+    prismaMock.billingTrialClaim.findFirst.mockResolvedValue({
+      userId: 'u-1',
+      emailNormalized: 'other@example.test',
+      organizationId: 'org-9',
+      stripeCustomerId: null,
+    });
+
+    expect(await checkTrialEligibility(input)).toEqual({ eligible: false, reason: 'user' });
+  });
+
+  it('正規化後のメールが一致すれば拒否する', async () => {
+    prismaMock.billingTrialClaim.findFirst.mockResolvedValue({
+      userId: 'u-9',
+      emailNormalized: 'user@example.test',
+      organizationId: 'org-9',
+      stripeCustomerId: null,
+    });
+
+    const result = await checkTrialEligibility({ ...input, email: 'User+again@Example.test' });
+
+    expect(result).toEqual({ eligible: false, reason: 'email' });
+  });
+
+  it('同一組織の履歴があれば拒否する', async () => {
+    prismaMock.billingTrialClaim.findFirst.mockResolvedValue({
+      userId: 'u-9',
+      emailNormalized: 'other@example.test',
+      organizationId: 'org-1',
+      stripeCustomerId: null,
+    });
+
+    expect(await checkTrialEligibility(input)).toEqual({ eligible: false, reason: 'organization' });
+  });
+
+  it('過去の顧客 ID が一致すれば拒否する', async () => {
+    prismaMock.billingTrialClaim.findFirst.mockResolvedValue({
+      userId: 'u-9',
+      emailNormalized: 'other@example.test',
+      organizationId: 'org-9',
+      stripeCustomerId: 'cus_1',
+    });
+
+    const result = await checkTrialEligibility({ ...input, stripeCustomerId: 'cus_1' });
+
+    expect(result).toEqual({ eligible: false, reason: 'customer' });
+  });
+
+  it('解除済みの履歴は判定に使わない (誤判定は運用で解除できる)', async () => {
+    await checkTrialEligibility(input);
+
+    expect(prismaMock.billingTrialClaim.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ releasedAt: null }) }),
+    );
+  });
+
+  it('顧客 ID が無ければ条件に含めない', async () => {
+    await checkTrialEligibility(input);
+
+    const where = prismaMock.billingTrialClaim.findFirst.mock.calls[0]![0].where as {
+      OR: Record<string, unknown>[];
+    };
+    expect(where.OR).toHaveLength(3);
+    expect(where.OR.some((c) => 'stripeCustomerId' in c)).toBe(false);
+  });
+
+  it('カードの識別子は判定に使わない (法人カード共有での誤判定を避ける)', async () => {
+    await checkTrialEligibility(input);
+
+    const call = JSON.stringify(prismaMock.billingTrialClaim.findFirst.mock.calls[0]);
+    expect(call).not.toMatch(/fingerprint/i);
+  });
+});

--- a/apps/web/server/services/billing/trialEligibility.ts
+++ b/apps/web/server/services/billing/trialEligibility.ts
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------------
+// トライアル重複判定 — 設計書 §7.9.2
+//
+// 【確定要件】法人カードの共有による誤判定があり得るため、カードの識別子のみを
+// 根拠に自動拒否してはならない。本設計ではそもそも識別子を保存しない。
+//
+// ハード拒否 : user_id / 正規化メール / organization_id / 過去の顧客 ID
+// 記録のみ   : メールドメイン (拒否には使わない)
+//
+// 誤判定時の解除は運用手順 (docs/operations.md) で DB を直接更新する。
+// -----------------------------------------------------------------------------
+import { prisma } from '@trakon/db';
+
+export type TrialEligibility = {
+  eligible: boolean;
+  /** 拒否理由。eligible なら null */
+  reason: 'user' | 'email' | 'organization' | 'customer' | null;
+};
+
+/**
+ * メールアドレスを正規化する。
+ * 大小文字とドット・+タグの揺れを吸収し、同一人物の再取得を防ぐ。
+ */
+export function normalizeEmail(email: string): string {
+  const trimmed = email.trim().toLowerCase();
+  const [local, domain] = trimmed.split('@');
+  if (!local || !domain) return trimmed;
+  const withoutTag = local.split('+')[0] ?? local;
+  // Gmail 系はドットを無視する
+  const normalizedLocal =
+    domain === 'gmail.com' || domain === 'googlemail.com'
+      ? withoutTag.replaceAll('.', '')
+      : withoutTag;
+  return `${normalizedLocal}@${domain}`;
+}
+
+export function emailDomain(email: string): string {
+  return email.trim().toLowerCase().split('@')[1] ?? '';
+}
+
+/** トライアルを付与してよいかを判定する。 */
+export async function checkTrialEligibility(input: {
+  userId: string;
+  organizationId: string;
+  email: string;
+  stripeCustomerId: string | null;
+}): Promise<TrialEligibility> {
+  const normalized = normalizeEmail(input.email);
+
+  const claim = await prisma.billingTrialClaim.findFirst({
+    where: {
+      releasedAt: null,
+      OR: [
+        { userId: input.userId },
+        { emailNormalized: normalized },
+        { organizationId: input.organizationId },
+        ...(input.stripeCustomerId ? [{ stripeCustomerId: input.stripeCustomerId }] : []),
+      ],
+    },
+    select: { userId: true, emailNormalized: true, organizationId: true, stripeCustomerId: true },
+  });
+
+  if (!claim) return { eligible: true, reason: null };
+
+  const reason: TrialEligibility['reason'] =
+    claim.userId === input.userId
+      ? 'user'
+      : claim.emailNormalized === normalized
+        ? 'email'
+        : claim.organizationId === input.organizationId
+          ? 'organization'
+          : 'customer';
+
+  return { eligible: false, reason };
+}

--- a/apps/web/server/test/integration.setup.ts
+++ b/apps/web/server/test/integration.setup.ts
@@ -29,6 +29,33 @@ process.env.SUPABASE_JWT_AUD ??= 'authenticated';
 process.env.APP_ENV ??= 'test';
 process.env.NODE_ENV = 'test';
 
+/**
+ * Stripe のテスト値。
+ *
+ * **ここで設定する理由**: `getServerEnv()` は初回アクセス時に env をキャッシュする。
+ * 各テストの beforeEach で process.env を書き換えても、先に別のテストが
+ * getServerEnv() を呼んでいると反映されない。setupFiles はどのテストより先に
+ * 走るので、ここで入れておけば確実にキャッシュへ載る (設計書 §7.3.3 / 実装メモ)。
+ *
+ * 実 Stripe には CI から一切接続しない。値はダミーで、
+ * 署名検証だけ SDK のテストヘルパーで実際に通す。
+ */
+export const TEST_STRIPE = {
+  secretKey: 'sk_test_dummy_key_for_signing',
+  webhookSecret: 'whsec_test_secret_value',
+  personalPriceId: 'price_test_personal',
+  teamPriceId: 'price_test_team',
+  taxRateId: 'txr_test_jp',
+  portalConfigurationId: 'bpc_test_configuration',
+} as const;
+
+process.env.STRIPE_SECRET_KEY ??= TEST_STRIPE.secretKey;
+process.env.STRIPE_WEBHOOK_SECRET ??= TEST_STRIPE.webhookSecret;
+process.env.STRIPE_PERSONAL_MONTHLY_PRICE_ID ??= TEST_STRIPE.personalPriceId;
+process.env.STRIPE_TEAM_MONTHLY_PRICE_ID ??= TEST_STRIPE.teamPriceId;
+process.env.STRIPE_JP_TAX_RATE_ID ??= TEST_STRIPE.taxRateId;
+process.env.STRIPE_PORTAL_CONFIGURATION_ID ??= TEST_STRIPE.portalConfigurationId;
+
 // TRUNCATE 対象 (FK 依存順は CASCADE で吸収)。
 const TABLES = [
   'audit_logs',


### PR DESCRIPTION
設計書 §7.4 / §7.7 / §7.8。#167 で受け口を作った Webhook に対して、こちらから Stripe を呼ぶ側を実装します。

有料プラン導入シリーズの 8/13。

## Checkout（§7.4）

ホスト型 Checkout へサーバーサイドでリダイレクトします。渡すパラメータの確定要件：

- **`quantity` は常に 1。** 人数課金はせず、Team の人数上限は TRAKON 側で判定します
- **`trial_period_days = 5`（= 120 時間）。`trial_end` は使いません。** `trial_end` だと Checkout Session 作成〜申込完了の時間差だけトライアルが短縮されるためです
- `payment_method_collection = 'always'` — トライアル開始時もカード登録を必須にします
- `automatic_tax` は無効。税込 Price + 手動 Tax Rate で内訳を表示します
- `metadata` に `user_id` / `organization_id` / `plan_code` / `checkout_attempt_id` を積み、Webhook 側から組織を引けるようにします

トライアル重複判定（§7.9）は **user_id / 正規化メール / organization_id / 過去の顧客 ID** をハード拒否、**メールドメインは記録のみ**です。**カードの識別子は保存も参照もしません** — 法人カードの共有で誤判定が起きうるためで、これは確定要件です。誤判定時の解除は Runbook で DB を直接更新します。

## Customer Portal（§7.8）

セッション URL は**保存せず都度生成**します（SR-BILL-07）。プラン変更の無効化は Portal Configuration 側の設定なので、**構成 ID を明示指定**してダッシュボードの既定に依存しません。

## プラン変更（§7.7）

**Personal → Team（即時・日割り）** — `proration_behavior: 'always_invoice'` + `payment_behavior: 'pending_if_incomplete'`。DB には `pending_plan_code` しか書かず、**追加請求の決済成功を Webhook で確認するまで Team 権限を与えません**（FR-BILL-07）。

**Team → Personal（次回更新時）** — 返金しません。会員 1 名以下・プロジェクト 10 件以下を条件とし、満たさなければ `PLAN_DOWNGRADE_BLOCKED` 409 で**整理すべきプロジェクトを添えて**返します。満たせば Subscription Schedule で `current_period_end` 始点の phase を積みます。

**解約** — `cancel_at_period_end`。返金なし。**プロジェクトやメンバーを削除するコードは存在しません。** 凍結を計算で表現する設計にしたため、削除処理そのものが不要になっています。

## 合わせて直したもの

統合テストが `503 BILLING_NOT_CONFIGURED` で落ちていました。`getServerEnv()` は初回アクセスで env をキャッシュするため、各テストの `beforeEach` での `process.env` 書き換えでは間に合いません。`setupFiles` はどのテストより先に走るので、そこで設定して `TEST_STRIPE` として共有するようにしました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
