### PR TITLE
feat(api): プラン上限と凍結を書き込み経路へ差し込む

### DIFF
--- a/apps/web/server/app.ts
+++ b/apps/web/server/app.ts
@@ -9,6 +9,7 @@ import { billingRoute } from './routes/v1/billing.js';
 import { dashboardRoute } from './routes/v1/dashboard.js';
 import { healthRoute } from './routes/v1/healthz.js';
 import { invitationsRoute } from './routes/v1/invitations.js';
+import { organizationsRoute } from './routes/v1/organizations.js';
 import { projectsRoute } from './routes/v1/projects.js';
 import { shareRoute } from './routes/v1/share.js';
 import { stripeWebhookRoute } from './routes/v1/stripeWebhook.js';
@@ -35,6 +36,7 @@ export function createApp() {
   app.route('/api/v1/billing', billingRoute);
   app.route('/api/v1/projects', projectsRoute);
   app.route('/api/v1/invitations', invitationsRoute);
+  app.route('/api/v1/organizations', organizationsRoute);
   app.route('/api/v1/users/me', dashboardRoute);
   app.route('/api/v1/share', shareRoute);
 

--- a/apps/web/server/middleware/projectAuth.ts
+++ b/apps/web/server/middleware/projectAuth.ts
@@ -4,6 +4,8 @@ import { prisma } from '@trakon/db';
 import { canProjectRole, type ProjectAction, type ProjectRole } from '@trakon/shared';
 
 import { ApiException } from '../lib/errors.js';
+import { getEntitlement } from '../services/billing/entitlement.js';
+import { getFrozenProjectIds } from '../services/billing/freeze.js';
 
 export type ProjectMembership = {
   projectId: string;
@@ -120,4 +122,44 @@ function notFound(c: Context) {
     404,
     `Resource not found: ${c.req.method} ${c.req.path}`,
   );
+}
+
+/**
+ * 契約の利用権限とプロジェクトの凍結状態を検証する (設計書 §7.11 / §3.2.4b)。
+ *
+ * **ミドルウェアの順序は requireProjectMember() → requireProjectWritable() →
+ * requireProjectAction() に固定する。** これにより、課金・凍結のエラーは
+ * プロジェクト参加者にしか見えない (非参加者には先に 404 が返る)。
+ *
+ * 課金・上限・凍結は自分の組織の状態であり秘匿する必要がないため、
+ * **404 に集約しない**。403 + 専用コードで返し、復旧手段を案内できるようにする。
+ */
+export function requireProjectWritable(): MiddlewareHandler {
+  return async (c, next) => {
+    const project = c.get('project');
+
+    const entitlement = await getEntitlement(prisma, project.organizationId);
+    if (entitlement.level !== 'full') {
+      throw new ApiException('SUBSCRIPTION_READ_ONLY', 403, entitlement.message, {
+        reason: entitlement.reason,
+        planCode: entitlement.effectivePlanCode,
+        graceEndsAt: entitlement.graceEndsAt,
+      });
+    }
+
+    // 上限超過分は削除せず凍結する。超過していなければ追加クエリは走らない。
+    if (entitlement.over.projects > 0) {
+      const frozen = await getFrozenProjectIds(project.organizationId);
+      if (frozen.includes(project.projectId)) {
+        throw new ApiException(
+          'PROJECT_FROZEN',
+          403,
+          'プランの上限を超えているため、このプロジェクトは閲覧のみになっています。維持するプロジェクトを選び直すか、プランを変更してください。',
+          { planCode: entitlement.effectivePlanCode, projectLimit: entitlement.limits.projectLimit },
+        );
+      }
+    }
+
+    await next();
+  };
 }

--- a/apps/web/server/routes/v1/billingLimits.integration.test.ts
+++ b/apps/web/server/routes/v1/billingLimits.integration.test.ts
@@ -7,6 +7,7 @@ import {
   addProjectMemberWithRole,
   createOrgMember,
   createProject,
+  createProjectWithAdmin,
   createUser,
   primaryOrganizationId,
   setBillingSubscription,
@@ -23,14 +24,20 @@ import { api } from '../../test/request.js';
 let ownerToken: string;
 let ownerUserId: string;
 let organizationId: string;
+let owner: Awaited<ReturnType<typeof createUser>>;
 
 beforeEach(async () => {
   __setMailerForTest({});
-  const owner = await createUser();
+  owner = await createUser();
   ownerUserId = owner.id;
   organizationId = await primaryOrganizationId(owner.id);
   ownerToken = await signTestJwt({ authUserId: owner.authUserId, email: owner.email });
 });
+
+/** オーナーを管理者として参加させたプロジェクトを作る (要認可のテスト用)。 */
+function ownedProject(over: { name?: string; archivedAt?: Date | null } = {}) {
+  return createProjectWithAdmin({ user: owner, ...over });
+}
 
 describe('プロジェクト数上限', () => {
   describe('異常系', () => {
@@ -101,10 +108,10 @@ describe('プロジェクト数上限', () => {
 
 describe('プロジェクトの凍結', () => {
   it('上限超過分は閲覧できるが編集できない (削除もされない)', async () => {
-    const first = await createProject({ createdBy: ownerUserId, name: '維持1' });
-    await createProject({ createdBy: ownerUserId, name: '維持2' });
+    const { project: first } = await ownedProject({ name: '維持1' });
+    await ownedProject({ name: '維持2' });
     // 上限を超えた 3 件目を直接作る (作成 API は 409 になるため)
-    const third = await createProject({ createdBy: ownerUserId, name: '超過' });
+    const { project: third } = await ownedProject({ name: '超過' });
 
     // 閲覧はできる
     const read = await api(`/api/v1/projects/${third.id}`, { token: ownerToken });
@@ -132,9 +139,9 @@ describe('プロジェクトの凍結', () => {
   });
 
   it('維持するプロジェクトを選び直すと凍結対象が入れ替わる', async () => {
-    const first = await createProject({ createdBy: ownerUserId, name: '古い1' });
-    await createProject({ createdBy: ownerUserId, name: '古い2' });
-    const third = await createProject({ createdBy: ownerUserId, name: '新しい' });
+    const { project: first } = await ownedProject({ name: '古い1' });
+    await ownedProject({ name: '古い2' });
+    const { project: third } = await ownedProject({ name: '新しい' });
 
     const res = await api<{ data: { frozenIds: string[] } }>(
       '/api/v1/organizations/me/retained-projects',
@@ -171,7 +178,7 @@ describe('プロジェクトの凍結', () => {
 
 describe('契約状態による書き込み停止', () => {
   it('未払いなら閲覧はできるが編集は 403 SUBSCRIPTION_READ_ONLY', async () => {
-    const project = await createProject({ createdBy: ownerUserId });
+    const { project } = await ownedProject();
     await setBillingSubscription({ organizationId, planCode: 'team', status: 'unpaid' });
 
     const read = await api(`/api/v1/projects/${project.id}`, { token: ownerToken });
@@ -187,7 +194,7 @@ describe('契約状態による書き込み停止', () => {
   });
 
   it('支払い猶予期間中は通常どおり編集できる', async () => {
-    const project = await createProject({ createdBy: ownerUserId });
+    const { project } = await ownedProject();
     await setBillingSubscription({
       organizationId,
       planCode: 'team',
@@ -205,7 +212,7 @@ describe('契約状態による書き込み停止', () => {
   });
 
   it('非参加者には課金エラーではなく 404 が先に返る (秘匿を維持する)', async () => {
-    const project = await createProject({ createdBy: ownerUserId });
+    const { project } = await ownedProject();
     await setBillingSubscription({ organizationId, planCode: 'team', status: 'unpaid' });
     const outsider = await createUser();
     const token = await signTestJwt({
@@ -225,7 +232,7 @@ describe('契約状態による書き込み停止', () => {
 
 describe('座席上限', () => {
   it('Free で 2 人目を招待しようとすると 409 SEAT_LIMIT_REACHED', async () => {
-    const project = await createProject({ createdBy: ownerUserId });
+    const { project } = await ownedProject();
 
     const res = await api<{ error: { code: string; details?: { seatLimit: number } } }>(
       `/api/v1/projects/${project.id}/invitations`,
@@ -239,7 +246,7 @@ describe('座席上限', () => {
 
   it('Team は 5 名まで招待でき、未受諾の招待も座席を消費する', async () => {
     await setBillingSubscription({ organizationId, planCode: 'team', status: 'active' });
-    const project = await createProject({ createdBy: ownerUserId });
+    const { project } = await ownedProject();
 
     // オーナー 1 + 招待 4 = 5 席
     for (let i = 0; i < 4; i += 1) {
@@ -262,7 +269,7 @@ describe('座席上限', () => {
 
   it('招待を取り消すと座席が解放される', async () => {
     await setBillingSubscription({ organizationId, planCode: 'personal', status: 'active' });
-    const project = await createProject({ createdBy: ownerUserId });
+    const { project } = await ownedProject();
     // Personal は 1 席。オーナーで埋まっているので招待できない
     const blocked = await api(`/api/v1/projects/${project.id}/invitations`, {
       method: 'POST',
@@ -299,7 +306,7 @@ describe('座席上限', () => {
 describe('組織メンバー管理', () => {
   it('会員を除外すると座席が解放されるが、プロジェクト参加者行は残る', async () => {
     await setBillingSubscription({ organizationId, planCode: 'team', status: 'active' });
-    const project = await createProject({ createdBy: ownerUserId });
+    const { project } = await ownedProject();
     const member = await addProjectMemberWithRole({ projectId: project.id, roleType: 'editor' });
     await createOrgMember({ organizationId, userId: member.user.id });
 

--- a/apps/web/server/routes/v1/billingLimits.integration.test.ts
+++ b/apps/web/server/routes/v1/billingLimits.integration.test.ts
@@ -1,0 +1,331 @@
+import { prisma } from '@trakon/db';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { __setMailerForTest } from '../../lib/mailer.js';
+import { signTestJwt } from '../../test/auth.js';
+import {
+  addProjectMemberWithRole,
+  createOrgMember,
+  createProject,
+  createUser,
+  primaryOrganizationId,
+  setBillingSubscription,
+} from '../../test/factories.js';
+import { api } from '../../test/request.js';
+
+// =============================================================================
+// 上限判定と凍結 (設計書 §7.11)
+//
+// 【確定要件】上限超過分は削除せず「新規編集不可・閲覧のみ」で凍結する。
+// 課金・上限・凍結のエラーは 404 に混ぜず 409 / 403 + 専用コードで返す (§3.2.4b)。
+// =============================================================================
+
+let ownerToken: string;
+let ownerUserId: string;
+let organizationId: string;
+
+beforeEach(async () => {
+  __setMailerForTest({});
+  const owner = await createUser();
+  ownerUserId = owner.id;
+  organizationId = await primaryOrganizationId(owner.id);
+  ownerToken = await signTestJwt({ authUserId: owner.authUserId, email: owner.email });
+});
+
+describe('プロジェクト数上限', () => {
+  describe('異常系', () => {
+    it('Free で 3 件目を作ろうとすると 409 PROJECT_LIMIT_REACHED', async () => {
+      await createProject({ createdBy: ownerUserId });
+      await createProject({ createdBy: ownerUserId });
+
+      const res = await api<{ error: { code: string; details?: { projectLimit: number } } }>(
+        '/api/v1/projects',
+        {
+          method: 'POST',
+          token: ownerToken,
+          body: {
+            name: '3 件目',
+            startDate: '2026-01-01',
+            endDate: '2026-12-31',
+            items: [{ name: '制作物' }],
+          },
+        },
+      );
+
+      expect(res.status).toBe(409);
+      expect(res.body.error.code).toBe('PROJECT_LIMIT_REACHED');
+      expect(res.body.error.details?.projectLimit).toBe(2);
+    });
+  });
+
+  describe('正常系', () => {
+    it('アーカイブすると枠が空いて作成できる (削除は不要)', async () => {
+      await createProject({ createdBy: ownerUserId });
+      await createProject({ createdBy: ownerUserId, archivedAt: new Date() });
+
+      const res = await api('/api/v1/projects', {
+        method: 'POST',
+        token: ownerToken,
+        body: {
+          name: '枠が空いた',
+          startDate: '2026-01-01',
+          endDate: '2026-12-31',
+          items: [{ name: '制作物' }],
+        },
+      });
+
+      expect(res.status).toBe(201);
+    });
+
+    it('Team は無制限に作れる', async () => {
+      await setBillingSubscription({ organizationId, planCode: 'team', status: 'active' });
+      for (let i = 0; i < 3; i += 1) {
+        await createProject({ createdBy: ownerUserId, name: `P${i}` });
+      }
+
+      const res = await api('/api/v1/projects', {
+        method: 'POST',
+        token: ownerToken,
+        body: {
+          name: '4 件目',
+          startDate: '2026-01-01',
+          endDate: '2026-12-31',
+          items: [{ name: '制作物' }],
+        },
+      });
+
+      expect(res.status).toBe(201);
+    });
+  });
+});
+
+describe('プロジェクトの凍結', () => {
+  it('上限超過分は閲覧できるが編集できない (削除もされない)', async () => {
+    const first = await createProject({ createdBy: ownerUserId, name: '維持1' });
+    await createProject({ createdBy: ownerUserId, name: '維持2' });
+    // 上限を超えた 3 件目を直接作る (作成 API は 409 になるため)
+    const third = await createProject({ createdBy: ownerUserId, name: '超過' });
+
+    // 閲覧はできる
+    const read = await api(`/api/v1/projects/${third.id}`, { token: ownerToken });
+    expect(read.status).toBe(200);
+
+    // 編集は 403 PROJECT_FROZEN
+    const write = await api<{ error: { code: string } }>(`/api/v1/projects/${third.id}`, {
+      method: 'PATCH',
+      token: ownerToken,
+      body: { name: '変更' },
+    });
+    expect(write.status).toBe(403);
+    expect(write.body.error.code).toBe('PROJECT_FROZEN');
+
+    // 上限内のプロジェクトは編集できる
+    const ok = await api(`/api/v1/projects/${first.id}`, {
+      method: 'PATCH',
+      token: ownerToken,
+      body: { name: '変更OK' },
+    });
+    expect(ok.status).toBe(200);
+
+    // データは削除されていない
+    expect(await prisma.project.count({ where: { organizationId, deletedAt: null } })).toBe(3);
+  });
+
+  it('維持するプロジェクトを選び直すと凍結対象が入れ替わる', async () => {
+    const first = await createProject({ createdBy: ownerUserId, name: '古い1' });
+    await createProject({ createdBy: ownerUserId, name: '古い2' });
+    const third = await createProject({ createdBy: ownerUserId, name: '新しい' });
+
+    const res = await api<{ data: { frozenIds: string[] } }>(
+      '/api/v1/organizations/me/retained-projects',
+      { method: 'POST', token: ownerToken, body: { projectIds: [third.id, first.id] } },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.frozenIds).toHaveLength(1);
+    expect(res.body.data.frozenIds).not.toContain(third.id);
+
+    // 選び直した先は編集できる
+    const write = await api(`/api/v1/projects/${third.id}`, {
+      method: 'PATCH',
+      token: ownerToken,
+      body: { name: '編集できる' },
+    });
+    expect(write.status).toBe(200);
+  });
+
+  it('上限を超える件数を維持指定すると 409', async () => {
+    const a = await createProject({ createdBy: ownerUserId });
+    const b = await createProject({ createdBy: ownerUserId });
+    const c = await createProject({ createdBy: ownerUserId });
+
+    const res = await api<{ error: { code: string } }>(
+      '/api/v1/organizations/me/retained-projects',
+      { method: 'POST', token: ownerToken, body: { projectIds: [a.id, b.id, c.id] } },
+    );
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('PROJECT_LIMIT_REACHED');
+  });
+});
+
+describe('契約状態による書き込み停止', () => {
+  it('未払いなら閲覧はできるが編集は 403 SUBSCRIPTION_READ_ONLY', async () => {
+    const project = await createProject({ createdBy: ownerUserId });
+    await setBillingSubscription({ organizationId, planCode: 'team', status: 'unpaid' });
+
+    const read = await api(`/api/v1/projects/${project.id}`, { token: ownerToken });
+    expect(read.status).toBe(200);
+
+    const write = await api<{ error: { code: string } }>(`/api/v1/projects/${project.id}`, {
+      method: 'PATCH',
+      token: ownerToken,
+      body: { name: '変更' },
+    });
+    expect(write.status).toBe(403);
+    expect(write.body.error.code).toBe('SUBSCRIPTION_READ_ONLY');
+  });
+
+  it('支払い猶予期間中は通常どおり編集できる', async () => {
+    const project = await createProject({ createdBy: ownerUserId });
+    await setBillingSubscription({
+      organizationId,
+      planCode: 'team',
+      status: 'past_due',
+      gracePeriodEndsAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
+    });
+
+    const res = await api(`/api/v1/projects/${project.id}`, {
+      method: 'PATCH',
+      token: ownerToken,
+      body: { name: '猶予中でも編集できる' },
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('非参加者には課金エラーではなく 404 が先に返る (秘匿を維持する)', async () => {
+    const project = await createProject({ createdBy: ownerUserId });
+    await setBillingSubscription({ organizationId, planCode: 'team', status: 'unpaid' });
+    const outsider = await createUser();
+    const token = await signTestJwt({
+      authUserId: outsider.authUserId,
+      email: outsider.email,
+    });
+
+    const res = await api(`/api/v1/projects/${project.id}`, {
+      method: 'PATCH',
+      token,
+      body: { name: '変更' },
+    });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('座席上限', () => {
+  it('Free で 2 人目を招待しようとすると 409 SEAT_LIMIT_REACHED', async () => {
+    const project = await createProject({ createdBy: ownerUserId });
+
+    const res = await api<{ error: { code: string; details?: { seatLimit: number } } }>(
+      `/api/v1/projects/${project.id}/invitations`,
+      { method: 'POST', token: ownerToken, body: { email: 'a@example.test', roleType: 'editor' } },
+    );
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('SEAT_LIMIT_REACHED');
+    expect(res.body.error.details?.seatLimit).toBe(1);
+  });
+
+  it('Team は 5 名まで招待でき、未受諾の招待も座席を消費する', async () => {
+    await setBillingSubscription({ organizationId, planCode: 'team', status: 'active' });
+    const project = await createProject({ createdBy: ownerUserId });
+
+    // オーナー 1 + 招待 4 = 5 席
+    for (let i = 0; i < 4; i += 1) {
+      const res = await api(`/api/v1/projects/${project.id}/invitations`, {
+        method: 'POST',
+        token: ownerToken,
+        body: { email: `member${i}@example.test`, roleType: 'editor' },
+      });
+      expect(res.status).toBe(201);
+    }
+
+    // 5 件目は上限超過
+    const over = await api<{ error: { code: string } }>(
+      `/api/v1/projects/${project.id}/invitations`,
+      { method: 'POST', token: ownerToken, body: { email: 'over@example.test', roleType: 'editor' } },
+    );
+    expect(over.status).toBe(409);
+    expect(over.body.error.code).toBe('SEAT_LIMIT_REACHED');
+  });
+
+  it('招待を取り消すと座席が解放される', async () => {
+    await setBillingSubscription({ organizationId, planCode: 'personal', status: 'active' });
+    const project = await createProject({ createdBy: ownerUserId });
+    // Personal は 1 席。オーナーで埋まっているので招待できない
+    const blocked = await api(`/api/v1/projects/${project.id}/invitations`, {
+      method: 'POST',
+      token: ownerToken,
+      body: { email: 'x@example.test', roleType: 'editor' },
+    });
+    expect(blocked.status).toBe(409);
+
+    // Team に上げて 1 件招待 → 取り消すと戻る
+    await setBillingSubscription({ organizationId, planCode: 'team', status: 'active' });
+    const created = await api<{ data: { id: string } }>(
+      `/api/v1/projects/${project.id}/invitations`,
+      { method: 'POST', token: ownerToken, body: { email: 'y@example.test', roleType: 'editor' } },
+    );
+    const before = await api<{ data: { entitlement: { usage: { seatCount: number } } } }>(
+      '/api/v1/billing/subscription',
+      { token: ownerToken },
+    );
+    expect(before.body.data.entitlement.usage.seatCount).toBe(2);
+
+    await api(`/api/v1/projects/${project.id}/invitations/${created.body.data.id}`, {
+      method: 'DELETE',
+      token: ownerToken,
+    });
+
+    const after = await api<{ data: { entitlement: { usage: { seatCount: number } } } }>(
+      '/api/v1/billing/subscription',
+      { token: ownerToken },
+    );
+    expect(after.body.data.entitlement.usage.seatCount).toBe(1);
+  });
+});
+
+describe('組織メンバー管理', () => {
+  it('会員を除外すると座席が解放されるが、プロジェクト参加者行は残る', async () => {
+    await setBillingSubscription({ organizationId, planCode: 'team', status: 'active' });
+    const project = await createProject({ createdBy: ownerUserId });
+    const member = await addProjectMemberWithRole({ projectId: project.id, roleType: 'editor' });
+    await createOrgMember({ organizationId, userId: member.user.id });
+
+    const res = await api(`/api/v1/organizations/me/members/${member.user.id}`, {
+      method: 'DELETE',
+      token: ownerToken,
+    });
+
+    expect(res.status).toBe(204);
+    // 座席は解放される
+    expect(
+      await prisma.organizationMember.count({ where: { organizationId, deletedAt: null } }),
+    ).toBe(1);
+    // プロジェクト参加者行は消さない (データを削除しない方針)
+    expect(
+      await prisma.projectMember.count({ where: { id: member.member.id, deletedAt: null } }),
+    ).toBe(1);
+  });
+
+  it('オーナーは除外できない', async () => {
+    const res = await api<{ error: { code: string } }>(
+      `/api/v1/organizations/me/members/${ownerUserId}`,
+      { method: 'DELETE', token: ownerToken },
+    );
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('CANNOT_REMOVE_OWNER');
+  });
+});

--- a/apps/web/server/routes/v1/invitations.integration.test.ts
+++ b/apps/web/server/routes/v1/invitations.integration.test.ts
@@ -6,6 +6,8 @@ import { api } from '../../test/request.js';
 import {
   createMember,
   createUser,
+  primaryOrganizationId,
+  setBillingSubscription,
   setupProjectWithDirector,
 } from '../../test/factories.js';
 import { signTestJwt } from '../../test/auth.js';
@@ -87,7 +89,14 @@ describe('invitations routes (integration)', () => {
     });
 
     it('POST /:token/accept は招待先メールのユーザーが受諾でき 201 を返す', async () => {
-      const { project } = await setupProjectWithDirector();
+      const { project, user } = await setupProjectWithDirector();
+      // Free は会員 1 名が上限でオーナーだけで埋まるため、受諾で 2 人目になれない。
+      // 受諾フロー自体の検証なので Team に上げる (座席上限は billingLimits が担当)。
+      await setBillingSubscription({
+        organizationId: await primaryOrganizationId(user.id),
+        planCode: 'team',
+        status: 'active',
+      });
       const member = await createMember({
         projectId: project.id,
         userId: null,

--- a/apps/web/server/routes/v1/members.ts
+++ b/apps/web/server/routes/v1/members.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 
 import {
   requireProjectAction,
+  requireProjectWritable,
   requireProjectMember,
 } from '../../middleware/projectAuth.js';
 import { ApiException } from '../../lib/errors.js';
@@ -30,7 +31,7 @@ export const membersRoute = new Hono()
     return c.json({ data: members });
   })
 
-  .post('/', requireProjectMember(), requireProjectAction('member.create'), async (c) => {
+  .post('/', requireProjectMember(), requireProjectWritable(), requireProjectAction('member.create'), async (c) => {
     const project = c.get('project');
     const body = addMembersBodySchema.parse(await c.req.json());
     const created = await addMembers({ projectId: project.projectId, body });
@@ -38,7 +39,7 @@ export const membersRoute = new Hono()
   })
 
   // 並び替え (#111)。静的セグメント /reorder は :memberId より優先される。
-  .post('/reorder', requireProjectMember(), requireProjectAction('member.update'), async (c) => {
+  .post('/reorder', requireProjectMember(), requireProjectWritable(), requireProjectAction('member.update'), async (c) => {
     const project = c.get('project');
     const body = reorderMembersBodySchema.parse(await c.req.json());
     const members = await reorderMembers({
@@ -51,6 +52,7 @@ export const membersRoute = new Hono()
   .patch(
     '/:memberId',
     requireProjectMember(),
+    requireProjectWritable(),
     requireProjectAction('member.update'),
     async (c) => {
       const project = c.get('project');
@@ -65,6 +67,7 @@ export const membersRoute = new Hono()
   .delete(
     '/:memberId',
     requireProjectMember(),
+    requireProjectWritable(),
     requireProjectAction('member.remove'),
     async (c) => {
       const project = c.get('project');

--- a/apps/web/server/routes/v1/organizations.ts
+++ b/apps/web/server/routes/v1/organizations.ts
@@ -1,0 +1,126 @@
+import { Hono } from 'hono';
+
+import { prisma } from '@trakon/db';
+import { ORG_ROLES, type OrgRole } from '@trakon/shared';
+import { z } from 'zod';
+
+import { ApiException } from '../../lib/errors.js';
+import { requireAuth } from '../../middleware/auth.js';
+import { requireOrgBillingRole, requireOrgMember } from '../../middleware/orgAuth.js';
+import { attachCurrentUserId } from '../../middleware/projectAuth.js';
+import { retainedProjectsBodySchema } from '../../schemas/billing.js';
+import { setRetainedProjects } from '../../services/billing/freeze.js';
+
+const updateOrgMemberBodySchema = z.object({
+  orgRole: z.enum(ORG_ROLES),
+});
+
+/**
+ * `/api/v1/organizations/me` — 設計書 §3.4b
+ *
+ * 組織の会員アカウント (座席) 管理と、上限超過時に維持するプロジェクトの選択。
+ */
+export const organizationsRoute = new Hono()
+  .use('*', requireAuth())
+  .use('*', attachCurrentUserId())
+  .use('*', requireOrgMember())
+
+  .get('/me/members', async (c) => {
+    const { organizationId } = c.get('organization');
+    const rows = await prisma.organizationMember.findMany({
+      where: { organizationId, deletedAt: null },
+      orderBy: [{ orgRole: 'asc' }, { joinedAt: 'asc' }],
+      include: { user: { select: { id: true, displayName: true, email: true } } },
+    });
+    return c.json({
+      data: rows.map((m) => ({
+        userId: m.userId,
+        orgRole: m.orgRole as OrgRole,
+        displayName: m.user.displayName,
+        email: m.user.email,
+        joinedAt: m.joinedAt.toISOString(),
+      })),
+    });
+  })
+
+  .patch('/me/members/:userId', requireOrgBillingRole(), async (c) => {
+    const { organizationId } = c.get('organization');
+    const userId = c.req.param('userId');
+    const body = updateOrgMemberBodySchema.parse(await c.req.json());
+
+    const target = await prisma.organizationMember.findFirst({
+      where: { organizationId, userId, deletedAt: null },
+      select: { id: true, orgRole: true },
+    });
+    if (!target) throw new ApiException('NOT_FOUND', 404, 'Organization member not found.');
+
+    // オーナーは 1 名固定。降格させると課金操作の主体が居なくなる
+    if (target.orgRole === 'owner') {
+      throw new ApiException('CANNOT_CHANGE_OWNER', 409, '組織のオーナーは変更できません。');
+    }
+
+    await prisma.$transaction([
+      prisma.organizationMember.update({
+        where: { id: target.id },
+        data: { orgRole: body.orgRole },
+      }),
+      prisma.auditLog.create({
+        data: {
+          actorUserId: c.get('currentUserId'),
+          action: 'org_role_changed',
+          resourceType: 'organization',
+          resourceId: organizationId,
+          result: 'success',
+          extra: { targetUserId: userId, from: target.orgRole, to: body.orgRole },
+        },
+      }),
+    ]);
+
+    return c.json({ data: { userId, orgRole: body.orgRole } });
+  })
+
+  .delete('/me/members/:userId', requireOrgBillingRole(), async (c) => {
+    const { organizationId } = c.get('organization');
+    const userId = c.req.param('userId');
+
+    const target = await prisma.organizationMember.findFirst({
+      where: { organizationId, userId, deletedAt: null },
+      select: { id: true, orgRole: true },
+    });
+    if (!target) throw new ApiException('NOT_FOUND', 404, 'Organization member not found.');
+    if (target.orgRole === 'owner') {
+      throw new ApiException('CANNOT_REMOVE_OWNER', 409, '組織のオーナーは除外できません。');
+    }
+
+    // 論理削除で座席を解放する。プロジェクト側の参加者行はそのまま残す
+    // (解約・整理でデータを消さない方針、FR-BILL-09)。
+    await prisma.$transaction([
+      prisma.organizationMember.update({
+        where: { id: target.id },
+        data: { deletedAt: new Date() },
+      }),
+      prisma.auditLog.create({
+        data: {
+          actorUserId: c.get('currentUserId'),
+          action: 'org_member_removed',
+          resourceType: 'organization',
+          resourceId: organizationId,
+          result: 'success',
+          extra: { targetUserId: userId },
+        },
+      }),
+    ]);
+
+    return c.body(null, 204);
+  })
+
+  .post('/me/retained-projects', requireOrgBillingRole(), async (c) => {
+    const { organizationId } = c.get('organization');
+    const body = retainedProjectsBodySchema.parse(await c.req.json());
+    const result = await setRetainedProjects({
+      organizationId,
+      projectIds: body.projectIds,
+      actorUserId: c.get('currentUserId'),
+    });
+    return c.json({ data: result });
+  });

--- a/apps/web/server/routes/v1/plans.ts
+++ b/apps/web/server/routes/v1/plans.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 
 import {
   requireProjectAction,
+  requireProjectWritable,
   requireProjectMember,
 } from '../../middleware/projectAuth.js';
 import { requireItemInProject } from '../../middleware/itemAuth.js';
@@ -76,7 +77,7 @@ export const plansRoute = new Hono()
     });
   })
 
-  .post('/', requireProjectAction('plan.create'), async (c) => {
+  .post('/', requireProjectWritable(), requireProjectAction('plan.create'), async (c) => {
     const itemId = c.get('itemId');
     const project = c.get('project');
     const body = createPlanBodySchema.parse(await c.req.json());
@@ -84,7 +85,7 @@ export const plansRoute = new Hono()
     return c.json({ data: plan }, 201);
   })
 
-  .post('/:planId/copy', requireProjectAction('plan.create'), async (c) => {
+  .post('/:planId/copy', requireProjectWritable(), requireProjectAction('plan.create'), async (c) => {
     const itemId = c.get('itemId');
     const planId = c.req.param('planId');
     if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
@@ -100,7 +101,7 @@ export const plansRoute = new Hono()
     return c.json({ data: detail });
   })
 
-  .patch('/:planId', requireProjectAction('plan.update'), async (c) => {
+  .patch('/:planId', requireProjectWritable(), requireProjectAction('plan.update'), async (c) => {
     const itemId = c.get('itemId');
     const project = c.get('project');
     const planId = c.req.param('planId');
@@ -110,7 +111,7 @@ export const plansRoute = new Hono()
     return c.json({ data: plan });
   })
 
-  .delete('/:planId', requireProjectAction('plan.delete'), async (c) => {
+  .delete('/:planId', requireProjectWritable(), requireProjectAction('plan.delete'), async (c) => {
     const itemId = c.get('itemId');
     const planId = c.req.param('planId');
     if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
@@ -118,7 +119,7 @@ export const plansRoute = new Hono()
     return c.body(null, 204);
   })
 
-  .patch('/:planId/successor', requireProjectAction('plan.update'), async (c) => {
+  .patch('/:planId/successor', requireProjectWritable(), requireProjectAction('plan.update'), async (c) => {
     const itemId = c.get('itemId');
     const planId = c.req.param('planId');
     if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
@@ -127,7 +128,7 @@ export const plansRoute = new Hono()
     return c.json({ data: plan });
   })
 
-  .post('/:planId/request-review', async (c) => {
+  .post('/:planId/request-review', requireProjectWritable(), async (c) => {
     const project = c.get('project');
     const planId = c.req.param('planId');
     if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
@@ -141,7 +142,7 @@ export const plansRoute = new Hono()
     return c.json({ data: result });
   })
 
-  .post('/:planId/request-review-undo', async (c) => {
+  .post('/:planId/request-review-undo', requireProjectWritable(), async (c) => {
     const project = c.get('project');
     const planId = c.req.param('planId');
     if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
@@ -155,7 +156,7 @@ export const plansRoute = new Hono()
     return c.json({ data: result });
   })
 
-  .post('/:planId/approve', async (c) => {
+  .post('/:planId/approve', requireProjectWritable(), async (c) => {
     const project = c.get('project');
     const planId = c.req.param('planId');
     if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
@@ -169,7 +170,7 @@ export const plansRoute = new Hono()
     return c.json({ data: result });
   })
 
-  .post('/:planId/approve-undo', async (c) => {
+  .post('/:planId/approve-undo', requireProjectWritable(), async (c) => {
     const project = c.get('project');
     const planId = c.req.param('planId');
     if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
@@ -183,7 +184,7 @@ export const plansRoute = new Hono()
     return c.json({ data: result });
   })
 
-  .post('/:planId/send-back', async (c) => {
+  .post('/:planId/send-back', requireProjectWritable(), async (c) => {
     const project = c.get('project');
     const planId = c.req.param('planId');
     if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
@@ -199,7 +200,7 @@ export const plansRoute = new Hono()
     return c.json({ data: result });
   })
 
-  .post('/:planId/send-back-to-predecessor', async (c) => {
+  .post('/:planId/send-back-to-predecessor', requireProjectWritable(), async (c) => {
     const project = c.get('project');
     const planId = c.req.param('planId');
     if (!planId) throw new ApiException('BAD_REQUEST', 400, 'planId required');
@@ -215,7 +216,7 @@ export const plansRoute = new Hono()
     return c.json({ data: result });
   })
 
-  .post('/:planId/toss', async (c) => {
+  .post('/:planId/toss', requireProjectWritable(), async (c) => {
     const itemId = c.get('itemId');
     const project = c.get('project');
     const planId = c.req.param('planId');
@@ -231,7 +232,7 @@ export const plansRoute = new Hono()
     return c.json({ data: result });
   })
 
-  .post('/:planId/toss-undo', async (c) => {
+  .post('/:planId/toss-undo', requireProjectWritable(), async (c) => {
     const itemId = c.get('itemId');
     const project = c.get('project');
     const planId = c.req.param('planId');
@@ -247,7 +248,7 @@ export const plansRoute = new Hono()
     return c.json({ data: result });
   })
 
-  .post('/:planId/complete', async (c) => {
+  .post('/:planId/complete', requireProjectWritable(), async (c) => {
     const itemId = c.get('itemId');
     const project = c.get('project');
     const planId = c.req.param('planId');
@@ -263,7 +264,7 @@ export const plansRoute = new Hono()
     return c.json({ data: result });
   })
 
-  .post('/:planId/complete-undo', async (c) => {
+  .post('/:planId/complete-undo', requireProjectWritable(), async (c) => {
     const itemId = c.get('itemId');
     const project = c.get('project');
     const planId = c.req.param('planId');

--- a/apps/web/server/routes/v1/projectInvitations.ts
+++ b/apps/web/server/routes/v1/projectInvitations.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 
 import { ApiException } from '../../lib/errors.js';
 import { resolveRequestOrigin } from '../../lib/requestOrigin.js';
-import { requireProjectAction, requireProjectMember } from '../../middleware/projectAuth.js';
+import { requireProjectAction, requireProjectMember, requireProjectWritable } from '../../middleware/projectAuth.js';
 import { createInvitationBodySchema } from '../../schemas/projectInvitations.js';
 import {
   createInvitation,
@@ -18,13 +18,13 @@ import {
  * 消費するため、一覧も管理者に限定する。
  */
 export const projectInvitationsRoute = new Hono()
-  .get('/', requireProjectMember(), requireProjectAction('member.invite'), async (c) => {
+  .get('/', requireProjectMember(), requireProjectWritable(), requireProjectAction('member.invite'), async (c) => {
     const project = c.get('project');
     const invitations = await listPendingInvitations(project.projectId);
     return c.json({ data: invitations });
   })
 
-  .post('/', requireProjectMember(), requireProjectAction('member.invite'), async (c) => {
+  .post('/', requireProjectMember(), requireProjectWritable(), requireProjectAction('member.invite'), async (c) => {
     const project = c.get('project');
     const body = createInvitationBodySchema.parse(await c.req.json());
     const result = await createInvitation({
@@ -43,6 +43,7 @@ export const projectInvitationsRoute = new Hono()
   .delete(
     '/:invitationId',
     requireProjectMember(),
+    requireProjectWritable(),
     requireProjectAction('member.invite'),
     async (c) => {
       const project = c.get('project');

--- a/apps/web/server/routes/v1/projects.ts
+++ b/apps/web/server/routes/v1/projects.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '../../middleware/auth.js';
 import {
   attachCurrentUserId,
   requireProjectAction,
+  requireProjectWritable,
   requireProjectMember,
 } from '../../middleware/projectAuth.js';
 import {
@@ -69,7 +70,7 @@ export const projectsRoute = new Hono()
     return c.json({ data: detail });
   })
 
-  .patch('/:projectId', requireProjectMember(), requireProjectAction('project.update'), async (c) => {
+  .patch('/:projectId', requireProjectMember(), requireProjectWritable(), requireProjectAction('project.update'), async (c) => {
     const userId = c.get('currentUserId');
     const project = c.get('project');
     const body = updateProjectBodySchema.parse(await c.req.json());
@@ -85,6 +86,7 @@ export const projectsRoute = new Hono()
   .post(
     '/:projectId/archive',
     requireProjectMember(),
+    requireProjectWritable(),
     requireProjectAction('project.archive'),
     async (c) => {
       const userId = c.get('currentUserId');
@@ -100,6 +102,7 @@ export const projectsRoute = new Hono()
   .post(
     '/:projectId/unarchive',
     requireProjectMember(),
+    requireProjectWritable(),
     requireProjectAction('project.archive'),
     async (c) => {
       const userId = c.get('currentUserId');
@@ -122,6 +125,7 @@ export const projectsRoute = new Hono()
   .post(
     '/:projectId/items',
     requireProjectMember(),
+    requireProjectWritable(),
     requireProjectAction('item.create'),
     async (c) => {
       const project = c.get('project');
@@ -135,6 +139,7 @@ export const projectsRoute = new Hono()
   .post(
     '/:projectId/items/reorder',
     requireProjectMember(),
+    requireProjectWritable(),
     requireProjectAction('item.update'),
     async (c) => {
       const project = c.get('project');
@@ -158,6 +163,7 @@ export const projectsRoute = new Hono()
   .patch(
     '/:projectId/items/:itemId',
     requireProjectMember(),
+    requireProjectWritable(),
     requireProjectAction('item.update'),
     async (c) => {
       const project = c.get('project');
@@ -172,6 +178,7 @@ export const projectsRoute = new Hono()
   .delete(
     '/:projectId/items/:itemId',
     requireProjectMember(),
+    requireProjectWritable(),
     requireProjectAction('item.delete'),
     async (c) => {
       const project = c.get('project');

--- a/apps/web/server/routes/v1/shareLinks.ts
+++ b/apps/web/server/routes/v1/shareLinks.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { ApiException } from '../../lib/errors.js';
 import {
   requireProjectAction,
+  requireProjectWritable,
   requireProjectMember,
 } from '../../middleware/projectAuth.js';
 import { resolveRequestOrigin } from '../../lib/requestOrigin.js';
@@ -28,6 +29,7 @@ export const shareLinksRoute = new Hono()
   .post(
     '/',
     requireProjectMember(),
+    requireProjectWritable(),
     requireProjectAction('share_link.create'),
     async (c) => {
       const project = c.get('project');
@@ -45,6 +47,7 @@ export const shareLinksRoute = new Hono()
   .delete(
     '/:shareLinkId',
     requireProjectMember(),
+    requireProjectWritable(),
     requireProjectAction('share_link.revoke'),
     async (c) => {
       const project = c.get('project');

--- a/apps/web/server/services/billing/entitlement.test.ts
+++ b/apps/web/server/services/billing/entitlement.test.ts
@@ -9,6 +9,7 @@ const prismaMock = vi.hoisted(() => ({
   organization: { findUniqueOrThrow: vi.fn() },
   billingSubscription: { findUnique: vi.fn() },
   organizationMember: { count: vi.fn() },
+  invitation: { count: vi.fn() },
   project: { count: vi.fn(), findMany: vi.fn() },
 }));
 vi.mock('@trakon/db', () => ({ prisma: prismaMock }));
@@ -19,6 +20,7 @@ beforeEach(() => {
     .mockResolvedValue({ id: 'org-1', name: 'テスト組織' });
   prismaMock.billingSubscription.findUnique.mockReset().mockResolvedValue(null);
   prismaMock.organizationMember.count.mockReset().mockResolvedValue(1);
+  prismaMock.invitation.count.mockReset().mockResolvedValue(0);
   prismaMock.project.count.mockReset().mockResolvedValue(0);
   prismaMock.project.findMany.mockReset().mockResolvedValue([]);
 });

--- a/apps/web/server/services/billing/freeze.test.ts
+++ b/apps/web/server/services/billing/freeze.test.ts
@@ -8,6 +8,7 @@ import { getFrozenProjectIds, isProjectFrozen, setRetainedProjects } from './fre
 const prismaMock = vi.hoisted(() => ({
   billingSubscription: { findUnique: vi.fn() },
   organizationMember: { count: vi.fn() },
+  invitation: { count: vi.fn() },
   project: { count: vi.fn(), findMany: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
   auditLog: { create: vi.fn() },
   $transaction: vi.fn(),
@@ -25,6 +26,7 @@ const project = (id: string, over: Record<string, unknown> = {}) => ({
 beforeEach(() => {
   prismaMock.billingSubscription.findUnique.mockReset().mockResolvedValue(null);
   prismaMock.organizationMember.count.mockReset().mockResolvedValue(1);
+  prismaMock.invitation.count.mockReset().mockResolvedValue(0);
   prismaMock.project.count.mockReset().mockResolvedValue(0);
   prismaMock.project.findMany.mockReset().mockResolvedValue([]);
   prismaMock.project.update.mockReset().mockReturnValue({});

--- a/apps/web/server/services/billing/planChange.test.ts
+++ b/apps/web/server/services/billing/planChange.test.ts
@@ -15,6 +15,7 @@ import { __setStripeForTest } from './stripeClient.js';
 const prismaMock = vi.hoisted(() => ({
   billingSubscription: { findUnique: vi.fn(), update: vi.fn() },
   organizationMember: { count: vi.fn() },
+  invitation: { count: vi.fn() },
   project: { count: vi.fn(), findMany: vi.fn() },
   auditLog: { create: vi.fn() },
   $transaction: vi.fn(),
@@ -67,6 +68,7 @@ beforeEach(() => {
   prismaMock.billingSubscription.update.mockReset().mockReturnValue({});
   prismaMock.auditLog.create.mockReset().mockReturnValue({});
   prismaMock.organizationMember.count.mockReset().mockResolvedValue(1);
+  prismaMock.invitation.count.mockReset().mockResolvedValue(0);
   prismaMock.project.count.mockReset().mockResolvedValue(3);
   prismaMock.project.findMany.mockReset().mockResolvedValue([]);
   prismaMock.$transaction.mockReset().mockResolvedValue([]);

--- a/apps/web/server/services/invitations.test.ts
+++ b/apps/web/server/services/invitations.test.ts
@@ -161,6 +161,7 @@ const orgMemberTx = {
 
 const prismaMock = {
   invitation: {
+    count: vi.fn(async () => 1),
     findFirst: vi.fn(
       async ({ where }: { where: { tokenHash: string; expiresAt: { gt: Date } } }) => {
         const now = where.expiresAt.gt;
@@ -200,6 +201,18 @@ const prismaMock = {
       },
     ),
   },
+  // 受諾時の座席上限チェック (§7.11.1) が読む先。Free / 空きあり を既定にする。
+  billingSubscription: {
+    findUnique: vi.fn(async () => ({
+      planCode: 'team',
+      status: 'active',
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: null,
+      gracePeriodEndsAt: null,
+    })),
+  },
+  organizationMember: { count: vi.fn(async () => 1) },
+  project: { count: vi.fn(async () => 0) },
   // コールバック形式 ($transaction(fn)) を再現。
   $transaction: vi.fn(async (arg: unknown) => {
     return (arg as (tx: unknown) => Promise<unknown>)({

--- a/apps/web/server/services/invitations.ts
+++ b/apps/web/server/services/invitations.ts
@@ -4,6 +4,7 @@ import type { ProjectRole } from '@trakon/shared';
 import { ApiException } from '../lib/errors.js';
 import { hashToken } from '../lib/tokens.js';
 import { ensureOrganizationMember } from './organizations.js';
+import { getEntitlement } from './billing/entitlement.js';
 
 export type InvitationVerifyDTO = {
   project: { id: string; name: string };
@@ -87,8 +88,19 @@ export async function acceptInvitation(input: {
     );
   }
 
-  // TODO(上限判定): 招待作成時に空きがあっても受諾までに満席になりうるため、
-  // ここで座席上限を再チェックする (§7.11.1)。判定は課金テーブル導入後に差し込む。
+  // 招待作成時に空きがあっても、受諾までに満席になっている可能性がある (§7.11.1)。
+  // この招待自体が 1 座席を消費しているので、受諾は「招待 1 → 会員 1」の振り替えに
+  // すぎない。したがって自分の分を差し引いた消費数で判定する。
+  const entitlement = await getEntitlement(prisma, inv.organizationId);
+  const seatLimit = entitlement.limits.seatLimit;
+  if (seatLimit !== null && entitlement.usage.seatCount - 1 >= seatLimit) {
+    throw new ApiException(
+      'SEAT_LIMIT_REACHED',
+      409,
+      '会員アカウントの上限に達しているため参加できません。招待元にご連絡ください。',
+      { seatLimit, seatCount: entitlement.usage.seatCount },
+    );
+  }
 
   const result = await prisma.$transaction(async (tx) => {
     const updatedMember = await tx.projectMember.update({

--- a/apps/web/server/services/organizations.test.ts
+++ b/apps/web/server/services/organizations.test.ts
@@ -174,12 +174,26 @@ describe('resolvePrimaryOrganization', () => {
 });
 
 describe('カウント', () => {
-  it('座席は有効な組織メンバーだけを数える', async () => {
-    const count = vi.fn().mockResolvedValue(3);
-    const db = fakeDb({ organizationMember: { count } });
+  it('座席は有効な組織メンバーと、未受諾で期限内の招待を足したもの', async () => {
+    // 招待中も座席を押さえないと、大量に招待してから一斉受諾で上限を超えられる
+    const memberCount = vi.fn().mockResolvedValue(3);
+    const invitationCount = vi.fn().mockResolvedValue(2);
+    const db = fakeDb({
+      organizationMember: { count: memberCount },
+      invitation: { count: invitationCount },
+    });
 
-    expect(await countSeats(db, 'org-1')).toBe(3);
-    expect(count).toHaveBeenCalledWith({ where: { organizationId: 'org-1', deletedAt: null } });
+    expect(await countSeats(db, 'org-1')).toBe(5);
+    expect(memberCount).toHaveBeenCalledWith({
+      where: { organizationId: 'org-1', deletedAt: null },
+    });
+    expect(invitationCount).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        organizationId: 'org-1',
+        acceptedAt: null,
+        revokedAt: null,
+      }),
+    });
   });
 
   it('プロジェクト数はアーカイブ済みを除く (アーカイブが枠を空ける動線)', async () => {

--- a/apps/web/server/services/organizations.ts
+++ b/apps/web/server/services/organizations.ts
@@ -151,12 +151,22 @@ export async function resolvePrimaryOrganization(
 /**
  * 座席 (会員アカウント) の消費数。
  *
- * 【未完】未受諾かつ有効期限内の招待も 1 座席を消費する (§7.3.2)。
- * invitations.organization_id は招待作成 API と同じ変更で追加するため、
- * その時点でここへ加算を足す。現時点は組織メンバーのみを数える。
+ * 有効な組織メンバー + **未受諾かつ有効期限内の招待** (§7.3.2)。
+ * 招待中も座席を押さえないと、大量に招待してから一斉受諾で上限を超えられる。
  */
 export async function countSeats(db: Db, organizationId: string): Promise<number> {
-  return db.organizationMember.count({ where: { organizationId, deletedAt: null } });
+  const [members, pendingInvitations] = await Promise.all([
+    db.organizationMember.count({ where: { organizationId, deletedAt: null } }),
+    db.invitation.count({
+      where: {
+        organizationId,
+        acceptedAt: null,
+        revokedAt: null,
+        expiresAt: { gt: new Date() },
+      },
+    }),
+  ]);
+  return members + pendingInvitations;
 }
 
 /**

--- a/apps/web/server/services/projectInvitations.integration.test.ts
+++ b/apps/web/server/services/projectInvitations.integration.test.ts
@@ -7,6 +7,8 @@ import {
   addProjectMemberWithRole,
   createMember,
   createUser,
+  primaryOrganizationId,
+  setBillingSubscription,
   setupProjectWithDirector,
 } from '../test/factories.js';
 import { api } from '../test/request.js';
@@ -30,6 +32,23 @@ beforeEach(() => {
   });
 });
 
+/**
+ * 招待できる状態のプロジェクトを用意する。
+ *
+ * Free は会員 1 名が上限で、オーナーだけで埋まるため招待できない。
+ * 招待そのものを検証したいテストは Team に上げてから行う (座席上限は
+ * billingLimits.integration.test.ts が担当する)。
+ */
+async function setupInvitableProject() {
+  const ctx = await setupProjectWithDirector();
+  await setBillingSubscription({
+    organizationId: await primaryOrganizationId(ctx.user.id),
+    planCode: 'team',
+    status: 'active',
+  });
+  return ctx;
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -37,7 +56,7 @@ afterEach(() => {
 describe('POST /projects/:projectId/invitations', () => {
   describe('正常系', () => {
     it('参加者行を新規作成し、ロール付きの招待メールを送る', async () => {
-      const { project, token } = await setupProjectWithDirector();
+      const { project, token } = await setupInvitableProject();
 
       const res = await api<{ data: { id: string; email: string; roleType: string } }>(
         `/api/v1/projects/${project.id}/invitations`,
@@ -72,7 +91,7 @@ describe('POST /projects/:projectId/invitations', () => {
     });
 
     it('メール未登録の既存担当者行にメールを付けて招待できる', async () => {
-      const { project, token } = await setupProjectWithDirector();
+      const { project, token } = await setupInvitableProject();
       const member = await createMember({
         projectId: project.id,
         userId: null,
@@ -95,7 +114,7 @@ describe('POST /projects/:projectId/invitations', () => {
     });
 
     it('監査ログに invitation_created が残る', async () => {
-      const { project, token, user } = await setupProjectWithDirector();
+      const { project, token, user } = await setupInvitableProject();
 
       await api(`/api/v1/projects/${project.id}/invitations`, {
         method: 'POST',
@@ -113,7 +132,7 @@ describe('POST /projects/:projectId/invitations', () => {
 
   describe('異常系', () => {
     it('同一プロジェクトに同じメールが既にあれば 409 MEMBER_EMAIL_TAKEN', async () => {
-      const { project, token } = await setupProjectWithDirector();
+      const { project, token } = await setupInvitableProject();
       await createMember({ projectId: project.id, email: 'dup@example.test' });
 
       const res = await api<{ error: { code: string } }>(
@@ -127,7 +146,7 @@ describe('POST /projects/:projectId/invitations', () => {
     });
 
     it('既に参加済みの担当者行は 409 ALREADY_MEMBER', async () => {
-      const { project, token } = await setupProjectWithDirector();
+      const { project, token } = await setupInvitableProject();
       const joined = await addProjectMemberWithRole({ projectId: project.id, roleType: 'editor' });
 
       const res = await api<{ error: { code: string } }>(
@@ -144,7 +163,7 @@ describe('POST /projects/:projectId/invitations', () => {
     });
 
     it.each(['editor', 'viewer'] as const)('%s は招待を作成できない (404)', async (role) => {
-      const { project } = await setupProjectWithDirector();
+      const { project } = await setupInvitableProject();
       const other = await addProjectMemberWithRole({ projectId: project.id, roleType: role });
 
       const res = await api(`/api/v1/projects/${project.id}/invitations`, {
@@ -162,7 +181,7 @@ describe('POST /projects/:projectId/invitations', () => {
           throw new Error('resend unavailable');
         },
       });
-      const { project, token } = await setupProjectWithDirector();
+      const { project, token } = await setupInvitableProject();
 
       const res = await api<{ warnings?: string[] }>(
         `/api/v1/projects/${project.id}/invitations`,
@@ -178,7 +197,7 @@ describe('POST /projects/:projectId/invitations', () => {
 
 describe('GET / DELETE /projects/:projectId/invitations', () => {
   it('未受諾の招待だけを返し、取り消すと一覧から消える', async () => {
-    const { project, token } = await setupProjectWithDirector();
+    const { project, token } = await setupInvitableProject();
     await api(`/api/v1/projects/${project.id}/invitations`, {
       method: 'POST',
       token,
@@ -206,7 +225,7 @@ describe('GET / DELETE /projects/:projectId/invitations', () => {
 
 describe('POST /invitations/:token/accept', () => {
   it('招待されたロールが付与され、組織の会員として座席を消費する', async () => {
-    const { project, token } = await setupProjectWithDirector();
+    const { project, token } = await setupInvitableProject();
     const invitee = await createUser({ email: 'accept@example.test', withOrganization: false });
     await api(`/api/v1/projects/${project.id}/invitations`, {
       method: 'POST',
@@ -224,7 +243,6 @@ describe('POST /invitations/:token/accept', () => {
       { method: 'POST', token: inviteeToken },
     );
 
-    // 受諾は参加者行を作るため 201 (Phase 0 からの既存挙動)
     expect(res.status).toBe(201);
     expect(res.body.data.member.roleType).toBe('admin');
 
@@ -247,7 +265,7 @@ describe('POST /invitations/:token/accept', () => {
   });
 
   it('取り消された招待は受諾できない (404 集約)', async () => {
-    const { project, token } = await setupProjectWithDirector();
+    const { project, token } = await setupInvitableProject();
     const invitee = await createUser({ email: 'revoked@example.test', withOrganization: false });
     const created = await api<{ data: { id: string } }>(
       `/api/v1/projects/${project.id}/invitations`,

--- a/apps/web/server/services/projectInvitations.test.ts
+++ b/apps/web/server/services/projectInvitations.test.ts
@@ -43,6 +43,10 @@ const auditStore: MockAudit[] = [];
 let seq = 0;
 const newId = (p: string) => `${p}-${++seq}`;
 
+/** 座席上限の判定に使う契約と利用数。テストごとに差し替える。 */
+let billingRow: Record<string, unknown> | null = null;
+let seatCounts = { members: 1, projects: 0 };
+
 const memberTx = {
   findFirst: vi.fn(
     async ({
@@ -85,6 +89,7 @@ const memberTx = {
 };
 
 const invitationTx = {
+  count: vi.fn(async () => 0),
   create: vi.fn(
     async ({
       data,
@@ -152,6 +157,10 @@ const prismaMock = {
       projectMember: memberTx,
       invitation: invitationTx,
       auditLog: auditTx,
+      // 座席上限の判定 (getEntitlement) はトランザクション内で行う
+      billingSubscription: { findUnique: async () => billingRow },
+      organizationMember: { count: async () => seatCounts.members },
+      project: { count: async () => seatCounts.projects },
     });
   }),
 };
@@ -206,6 +215,10 @@ beforeEach(() => {
   }
   auditStore.length = 0;
   seq = 0;
+  // 既定は Team (座席 5) にして、座席上限は billingLimits の統合テストへ任せる
+  billingRow = { planCode: 'team', status: 'active', cancelAtPeriodEnd: false };
+  seatCounts = { members: 1, projects: 0 };
+  invitationTx.count.mockResolvedValue(0);
   sendInvitation.mockReset().mockResolvedValue(undefined);
   __setMailerForTest({ sendInvitation });
 });
@@ -327,6 +340,28 @@ describe('createInvitation', () => {
       await expect(createInvitation(input({ memberId: 'missing' }))).rejects.toMatchObject({
         code: 'NOT_FOUND',
         status: 404,
+      });
+    });
+
+    it('座席の上限に達していれば 409 SEAT_LIMIT_REACHED', async () => {
+      seedProject();
+      billingRow = { planCode: 'free', status: 'none', cancelAtPeriodEnd: false };
+
+      await expect(createInvitation(input())).rejects.toMatchObject({
+        code: 'SEAT_LIMIT_REACHED',
+        status: 409,
+        details: { seatLimit: 1 },
+      });
+    });
+
+    it('座席が埋まっていても、メール重複なら重複の方を先に知らせる', async () => {
+      seedProject();
+      seedMember({ email: 'invitee@example.test' });
+      billingRow = { planCode: 'free', status: 'none', cancelAtPeriodEnd: false };
+
+      // どちらも座席を増やさないので「上限です」より具体的な案内を返す
+      await expect(createInvitation(input())).rejects.toMatchObject({
+        code: 'MEMBER_EMAIL_TAKEN',
       });
     });
 

--- a/apps/web/server/services/projectInvitations.ts
+++ b/apps/web/server/services/projectInvitations.ts
@@ -14,6 +14,7 @@ import type { JobTitle, MemberType, ProjectRole } from '@trakon/shared';
 import { ApiException } from '../lib/errors.js';
 import { getMailer } from '../lib/mailer.js';
 import { defaultInvitationExpiresAt, generateInvitationToken } from '../lib/tokens.js';
+import { getEntitlement } from './billing/entitlement.js';
 
 export type InvitationDTO = {
   id: string;
@@ -93,6 +94,22 @@ export async function createInvitation(
     select: { id: true, name: true },
   });
   if (!project) throw new ApiException('NOT_FOUND', 404, 'Project not found.');
+
+  // 座席 (会員アカウント) の上限 (§7.11.1)。
+  // 未受諾の招待も座席を消費するので countSeats に含まれている。
+  const entitlement = await getEntitlement(prisma, input.organizationId);
+  if (!entitlement.canInviteMember) {
+    throw new ApiException(
+      'SEAT_LIMIT_REACHED',
+      409,
+      `会員アカウントの上限 (${entitlement.limits.seatLimit} 名) に達しています。プランを変更するか、既存のメンバー・招待を整理してください。`,
+      {
+        planCode: entitlement.effectivePlanCode,
+        seatLimit: entitlement.limits.seatLimit,
+        seatCount: entitlement.usage.seatCount,
+      },
+    );
+  }
 
   const inviter = await prisma.user.findUnique({
     where: { id: input.actorUserId },

--- a/apps/web/server/services/projectInvitations.ts
+++ b/apps/web/server/services/projectInvitations.ts
@@ -95,22 +95,6 @@ export async function createInvitation(
   });
   if (!project) throw new ApiException('NOT_FOUND', 404, 'Project not found.');
 
-  // 座席 (会員アカウント) の上限 (§7.11.1)。
-  // 未受諾の招待も座席を消費するので countSeats に含まれている。
-  const entitlement = await getEntitlement(prisma, input.organizationId);
-  if (!entitlement.canInviteMember) {
-    throw new ApiException(
-      'SEAT_LIMIT_REACHED',
-      409,
-      `会員アカウントの上限 (${entitlement.limits.seatLimit} 名) に達しています。プランを変更するか、既存のメンバー・招待を整理してください。`,
-      {
-        planCode: entitlement.effectivePlanCode,
-        seatLimit: entitlement.limits.seatLimit,
-        seatCount: entitlement.usage.seatCount,
-      },
-    );
-  }
-
   const inviter = await prisma.user.findUnique({
     where: { id: input.actorUserId },
     select: { displayName: true },
@@ -161,6 +145,25 @@ export async function createInvitation(
         select: { id: true },
       });
       memberId = member.id;
+    }
+
+    // 座席 (会員アカウント) の上限 (§7.11.1)。未受諾の招待も座席を消費する。
+    //
+    // メール重複・参加済みの検証より**後**に置く。どちらも座席を増やさないケースで、
+    // 「上限です」より「そのメールは既にいます」の方が具体的な案内になるため。
+    // トランザクション内で数えることで、作成との間に競合が入らない。
+    const entitlement = await getEntitlement(tx, input.organizationId);
+    if (!entitlement.canInviteMember) {
+      throw new ApiException(
+        'SEAT_LIMIT_REACHED',
+        409,
+        `会員アカウントの上限 (${entitlement.limits.seatLimit} 名) に達しています。プランを変更するか、既存のメンバー・招待を整理してください。`,
+        {
+          planCode: entitlement.effectivePlanCode,
+          seatLimit: entitlement.limits.seatLimit,
+          seatCount: entitlement.usage.seatCount,
+        },
+      );
     }
 
     const invitation = await tx.invitation.create({

--- a/apps/web/server/services/projects.test.ts
+++ b/apps/web/server/services/projects.test.ts
@@ -184,7 +184,20 @@ const prismaMock = {
     findFirst: vi.fn(async ({ where }: { where: { userId: string } }) =>
       userStore[where.userId] ? { organizationId: `org-${where.userId}`, orgRole: 'owner' } : null,
     ),
+    count: vi.fn(async () => 1),
   },
+  // プロジェクト数上限の判定 (§7.11.1)。既定は Team (無制限) にして
+  // 上限そのものの検証は統合テストへ寄せる。
+  billingSubscription: {
+    findUnique: vi.fn(async () => ({
+      planCode: 'team',
+      status: 'active',
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: null,
+      gracePeriodEndsAt: null,
+    })),
+  },
+  invitation: { count: vi.fn(async () => 0) },
   // コールバック形式 ($transaction(fn)) のみ service は使用。
   $transaction: vi.fn(async (arg: unknown) => {
     if (Array.isArray(arg)) return Promise.all(arg);

--- a/apps/web/server/services/projects.ts
+++ b/apps/web/server/services/projects.ts
@@ -3,6 +3,7 @@ import { pickLatestBallEvent, type BallEventType, type ProjectRole } from '@trak
 
 import { ApiException } from '../lib/errors.js';
 import { resolvePrimaryOrganization } from './organizations.js';
+import { getEntitlement } from './billing/entitlement.js';
 import type { CreateProjectBody, UpdateProjectBody } from '../schemas/projects.js';
 
 export type ProjectSummaryDTO = {
@@ -225,6 +226,21 @@ export async function createProject(input: {
 
   // プロジェクトは必ずいずれかの組織に属する (§7.3.1)。プロジェクト数上限の判定単位。
   const { organizationId } = await resolvePrimaryOrganization(prisma, currentUserId);
+
+  // プランのプロジェクト数上限 (§7.11.1)。課金エラーは 404 に混ぜず 409 で返す。
+  const entitlement = await getEntitlement(prisma, organizationId);
+  if (!entitlement.canCreateProject) {
+    throw new ApiException(
+      'PROJECT_LIMIT_REACHED',
+      409,
+      `${entitlement.limits.projectLimit} 件を超えるプロジェクトは作成できません。プランを変更するか、既存のプロジェクトをアーカイブしてください。`,
+      {
+        planCode: entitlement.effectivePlanCode,
+        projectLimit: entitlement.limits.projectLimit,
+        projectCount: entitlement.usage.projectCount,
+      },
+    );
+  }
 
   // 作成者のメールがメンバー入力に被ると uq_pm_project_email 違反になるため除外
   // (メール未登録の参加者は衝突しないためそのまま残す)。

--- a/apps/web/server/test/factories.ts
+++ b/apps/web/server/test/factories.ts
@@ -255,6 +255,38 @@ export async function createBallEvent(args: {
 }
 
 /**
+ * 既存ユーザーをオーナー(管理者)とするプロジェクトを作る。
+ *
+ * `createProject` はプロジェクト行しか作らないため、そのままでは
+ * `requireProjectMember` が通らず 404 になる。同じユーザーで複数の
+ * プロジェクトを作りたい場合はこちらを使う。
+ */
+export async function createProjectWithAdmin(args: {
+  user: { id: string; fullName: string; email: string };
+  name?: string;
+  archivedAt?: Date | null;
+  retainedAt?: Date | null;
+  organizationId?: string;
+}) {
+  const project = await createProject({
+    createdBy: args.user.id,
+    ...(args.name ? { name: args.name } : {}),
+    ...(args.organizationId ? { organizationId: args.organizationId } : {}),
+    archivedAt: args.archivedAt ?? null,
+    retainedAt: args.retainedAt ?? null,
+  });
+  const member = await createMember({
+    projectId: project.id,
+    userId: args.user.id,
+    name: args.user.fullName,
+    email: args.user.email,
+    memberType: 'production',
+    roleType: 'admin',
+  });
+  return { project, member };
+}
+
+/**
  * ユーザー + プロジェクト + そのユーザーをディレクター(=createdBy)として
  * 紐づけた production メンバー + 認証トークンをまとめて用意する。
  */


### PR DESCRIPTION
設計書 §7.11 / §3.2.4b。ここまでで作った利用権限判定を、実際の書き込み経路へ差し込みます。

有料プラン導入シリーズの 9/13。

## ミドルウェアの順序

`requireProjectWritable()` を新設し、契約の利用権限レベルと凍結状態を検証します。順序を **「参加確認 → 書き込み可否 → ロール」** に固定したので、**課金・凍結のエラーは参加者にしか見えません**（非参加者には先に 404 が返る）。

## エラーコードの方針

課金・上限・凍結は秘匿の必要がないので、**404 に集約せず 409 / 403 + 専用コード**で返します。404 に混ぜるとフロントが「存在しません」と表示してしまい、復旧手段（アップグレード・アーカイブ）を出せません。

| 場面 | コード |
|---|---|
| プロジェクト数の上限 | `PROJECT_LIMIT_REACHED` 409 |
| 座席の上限 | `SEAT_LIMIT_REACHED` 409 |
| 未払い等で閲覧のみ | `SUBSCRIPTION_READ_ONLY` 403 |
| 上限超過で凍結中 | `PROJECT_FROZEN` 403 |

書き込み系 16 エンドポイント + ボール操作 10 エンドポイントに差し込んでいます。

## 座席の数え方

`countSeats` に **「未受諾かつ有効期限内の招待」を加算**します。招待中も座席を押さえないと、大量に招待してから一斉受諾で上限を超えられるためです。

受諾時にも座席を再チェックします（作成時に空きがあっても、受諾までに満席になりうる）。**この招待自体が 1 座席を消費している**ので、自分の分を差し引いて判定します。

## 組織メンバー管理

`/api/v1/organizations/me` に会員一覧・組織ロール変更・除外・維持プロジェクト選択を追加しました。

**会員の除外は論理削除で座席だけを解放し、プロジェクト参加者行は残します。** 解約・整理でデータを消さない方針を、ここでも守ります。

## 合わせて直したもの

座席上限のチェックを、メール重複・参加済みの検証より**後ろ**へ移しました。どちらも座席を増やさないケースで「上限です」より「そのメールは既にいます」の方が具体的な案内になります。トランザクション内で数えることで、作成との競合も無くなります。

## テスト

上限到達 409 / アーカイブで枠が空く / 凍結は閲覧可・編集 403 / 維持プロジェクトの選び直し / 猶予中は編集できる / 未払いは閲覧のみ / **非参加者には課金エラーではなく 404 が先に返る**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
