### PR TITLE
feat(web): プランと請求の画面、上限・凍結・支払い失敗の UI を追加する

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@ import { CommercePage } from './features/legal/CommercePage';
 import { CompanyPage } from './features/legal/CompanyPage';
 import { PrivacyPage } from './features/legal/PrivacyPage';
 import { TermsPage } from './features/legal/TermsPage';
+import { BillingPage } from './features/billing/BillingPage';
 import { ItemSchedulePage } from './features/plans/ItemSchedulePage';
 import { MembersPage } from './features/projects/MembersPage';
 import { ProjectCreatePage } from './features/projects/ProjectCreatePage';
@@ -53,6 +54,7 @@ export function App() {
           }
         >
           <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/settings/billing" element={<BillingPage />} />
           <Route path="/projects" element={<ProjectListPage />} />
           <Route path="/projects/new" element={<ProjectCreatePage />} />
           <Route path="/projects/:projectId/edit" element={<ProjectEditPage />} />

--- a/apps/web/src/app/SidebarLayout.tsx
+++ b/apps/web/src/app/SidebarLayout.tsx
@@ -7,6 +7,9 @@ import { supabase } from '@/lib/supabase';
 import { useCurrentUser } from '@/features/auth/useCurrentUser';
 import { ProfileModal } from '@/features/auth/ProfileModal';
 import { projectsApi, projectsQueryKey } from '@/features/projects/api';
+import { useEntitlement } from '@/features/billing/useEntitlement';
+import { BillingStatusBanner } from '@/features/billing/BillingStatusBanner';
+import { BILLING_PLANS } from '@trakon/shared';
 
 /**
  * ログイン後画面の共通レイアウト。
@@ -23,6 +26,13 @@ export function SidebarLayout() {
     queryFn: () => projectsApi.list(),
   });
 
+  // サイドバーのプランバッジは契約状態から作る (ハードコードしない、§4.5)
+  const { subscription } = useEntitlement();
+  const planBadge =
+    subscription && subscription.planCode !== 'free'
+      ? { label: BILLING_PLANS[subscription.planCode].label, variant: 'brand' as const }
+      : null;
+
   const signOut = async () => {
     await supabase.auth.signOut();
     navigate('/login', { replace: true });
@@ -34,9 +44,12 @@ export function SidebarLayout() {
         projects={projectsQuery.data ?? []}
         user={user}
         onOpenProfile={() => setProfileOpen(true)}
+        planBadge={planBadge}
       />
 
       <main className="h-full flex-1 overflow-auto bg-content">
+        {/* 課金起因の状態は隠さずバナーで示し、復旧導線を出す (§4.5.2) */}
+        <BillingStatusBanner />
         <Outlet />
       </main>
 

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -40,11 +40,14 @@ export function AppSidebar({
   projects,
   user,
   onOpenProfile,
+  planBadge,
 }: {
   projects: SidebarProject[];
   /** 読込中・未ログインは null（フッターを Skeleton にする） */
   user: SidebarUser | null;
   onOpenProfile: () => void;
+  /** プランバッジ。契約状態から注入する。null なら非表示 (Free) */
+  planBadge?: { label: string; variant: 'brand' | 'secondary' } | null;
 }) {
   return (
     <aside className="border-sidebar-border bg-sidebar text-sidebar-foreground flex h-full w-56 shrink-0 flex-col border-r">
@@ -122,9 +125,11 @@ export function AppSidebar({
             <span className="min-w-0 flex-1">
               <span className="block truncate text-body font-medium">{user.displayName}</span>
               <span className="text-text-tertiary block truncate text-mini">アカウント設定</span>
-              <Badge variant="brand" size="sm" className="mt-1 font-bold">
-                PRO
-              </Badge>
+              {planBadge && (
+                <Badge variant={planBadge.variant} size="sm" className="mt-1 font-bold">
+                  {planBadge.label}
+                </Badge>
+              )}
             </span>
             <MoreHorizontal className="text-text-tertiary size-[18px] shrink-0" aria-hidden />
           </button>

--- a/apps/web/src/features/billing/BillingPage.test.tsx
+++ b/apps/web/src/features/billing/BillingPage.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { Toaster } from '@/components/ui/sonner';
 import { defaultBillingResponse, server } from '@/test/handlers';
 import { renderWithProviders } from '@/test/render';
 import { BillingPage } from './BillingPage';
@@ -43,6 +44,17 @@ function stubBilling(over: Partial<Billing> = {}) {
       HttpResponse.json({ data: { ...defaultBillingResponse, ...over } }),
     ),
     http.get('*/api/v1/projects', () => HttpResponse.json({ data: [] })),
+  );
+}
+
+/** トースト本文を確かめるケースは Toaster も一緒に描画する (本番は App 直下にある)。 */
+function renderWithToaster(route = '/settings/billing') {
+  return renderWithProviders(
+    <>
+      <BillingPage />
+      <Toaster />
+    </>,
+    { route },
   );
 }
 
@@ -96,6 +108,148 @@ describe('BillingPage (integration)', () => {
       await waitFor(() =>
         expect(externalRedirect).toHaveBeenCalledWith('https://checkout.test/session'),
       );
+    });
+  });
+
+  describe('プラン変更', () => {
+    const subscribed = {
+      subscription: {
+        ...defaultBillingResponse.subscription,
+        planCode: 'personal' as const,
+        status: 'active' as const,
+        hasStripeCustomer: true,
+      },
+      entitlement: {
+        ...defaultBillingResponse.entitlement,
+        planCode: 'personal' as const,
+        effectivePlanCode: 'personal' as const,
+        limits: { seatLimit: 1, projectLimit: 10 },
+        message: 'Personal プランを利用中です。',
+      },
+    };
+
+    it('契約中はボタンが「このプランに変更」になり、Checkout ではなく変更 API を呼ぶ', async () => {
+      stubBilling(subscribed);
+      let changedTo: unknown = null;
+      server.use(
+        http.post('*/api/v1/billing/plan', async ({ request }) => {
+          changedTo = await request.json();
+          return HttpResponse.json({ data: { appliedImmediately: false, pendingPlanCode: 'team' } });
+        }),
+      );
+      renderWithToaster();
+
+      const teamCard = await screen.findByTestId('plan-team');
+      await userEvent.click(within(teamCard).getByRole('button', { name: 'このプランに変更' }));
+
+      await waitFor(() => expect(changedTo).toEqual({ planCode: 'team' }));
+      // 決済の確認まで反映されないことを伝える
+      expect(await screen.findByText(/お支払いの確認後に反映されます/)).toBeInTheDocument();
+      expect(externalRedirect).not.toHaveBeenCalled();
+    });
+
+    it('Personal への変更は次回更新時であることを伝える', async () => {
+      stubBilling({
+        subscription: {
+          ...defaultBillingResponse.subscription,
+          planCode: 'team',
+          status: 'active',
+          hasStripeCustomer: true,
+        },
+      });
+      server.use(
+        http.post('*/api/v1/billing/plan', () =>
+          HttpResponse.json({
+            data: { appliedImmediately: false, pendingPlanCode: 'personal' },
+          }),
+        ),
+      );
+      renderWithToaster();
+
+      const personalCard = await screen.findByTestId('plan-personal');
+      await userEvent.click(within(personalCard).getByRole('button', { name: 'このプランに変更' }));
+
+      expect(await screen.findByText(/次回更新時に Personal/)).toBeInTheDocument();
+    });
+
+    it('上限超過で変更できない場合は理由を出す', async () => {
+      stubBilling(subscribed);
+      server.use(
+        http.post('*/api/v1/billing/plan', () =>
+          HttpResponse.json(
+            {
+              error: {
+                code: 'PLAN_DOWNGRADE_BLOCKED',
+                message: 'Personal プランの上限を超えているため変更できません。',
+              },
+            },
+            { status: 409 },
+          ),
+        ),
+      );
+      renderWithToaster();
+
+      const teamCard = await screen.findByTestId('plan-team');
+      await userEvent.click(within(teamCard).getByRole('button', { name: 'このプランに変更' }));
+
+      expect(await screen.findByText(/上限を超えているため変更できません/)).toBeInTheDocument();
+    });
+
+    it('変更予定と支払い方法を表示する', async () => {
+      stubBilling({
+        subscription: {
+          ...defaultBillingResponse.subscription,
+          planCode: 'team',
+          status: 'active',
+          hasStripeCustomer: true,
+          currentPeriodEnd: '2026-10-01T00:00:00.000Z',
+          pendingPlanCode: 'personal',
+          pendingPlanEffectiveAt: '2026-10-01T00:00:00.000Z',
+          paymentMethod: { brand: 'visa', last4: '4242' },
+        },
+      });
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      expect(await screen.findByText('変更予定')).toBeInTheDocument();
+      expect(screen.getByText(/visa •••• 4242/)).toBeInTheDocument();
+      expect(screen.getByText('次回更新')).toBeInTheDocument();
+    });
+  });
+
+  describe('お支払い方法・請求書', () => {
+    it('Customer Portal の URL へ遷移する', async () => {
+      stubBilling({
+        subscription: {
+          ...defaultBillingResponse.subscription,
+          planCode: 'team',
+          status: 'active',
+          hasStripeCustomer: true,
+        },
+      });
+      server.use(
+        http.post('*/api/v1/billing/portal-session', () =>
+          HttpResponse.json({ data: { url: 'https://portal.test/ps' } }),
+        ),
+      );
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'お支払い方法・請求書' }),
+      );
+
+      await waitFor(() =>
+        expect(externalRedirect).toHaveBeenCalledWith('https://portal.test/ps'),
+      );
+    });
+
+    it('顧客が未登録なら導線を出さない', async () => {
+      stubBilling();
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      await screen.findByText('現在のプラン');
+      expect(
+        screen.queryByRole('button', { name: 'お支払い方法・請求書' }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/features/billing/BillingPage.test.tsx
+++ b/apps/web/src/features/billing/BillingPage.test.tsx
@@ -1,0 +1,241 @@
+import { http, HttpResponse } from 'msw';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { defaultBillingResponse, server } from '@/test/handlers';
+import { renderWithProviders } from '@/test/render';
+import { BillingPage } from './BillingPage';
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: vi
+        .fn()
+        .mockResolvedValue({ data: { session: { access_token: 't', user: { id: 'u-me' } } } }),
+      onAuthStateChange: vi.fn().mockReturnValue({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      }),
+    },
+  },
+}));
+
+// 外部サイト (Stripe) への遷移は jsdom で追えないのでラッパをモックする
+const externalRedirect = vi.fn();
+vi.mock('@/lib/navigate', () => ({
+  externalRedirect: (url: string) => externalRedirect(url),
+}));
+
+beforeAll(() => {
+  const p = window.HTMLElement.prototype;
+  p.scrollIntoView = vi.fn();
+  p.hasPointerCapture = vi.fn();
+  p.releasePointerCapture = vi.fn();
+});
+
+afterEach(() => vi.clearAllMocks());
+
+type Billing = typeof defaultBillingResponse;
+
+function stubBilling(over: Partial<Billing> = {}) {
+  server.use(
+    http.get('*/api/v1/billing/subscription', () =>
+      HttpResponse.json({ data: { ...defaultBillingResponse, ...over } }),
+    ),
+    http.get('*/api/v1/projects', () => HttpResponse.json({ data: [] })),
+  );
+}
+
+describe('BillingPage (integration)', () => {
+  describe('表示', () => {
+    it('現在のプランと利用状況を表示する', async () => {
+      stubBilling();
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      expect(await screen.findByText('現在のプラン')).toBeInTheDocument();
+      expect(screen.getByText('Free プランを利用中です。')).toBeInTheDocument();
+      expect(screen.getByText('0 / 2')).toBeInTheDocument();
+    });
+
+    it('プラン比較に Free / Personal / Team を出す', async () => {
+      stubBilling();
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      await screen.findByText('プランを選ぶ');
+      expect(screen.getByTestId('plan-free')).toBeInTheDocument();
+      expect(screen.getByTestId('plan-personal')).toBeInTheDocument();
+      expect(screen.getByTestId('plan-team')).toBeInTheDocument();
+      expect(screen.getByText('9,800')).toBeInTheDocument();
+    });
+
+    it('組織メンバー (非管理者) には変更操作を無効化し理由を出す', async () => {
+      stubBilling({ orgRole: 'member' });
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      expect(
+        await screen.findByText(/プランの変更・解約は組織のオーナーまたは管理者のみ/),
+      ).toBeInTheDocument();
+      const buttons = screen.getAllByRole('button', { name: '申し込む' });
+      for (const b of buttons) expect(b).toBeDisabled();
+    });
+  });
+
+  describe('申し込み', () => {
+    it('プランを選ぶと Checkout の URL へ遷移する', async () => {
+      stubBilling();
+      server.use(
+        http.post('*/api/v1/billing/checkout-session', () =>
+          HttpResponse.json({ data: { url: 'https://checkout.test/session', trialApplied: true } }),
+        ),
+      );
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      const teamCard = await screen.findByTestId('plan-team');
+      await userEvent.click(within(teamCard).getByRole('button', { name: '申し込む' }));
+
+      await waitFor(() =>
+        expect(externalRedirect).toHaveBeenCalledWith('https://checkout.test/session'),
+      );
+    });
+  });
+
+  describe('Checkout からの復帰', () => {
+    it('success で戻った直後は「反映待ち」を出す (この遷移だけで有効化しない)', async () => {
+      stubBilling();
+      renderWithProviders(<BillingPage />, {
+        route: '/settings/billing?checkout=success&session_id=cs_1',
+      });
+
+      expect(await screen.findByText(/お支払いの確認中です/)).toBeInTheDocument();
+    });
+
+    it('canceled で戻ると未完了の案内を出す', async () => {
+      stubBilling();
+      renderWithProviders(<BillingPage />, { route: '/settings/billing?checkout=canceled' });
+
+      expect(await screen.findByText(/お申し込みは完了していません/)).toBeInTheDocument();
+    });
+  });
+
+  describe('支払い失敗', () => {
+    it('猶予期限と復旧導線を出す', async () => {
+      stubBilling({
+        subscription: {
+          ...defaultBillingResponse.subscription,
+          planCode: 'team',
+          status: 'past_due',
+          hasStripeCustomer: true,
+        },
+        entitlement: {
+          ...defaultBillingResponse.entitlement,
+          reason: 'in_grace_period',
+          planCode: 'team',
+          effectivePlanCode: 'team',
+          graceEndsAt: '2026-09-08T00:00:00.000Z',
+          message: 'お支払いを確認できませんでした。お支払い方法を更新してください。',
+        },
+      });
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      expect(
+        await screen.findByText(/までにお支払い方法を更新してください/),
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'お支払い方法・請求書' })).toBeEnabled();
+    });
+  });
+
+  describe('解約', () => {
+    it('契約中なら解約ボタンを出す', async () => {
+      stubBilling({
+        subscription: {
+          ...defaultBillingResponse.subscription,
+          planCode: 'team',
+          status: 'active',
+          hasStripeCustomer: true,
+        },
+      });
+      let canceled = false;
+      server.use(
+        http.post('*/api/v1/billing/cancel', () => {
+          canceled = true;
+          return HttpResponse.json({ data: { cancelAtPeriodEnd: true, currentPeriodEnd: null } });
+        }),
+      );
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      await userEvent.click(await screen.findByRole('button', { name: '解約する' }));
+
+      await waitFor(() => expect(canceled).toBe(true));
+    });
+
+    it('解約予定なら取り消しボタンを出す', async () => {
+      stubBilling({
+        subscription: {
+          ...defaultBillingResponse.subscription,
+          planCode: 'team',
+          status: 'active',
+          cancelAtPeriodEnd: true,
+          hasStripeCustomer: true,
+        },
+      });
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      expect(await screen.findByRole('button', { name: '解約を取り消す' })).toBeInTheDocument();
+    });
+  });
+
+  describe('上限超過と凍結', () => {
+    it('凍結中のプロジェクトがあれば維持対象を選び直せる', async () => {
+      stubBilling({
+        entitlement: {
+          ...defaultBillingResponse.entitlement,
+          usage: { seatCount: 1, projectCount: 3 },
+          over: { seats: 0, projects: 1 },
+          canCreateProject: false,
+          message: 'Free プランの上限を超えているため、1 件のプロジェクトが閲覧のみになっています。',
+        },
+        frozenProjectIds: ['p3'],
+      });
+      server.use(
+        http.get('*/api/v1/projects', () =>
+          HttpResponse.json({
+            data: ['p1', 'p2', 'p3'].map((id, i) => ({
+              id,
+              name: `プロジェクト${i + 1}`,
+              clientName: null,
+              startDate: '2026-01-01',
+              endDate: '2026-12-31',
+              status: 'active',
+              archivedAt: null,
+              role: 'admin',
+              createdBy: 'u-me',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:00:00.000Z',
+              progressManager: null,
+              overdueCount: 0,
+            })),
+          }),
+        ),
+      );
+      let posted: unknown = null;
+      server.use(
+        http.post('*/api/v1/organizations/me/retained-projects', async ({ request }) => {
+          posted = await request.json();
+          return HttpResponse.json({ data: { retainedIds: [], frozenIds: [] } });
+        }),
+      );
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      expect(await screen.findByText('維持するプロジェクトを選ぶ')).toBeInTheDocument();
+      // 凍結中の 1 件にはバッジが付く (プロジェクト一覧の読み込みを待つ)
+      expect(await screen.findByText('閲覧のみ')).toBeInTheDocument();
+
+      // 凍結中の p3 を選び、p1 を外す
+      await userEvent.click(screen.getByLabelText(/プロジェクト3/));
+      await userEvent.click(screen.getByLabelText(/プロジェクト1/));
+      await userEvent.click(screen.getByRole('button', { name: 'この構成で維持する' }));
+
+      await waitFor(() => expect(posted).toEqual({ projectIds: ['p2', 'p3'] }));
+    });
+  });
+});

--- a/apps/web/src/features/billing/BillingPage.tsx
+++ b/apps/web/src/features/billing/BillingPage.tsx
@@ -1,0 +1,474 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { format, parseISO } from 'date-fns';
+import { AlertTriangle, Check, Loader2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { BILLING_PLANS, SELECTABLE_BILLING_PLAN_CODES, type BillingPlanCode } from '@trakon/shared';
+
+import { PageContainer } from '@/components/layout/PageContainer';
+import { PageHeader } from '@/components/layout/PageHeader';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ApiClientError } from '@/lib/api';
+import { externalRedirect } from '@/lib/navigate';
+import { projectsApi, projectsQueryKey } from '@/features/projects/api';
+
+import {
+  billingApi,
+  billingQueryKey,
+  type CheckoutablePlan,
+  type OrganizationBilling,
+} from './api';
+
+/**
+ * SC-18 プランと請求 (設計書 §4.4 / 章7)。
+ *
+ * 状態表現の方針 (§4.5.2):
+ *   - 課金起因の制限は**隠さず**、無効化 + 理由 + 復旧導線 (CTA) を出す
+ *   - Checkout から戻った直後は「反映待ち」を表示し、契約状態をポーリングする。
+ *     **この画面遷移だけを根拠に有料機能を有効化しない** (PRD SR-BILL-03)
+ */
+export function BillingPage() {
+  const [params, setParams] = useSearchParams();
+  const checkoutResult = params.get('checkout');
+  const [awaitingWebhook, setAwaitingWebhook] = useState(checkoutResult === 'success');
+  const qc = useQueryClient();
+
+  const query = useQuery({
+    queryKey: billingQueryKey.subscription,
+    queryFn: () => billingApi.get(),
+    // 反映待ちの間だけポーリングする (Webhook の到着を待つ)
+    refetchInterval: awaitingWebhook ? 2000 : false,
+  });
+
+  const status = query.data?.subscription.status;
+
+  // 契約状態が確定したら反映待ちを解除する
+  useEffect(() => {
+    if (!awaitingWebhook) return;
+    if (status && status !== 'none') {
+      setAwaitingWebhook(false);
+      const next = new URLSearchParams(params);
+      next.delete('checkout');
+      next.delete('session_id');
+      setParams(next, { replace: true });
+      toast.success('プランが有効になりました');
+    }
+  }, [awaitingWebhook, status, params, setParams]);
+
+  // 反映待ちが長引いても永遠に回さない (Webhook 遅延時の保険)
+  useEffect(() => {
+    if (!awaitingWebhook) return;
+    const timer = setTimeout(() => setAwaitingWebhook(false), 30_000);
+    return () => clearTimeout(timer);
+  }, [awaitingWebhook]);
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: billingQueryKey.subscription });
+    qc.invalidateQueries({ queryKey: projectsQueryKey.all });
+  };
+
+  const checkoutMut = useMutation({
+    mutationFn: (planCode: CheckoutablePlan) => billingApi.checkout(planCode),
+    onSuccess: (data) => externalRedirect(data.url),
+    onError: (e) => toast.error(errorMessage(e, 'お申し込みを開始できませんでした')),
+  });
+
+  const portalMut = useMutation({
+    mutationFn: () => billingApi.portal(),
+    onSuccess: (data) => externalRedirect(data.url),
+    onError: (e) => toast.error(errorMessage(e, 'お支払い管理画面を開けませんでした')),
+  });
+
+  const changePlanMut = useMutation({
+    mutationFn: (planCode: CheckoutablePlan) => billingApi.changePlan(planCode),
+    onSuccess: (data) => {
+      invalidate();
+      toast.success(
+        data.pendingPlanCode === 'team'
+          ? 'プラン変更を受け付けました。お支払いの確認後に反映されます。'
+          : '次回更新時に Personal プランへ変更されます。',
+      );
+    },
+    onError: (e) => toast.error(errorMessage(e, 'プランを変更できませんでした')),
+  });
+
+  const cancelMut = useMutation({
+    mutationFn: () => billingApi.cancel(),
+    onSuccess: () => {
+      invalidate();
+      toast.success('解約を受け付けました。期間終了まではご利用いただけます。');
+    },
+    onError: (e) => toast.error(errorMessage(e, '解約できませんでした')),
+  });
+
+  const resumeMut = useMutation({
+    mutationFn: () => billingApi.resume(),
+    onSuccess: () => {
+      invalidate();
+      toast.success('解約を取り消しました');
+    },
+    onError: (e) => toast.error(errorMessage(e, '解約を取り消せませんでした')),
+  });
+
+  const anyPending =
+    checkoutMut.isPending ||
+    portalMut.isPending ||
+    changePlanMut.isPending ||
+    cancelMut.isPending ||
+    resumeMut.isPending;
+
+  return (
+    <>
+      <PageHeader title="プランと請求" />
+      <PageContainer>
+        {query.isLoading && <Skeleton className="h-64 w-full rounded-md" />}
+        {query.error && <p className="text-sm text-destructive">契約情報の取得に失敗しました</p>}
+
+        {query.data && (
+          <div className="grid gap-6">
+            {checkoutResult === 'canceled' && (
+              <Notice>お申し込みは完了していません。もう一度お試しください。</Notice>
+            )}
+
+            {awaitingWebhook && (
+              <Notice icon={<Loader2 className="size-4 animate-spin" />}>
+                お支払いの確認中です。反映まで少しお待ちください。
+              </Notice>
+            )}
+
+            <CurrentPlanCard
+              billing={query.data}
+              onOpenPortal={() => portalMut.mutate()}
+              onCancel={() => cancelMut.mutate()}
+              onResume={() => resumeMut.mutate()}
+              disabled={anyPending || awaitingWebhook}
+            />
+
+            <PlanComparison
+              current={query.data.subscription.planCode}
+              hasSubscription={Boolean(query.data.subscription.hasStripeCustomer)}
+              canManage={query.data.orgRole === 'owner' || query.data.orgRole === 'admin'}
+              disabled={anyPending || awaitingWebhook}
+              onSelect={(plan) =>
+                query.data.subscription.hasStripeCustomer &&
+                query.data.subscription.status !== 'none'
+                  ? changePlanMut.mutate(plan)
+                  : checkoutMut.mutate(plan)
+              }
+            />
+
+            {query.data.frozenProjectIds.length > 0 && (
+              <RetainedProjectsCard
+                organizationBillingKey={query.data.organizationId}
+                frozenProjectIds={query.data.frozenProjectIds}
+                projectLimit={query.data.entitlement.limits.projectLimit}
+                onDone={invalidate}
+                disabled={anyPending}
+              />
+            )}
+          </div>
+        )}
+      </PageContainer>
+    </>
+  );
+}
+
+function errorMessage(e: unknown, fallback: string): string {
+  return e instanceof ApiClientError ? e.message : fallback;
+}
+
+function Notice({ children, icon }: { children: React.ReactNode; icon?: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border bg-muted px-4 py-3 text-sm">
+      {icon ?? <AlertTriangle className="size-4" />}
+      <span>{children}</span>
+    </div>
+  );
+}
+
+function CurrentPlanCard({
+  billing,
+  onOpenPortal,
+  onCancel,
+  onResume,
+  disabled,
+}: {
+  billing: OrganizationBilling;
+  onOpenPortal: () => void;
+  onCancel: () => void;
+  onResume: () => void;
+  disabled: boolean;
+}) {
+  const { subscription, entitlement } = billing;
+  const spec = BILLING_PLANS[subscription.planCode];
+  const canManage = billing.orgRole === 'owner' || billing.orgRole === 'admin';
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">現在のプラン</CardTitle>
+          <Badge variant={subscription.planCode === 'free' ? 'secondary' : 'brand'}>
+            {spec.label}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        <p className="text-sm text-muted-foreground">{entitlement.message}</p>
+
+        <dl className="grid gap-2 text-sm sm:grid-cols-2">
+          <Row label="月額">
+            {spec.monthlyPriceJpyIncTax === null
+              ? '個別見積'
+              : `${spec.monthlyPriceJpyIncTax.toLocaleString()} 円 (税込)`}
+          </Row>
+          <Row label="会員アカウント">
+            {entitlement.usage.seatCount} / {entitlement.limits.seatLimit ?? '無制限'}
+          </Row>
+          <Row label="プロジェクト">
+            {entitlement.usage.projectCount} / {entitlement.limits.projectLimit ?? '無制限'}
+          </Row>
+          {subscription.trialEnd && (
+            <Row label="トライアル終了">{formatDateTime(subscription.trialEnd)}</Row>
+          )}
+          {subscription.currentPeriodEnd && (
+            <Row label={subscription.cancelAtPeriodEnd ? '利用可能期限' : '次回更新'}>
+              {formatDateTime(subscription.currentPeriodEnd)}
+            </Row>
+          )}
+          {subscription.pendingPlanCode && (
+            <Row label="変更予定">
+              {BILLING_PLANS[subscription.pendingPlanCode].label}
+              {subscription.pendingPlanEffectiveAt
+                ? `（${formatDateTime(subscription.pendingPlanEffectiveAt)}）`
+                : '（お支払いの確認後）'}
+            </Row>
+          )}
+          {subscription.paymentMethod?.last4 && (
+            <Row label="お支払い方法">
+              {subscription.paymentMethod.brand ?? 'カード'} •••• {subscription.paymentMethod.last4}
+            </Row>
+          )}
+        </dl>
+
+        {/* 課金起因の制限は隠さず、理由と復旧導線を出す (§4.5.2) */}
+        {entitlement.graceEndsAt && (
+          <Notice>
+            {formatDateTime(entitlement.graceEndsAt)} までにお支払い方法を更新してください。
+          </Notice>
+        )}
+
+        <div className="flex flex-wrap gap-2">
+          {subscription.hasStripeCustomer && (
+            <Button variant="outline" onClick={onOpenPortal} disabled={disabled || !canManage}>
+              お支払い方法・請求書
+            </Button>
+          )}
+          {subscription.hasStripeCustomer &&
+            subscription.status !== 'none' &&
+            (subscription.cancelAtPeriodEnd ? (
+              <Button variant="outline" onClick={onResume} disabled={disabled || !canManage}>
+                解約を取り消す
+              </Button>
+            ) : (
+              <Button variant="outline" onClick={onCancel} disabled={disabled || !canManage}>
+                解約する
+              </Button>
+            ))}
+        </div>
+
+        {!canManage && (
+          <p className="text-xs text-muted-foreground">
+            プランの変更・解約は組織のオーナーまたは管理者のみが行えます。
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function PlanComparison({
+  current,
+  hasSubscription,
+  canManage,
+  disabled,
+  onSelect,
+}: {
+  current: BillingPlanCode;
+  hasSubscription: boolean;
+  canManage: boolean;
+  disabled: boolean;
+  onSelect: (plan: CheckoutablePlan) => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">プランを選ぶ</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-4 sm:grid-cols-3">
+        {SELECTABLE_BILLING_PLAN_CODES.map((code) => {
+          const spec = BILLING_PLANS[code];
+          const isCurrent = code === current;
+          return (
+            <div
+              key={code}
+              className="flex flex-col gap-3 rounded-lg border border-border p-4"
+              data-testid={`plan-${code}`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{spec.label}</span>
+                {isCurrent && (
+                  <Badge variant="secondary">
+                    <Check className="size-3" />
+                    利用中
+                  </Badge>
+                )}
+              </div>
+              <p className="text-2xl font-semibold">
+                {spec.monthlyPriceJpyIncTax?.toLocaleString() ?? '—'}
+                <span className="ml-1 text-xs font-normal text-muted-foreground">円 / 月(税込)</span>
+              </p>
+              <ul className="grid gap-1 text-xs text-muted-foreground">
+                <li>会員アカウント {spec.seatLimit ?? '無制限'} 名</li>
+                <li>プロジェクト {spec.projectLimit ?? '無制限'} 件</li>
+                <li>{spec.trialHours ? `無料トライアル ${spec.trialHours} 時間` : 'トライアルなし'}</li>
+              </ul>
+              {code !== 'free' && !isCurrent && (
+                <Button
+                  size="sm"
+                  onClick={() => onSelect(code as CheckoutablePlan)}
+                  disabled={disabled || !canManage}
+                >
+                  {hasSubscription ? 'このプランに変更' : '申し込む'}
+                </Button>
+              )}
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * 上限超過時に維持するプロジェクトを選び直す (FR-BILL-11)。
+ * 超過分は削除されず凍結されているだけなので、選び直せば元に戻る。
+ */
+function RetainedProjectsCard({
+  frozenProjectIds,
+  projectLimit,
+  onDone,
+  disabled,
+}: {
+  organizationBillingKey: string;
+  frozenProjectIds: string[];
+  projectLimit: number | null;
+  onDone: () => void;
+  disabled: boolean;
+}) {
+  const projectsQuery = useQuery({
+    queryKey: projectsQueryKey.all,
+    queryFn: () => projectsApi.list(),
+  });
+  const [selected, setSelected] = useState<string[] | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: (projectIds: string[]) => billingApi.setRetainedProjects(projectIds),
+    onSuccess: () => {
+      onDone();
+      toast.success('維持するプロジェクトを更新しました');
+    },
+    onError: (e) => toast.error(errorMessage(e, '更新できませんでした')),
+  });
+
+  const projects = projectsQuery.data ?? [];
+  const active = projects.filter((p) => p.archivedAt === null);
+  const current = selected ?? active.filter((p) => !frozenProjectIds.includes(p.id)).map((p) => p.id);
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const base = prev ?? current;
+      return base.includes(id) ? base.filter((x) => x !== id) : [...base, id];
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">維持するプロジェクトを選ぶ</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        <p className="text-sm text-muted-foreground">
+          プランの上限を超えているため、{frozenProjectIds.length} 件のプロジェクトが閲覧のみに
+          なっています。データは削除されていません。
+          {projectLimit !== null && ` 維持できるのは ${projectLimit} 件までです。`}
+        </p>
+
+        <ul className="grid gap-2">
+          {active.map((p) => {
+            const checked = current.includes(p.id);
+            return (
+              <li key={p.id} className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  id={`retain-${p.id}`}
+                  checked={checked}
+                  onChange={() => toggle(p.id)}
+                  disabled={disabled || mutation.isPending}
+                />
+                <label htmlFor={`retain-${p.id}`} className="flex items-center gap-2">
+                  {p.name}
+                  {frozenProjectIds.includes(p.id) && (
+                    <Badge variant="secondary">閲覧のみ</Badge>
+                  )}
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+
+        <div>
+          <Button
+            size="sm"
+            onClick={() => mutation.mutate(current)}
+            disabled={
+              disabled ||
+              mutation.isPending ||
+              (projectLimit !== null && current.length > projectLimit)
+            }
+          >
+            {mutation.isPending && <Loader2 className="size-4 animate-spin" />}
+            この構成で維持する
+          </Button>
+          {projectLimit !== null && current.length > projectLimit && (
+            <p className="mt-1 text-xs text-destructive">
+              選べるのは {projectLimit} 件までです（現在 {current.length} 件）。
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex gap-2">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="font-medium">{children}</dd>
+    </div>
+  );
+}
+
+function formatDateTime(iso: string): string {
+  try {
+    return format(parseISO(iso), 'yyyy/MM/dd HH:mm');
+  } catch {
+    return iso;
+  }
+}

--- a/apps/web/src/features/billing/BillingStatusBanner.test.tsx
+++ b/apps/web/src/features/billing/BillingStatusBanner.test.tsx
@@ -1,0 +1,74 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import { defaultBillingResponse, server } from '@/test/handlers';
+import { renderWithProviders } from '@/test/render';
+import { BillingStatusBanner } from './BillingStatusBanner';
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: vi
+        .fn()
+        .mockResolvedValue({ data: { session: { access_token: 't', user: { id: 'u-me' } } } }),
+      onAuthStateChange: vi.fn().mockReturnValue({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      }),
+    },
+  },
+}));
+
+type Entitlement = typeof defaultBillingResponse.entitlement;
+
+function stub(entitlement: Partial<Entitlement>) {
+  server.use(
+    http.get('*/api/v1/billing/subscription', () =>
+      HttpResponse.json({
+        data: {
+          ...defaultBillingResponse,
+          entitlement: { ...defaultBillingResponse.entitlement, ...entitlement },
+        },
+      }),
+    ),
+  );
+}
+
+// 課金起因の制限は隠さず、理由と復旧導線を必ず添える (設計書 §4.5.2)。
+describe('BillingStatusBanner', () => {
+  it('支払い猶予中は理由と復旧導線を出す', async () => {
+    stub({
+      reason: 'in_grace_period',
+      message: 'お支払いを確認できませんでした。お支払い方法を更新してください。',
+    });
+    renderWithProviders(<BillingStatusBanner />);
+
+    expect(await screen.findByRole('status')).toHaveTextContent('お支払いを確認できませんでした');
+    expect(screen.getByRole('link', { name: 'お支払い方法を更新' })).toHaveAttribute(
+      'href',
+      '/settings/billing',
+    );
+  });
+
+  it('閲覧のみに落ちている場合も出す', async () => {
+    stub({ level: 'read_only', reason: 'grace_expired', message: '閲覧のみになっています。' });
+    renderWithProviders(<BillingStatusBanner />);
+
+    expect(await screen.findByRole('status')).toHaveTextContent('閲覧のみになっています。');
+  });
+
+  it('決済が未完了なら出す', async () => {
+    stub({ reason: 'incomplete', message: 'お支払いが完了していません。' });
+    renderWithProviders(<BillingStatusBanner />);
+
+    expect(await screen.findByRole('status')).toBeInTheDocument();
+  });
+
+  it('通常利用中は何も出さない', async () => {
+    renderWithProviders(<BillingStatusBanner />);
+
+    // 読み込み完了を待ってから、バナーが無いことを確かめる
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/billing/BillingStatusBanner.tsx
+++ b/apps/web/src/features/billing/BillingStatusBanner.tsx
@@ -1,0 +1,39 @@
+import { AlertTriangle } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import { useEntitlement } from './useEntitlement';
+
+/**
+ * 支払い失敗・閲覧のみ状態のグローバルバナー (設計書 §4.5.2)。
+ *
+ * 課金起因の制限は**隠さない**。理由と復旧導線 (CTA) を必ず添える。
+ * 隠すとユーザーが復旧手段にたどり着けないため。
+ */
+export function BillingStatusBanner() {
+  const { entitlement } = useEntitlement();
+  if (!entitlement) return null;
+
+  const needsAttention =
+    entitlement.reason === 'in_grace_period' ||
+    entitlement.level === 'read_only' ||
+    entitlement.reason === 'incomplete';
+  if (!needsAttention) return null;
+
+  return (
+    <div
+      role="status"
+      className="flex items-center justify-between gap-3 border-b border-border bg-warning-subtle px-6 py-3 text-sm"
+    >
+      <span className="flex items-center gap-2">
+        <AlertTriangle className="size-4 shrink-0" aria-hidden />
+        {entitlement.message}
+      </span>
+      <Link
+        to="/settings/billing"
+        className="shrink-0 font-medium underline underline-offset-2"
+      >
+        お支払い方法を更新
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/features/billing/api.ts
+++ b/apps/web/src/features/billing/api.ts
@@ -1,0 +1,63 @@
+import type { BillingPlanCode, Entitlement, OrgRole, SubscriptionStatus } from '@trakon/shared';
+
+import { apiRequest } from '@/lib/api';
+
+export type BillingSubscriptionSummary = {
+  planCode: BillingPlanCode;
+  status: SubscriptionStatus;
+  cancelAtPeriodEnd: boolean;
+  currentPeriodEnd: string | null;
+  trialEnd: string | null;
+  gracePeriodEndsAt: string | null;
+  pendingPlanCode: BillingPlanCode | null;
+  pendingPlanEffectiveAt: string | null;
+  paymentMethod: { brand: string | null; last4: string | null } | null;
+  hasStripeCustomer: boolean;
+};
+
+export type OrganizationBilling = {
+  organizationId: string;
+  organizationName: string;
+  subscription: BillingSubscriptionSummary;
+  entitlement: Entitlement;
+  /** 上限超過で閲覧のみになっているプロジェクト */
+  frozenProjectIds: string[];
+  orgRole: OrgRole;
+};
+
+export type CheckoutablePlan = 'personal' | 'team';
+
+export const billingApi = {
+  get: () => apiRequest<OrganizationBilling>('/billing/subscription'),
+
+  checkout: (planCode: CheckoutablePlan) =>
+    apiRequest<{ url: string; trialApplied: boolean }>('/billing/checkout-session', {
+      method: 'POST',
+      body: { planCode },
+    }),
+
+  portal: () => apiRequest<{ url: string }>('/billing/portal-session', { method: 'POST' }),
+
+  changePlan: (planCode: CheckoutablePlan) =>
+    apiRequest<{ appliedImmediately: boolean; pendingPlanCode: BillingPlanCode }>('/billing/plan', {
+      method: 'POST',
+      body: { planCode },
+    }),
+
+  cancel: () =>
+    apiRequest<{ cancelAtPeriodEnd: boolean; currentPeriodEnd: string | null }>('/billing/cancel', {
+      method: 'POST',
+    }),
+
+  resume: () => apiRequest<{ cancelAtPeriodEnd: boolean }>('/billing/resume', { method: 'POST' }),
+
+  setRetainedProjects: (projectIds: string[]) =>
+    apiRequest<{ retainedIds: string[]; frozenIds: string[] }>(
+      '/organizations/me/retained-projects',
+      { method: 'POST', body: { projectIds } },
+    ),
+};
+
+export const billingQueryKey = {
+  subscription: ['billing', 'subscription'] as const,
+};

--- a/apps/web/src/features/billing/useEntitlement.ts
+++ b/apps/web/src/features/billing/useEntitlement.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { billingApi, billingQueryKey } from './api';
+
+/**
+ * 契約状態・利用権限・上限・凍結対象を取得する (設計書 §4.5)。
+ *
+ * **利用権限はフロントエンドで再計算しない。** バックエンドが返した判定結果を
+ * そのまま表示に使う。二重実装は必ずずれるため (§7.6.4)。
+ */
+export function useEntitlement() {
+  const query = useQuery({
+    queryKey: billingQueryKey.subscription,
+    queryFn: () => billingApi.get(),
+    staleTime: 30_000,
+  });
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    entitlement: query.data?.entitlement ?? null,
+    subscription: query.data?.subscription ?? null,
+    /** 課金操作 (契約・変更・解約) ができるか */
+    canManageBilling: query.data?.orgRole === 'owner' || query.data?.orgRole === 'admin',
+    frozenProjectIds: query.data?.frozenProjectIds ?? [],
+    refetch: query.refetch,
+  };
+}

--- a/apps/web/src/features/projects/ProjectListPage.tsx
+++ b/apps/web/src/features/projects/ProjectListPage.tsx
@@ -1,4 +1,5 @@
 import { canProjectRole } from '@trakon/shared';
+import { useEntitlement } from '@/features/billing/useEntitlement';
 import { useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -17,6 +18,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -65,6 +67,11 @@ export function ProjectListPage() {
   const [keyword, setKeyword] = useState('');
   const [sort, setSort] = useState<Sort>('updated');
 
+  // プランの上限。到達していれば作成ボタンを無効化し、理由と復旧導線を出す (§4.5.2)
+  const { entitlement, frozenProjectIds } = useEntitlement();
+  const canCreateProject = entitlement?.canCreateProject ?? true;
+  const limitReached = entitlement !== null && !entitlement.canCreateProject;
+
   const { data, isLoading, error } = useQuery({
     queryKey: archived ? projectsQueryKey.archived : projectsQueryKey.all,
     queryFn: () => projectsApi.list({ archived }),
@@ -102,17 +109,38 @@ export function ProjectListPage() {
         title="プロジェクト一覧"
         description="進行中のプロジェクトと遅延状況を確認します"
         actions={
-          <Button size="lg" asChild>
-            <Link to="/projects/new">
+          canCreateProject ? (
+            <Button size="lg" asChild>
+              <Link to="/projects/new">
+                <Plus />
+                プロジェクトを作成
+              </Link>
+            </Button>
+          ) : (
+            // 課金起因の制限は隠さず無効化して理由を出す (§4.5.2)
+            <Button size="lg" disabled>
               <Plus />
               プロジェクトを作成
-            </Link>
-          </Button>
+            </Button>
+          )
         }
       />
 
       <div className="min-h-0 flex-1 overflow-auto px-12 py-8">
         <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-6">
+          {limitReached && (
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border bg-warning-subtle px-4 py-3 text-sm">
+              <span>{entitlement?.message}</span>
+              <span className="flex gap-3">
+                <Link to="/settings/billing" className="font-medium underline underline-offset-2">
+                  プランを見る
+                </Link>
+                <span className="text-text-tertiary">
+                  アーカイブすると枠が空きます
+                </span>
+              </span>
+            </div>
+          )}
           <div className="flex flex-wrap items-center gap-6">
             <div className="relative w-90">
               <Search
@@ -163,7 +191,7 @@ export function ProjectListPage() {
           ) : rows.length === 0 ? (
             <EmptyState archived={archived} filtered={keyword.trim() !== ''} />
           ) : (
-            <ProjectTable rows={rows} />
+            <ProjectTable rows={rows} frozenProjectIds={frozenProjectIds} />
           )}
         </div>
       </div>
@@ -172,7 +200,14 @@ export function ProjectListPage() {
 }
 
 /** テーブル本体 (Figma node 84:78)。行全体がスケジュールへのリンクになる。 */
-export function ProjectTable({ rows }: { rows: ProjectSummary[] }) {
+export function ProjectTable({
+  rows,
+  frozenProjectIds = [],
+}: {
+  rows: ProjectSummary[];
+  /** プラン上限超過で閲覧のみになっているプロジェクト (§7.11) */
+  frozenProjectIds?: string[];
+}) {
   return (
     <div className="border-border overflow-hidden rounded-2xl border bg-background">
       <div className="border-border bg-surface-subtle text-text-secondary grid h-13 grid-cols-[72px_1fr_200px_180px_56px] items-center border-b text-xs font-medium">
@@ -185,7 +220,7 @@ export function ProjectTable({ rows }: { rows: ProjectSummary[] }) {
       <ul>
         {rows.map((p) => (
           <li key={p.id}>
-            <ProjectRow project={p} />
+            <ProjectRow project={p} frozen={frozenProjectIds.includes(p.id)} />
           </li>
         ))}
       </ul>
@@ -193,7 +228,14 @@ export function ProjectTable({ rows }: { rows: ProjectSummary[] }) {
   );
 }
 
-function ProjectRow({ project: p }: { project: ProjectSummary }) {
+function ProjectRow({
+  project: p,
+  frozen,
+}: {
+  project: ProjectSummary;
+  /** プラン上限超過で閲覧のみになっているか (削除はされていない、§7.11) */
+  frozen?: boolean;
+}) {
   const qc = useQueryClient();
   const [confirming, setConfirming] = useState(false);
   const isArchived = p.archivedAt !== null;
@@ -224,7 +266,14 @@ function ProjectRow({ project: p }: { project: ProjectSummary }) {
         <DelayStatusIcon overdueCount={p.overdueCount} />
       </span>
       <span className="flex min-w-0 flex-col gap-1 pr-4">
-        <span className="truncate text-sm font-bold">{p.name}</span>
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm font-bold">{p.name}</span>
+          {frozen && (
+            <Badge variant="secondary" size="sm" className="shrink-0">
+              閲覧のみ
+            </Badge>
+          )}
+        </span>
         <span className="text-text-secondary truncate text-xs">{p.clientName ?? '—'}</span>
       </span>
       <span className="text-text-secondary text-body">

--- a/apps/web/src/lib/navigate.test.ts
+++ b/apps/web/src/lib/navigate.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { externalRedirect } from './navigate';
+
+// Stripe の Checkout / Customer Portal への遷移は jsdom で追えないため
+// ここを唯一の窓口にしている。画面側はこのラッパをモックしてテストする。
+
+const assign = vi.fn();
+const original = window.location;
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', { value: original, writable: true });
+  assign.mockReset();
+});
+
+describe('externalRedirect', () => {
+  it('外部サイトへ遷移する', () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...original, assign },
+      writable: true,
+    });
+
+    externalRedirect('https://checkout.stripe.test/cs_1');
+
+    expect(assign).toHaveBeenCalledWith('https://checkout.stripe.test/cs_1');
+  });
+});

--- a/apps/web/src/lib/navigate.ts
+++ b/apps/web/src/lib/navigate.ts
@@ -1,0 +1,8 @@
+/**
+ * 外部サイト (Stripe の Checkout / Customer Portal) への遷移。
+ *
+ * 直接 window.location を触ると jsdom でテストできないため、薄いラッパにする。
+ */
+export function externalRedirect(url: string): void {
+  window.location.assign(url);
+}

--- a/apps/web/src/test/handlers.ts
+++ b/apps/web/src/test/handlers.ts
@@ -1,5 +1,51 @@
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
-// 既定ハンドラは空。各テストで `server.use(http.get('*/api/v1/...', ...))` を使って
-// 必要なエンドポイントだけモックする。未登録リクエストは onUnhandledRequest='error' で検出。
-export const server = setupServer();
+import type { OrganizationBilling } from '@/features/billing/api';
+
+/**
+ * 既定ハンドラは原則空。各テストで server.use() を使い、必要なエンドポイントだけ
+ * モックする。未登録リクエストは onUnhandledRequest='error' で検出される。
+ *
+ * 例外として `GET /billing/subscription` だけ既定を置く。認証後の共通レイアウトが
+ * プランバッジと課金バナーのために毎回呼ぶため、既定が無いと全ページのテストが
+ * 未ハンドルで落ちてしまう (設計書 §4.5.2)。Free / 上限内 / 制限なしを既定にする。
+ */
+export const defaultBillingResponse: OrganizationBilling = {
+  organizationId: 'org-test',
+  organizationName: 'テスト組織',
+  orgRole: 'owner',
+  subscription: {
+    planCode: 'free',
+    status: 'none',
+    cancelAtPeriodEnd: false,
+    currentPeriodEnd: null,
+    trialEnd: null,
+    gracePeriodEndsAt: null,
+    pendingPlanCode: null,
+    pendingPlanEffectiveAt: null,
+    paymentMethod: null,
+    hasStripeCustomer: false,
+  },
+  entitlement: {
+    level: 'full',
+    reason: 'free',
+    planCode: 'free',
+    effectivePlanCode: 'free',
+    limits: { seatLimit: 1, projectLimit: 2 },
+    usage: { seatCount: 1, projectCount: 0 },
+    over: { seats: 0, projects: 0 },
+    canCreateProject: true,
+    canInviteMember: false,
+    graceEndsAt: null,
+    periodEndsAt: null,
+    message: 'Free プランを利用中です。',
+  },
+  frozenProjectIds: [],
+};
+
+export const server = setupServer(
+  http.get('*/api/v1/billing/subscription', () =>
+    HttpResponse.json({ data: defaultBillingResponse }),
+  ),
+);


### PR DESCRIPTION
設計書 §4.4 / §4.5.2 / SC-18。ここまでのバックエンドを画面から使えるようにします。

有料プラン導入シリーズの 10/13。

## `/settings/billing`（SC-18）

現在のプラン・利用状況・Free / Personal / Team の比較・申し込み・プラン変更・解約・解約取り消し・Customer Portal への導線。

## UI の出し分け方針

| 種類 | 方針 | 理由 |
|---|---|---|
| ロール起因 | **隠す** | メンバー管理・共有リンク・設定タブは入口ごと見せない |
| 課金起因（閲覧のみ / 凍結 / 上限） | **隠さず無効化 + 理由 + CTA** | 隠すと復旧手段にたどり着けない |

- **上限到達** — プロジェクト一覧に Alert +「アップグレード」「アーカイブして枠を空ける」。新規作成ボタンを無効化
- **凍結** — 一覧行に「閲覧のみ」バッジ、`/settings/billing` に「維持するプロジェクトを選ぶ」。**超過分は削除されておらず凍結されているだけなので、選び直せば元に戻ります**
- **支払い失敗** — グローバルバナー +「お支払い方法を更新」→ Portal

## Checkout からの復帰

`?checkout=success` では **「反映待ち」表示 + `GET /billing/subscription` のポーリング**のみを行います。**success URL への到達を根拠に権限を出す実装は作りません**（確定要件）。これを実装しないと「決済したのに反映されない」問い合わせになるため、UX 上も必須です。

## その他

- `useEntitlement` は**バックエンドが返した判定結果をそのまま使い、フロントで再計算しません**。二重実装は必ずずれるためです（§7.6.4）
- サイドバーのハードコードされていた `PRO` バッジを、実際のプランに置き換えました（Free では非表示）
- Stripe への遷移は `src/lib/navigate.ts` の薄いラッパ 1 箇所に閉じ込めています（jsdom でテストできるように）
- MSW の共通ハンドラに `GET /billing/subscription` の既定を追加しました。`SidebarLayout` がこれを叩くようになるため、先に入れないと既存のフロントテストが一斉に落ちます

🤖 Generated with [Claude Code](https://claude.com/claude-code)
