### PR TITLE
fix(api): Checkout で Managed Payments を明示的に無効化する

### DIFF
--- a/apps/web/server/services/billing/checkout.test.ts
+++ b/apps/web/server/services/billing/checkout.test.ts
@@ -52,6 +52,7 @@ const input = {
 type CheckoutParams = {
   line_items: unknown;
   automatic_tax: unknown;
+  managed_payments: unknown;
   payment_method_collection: string;
   success_url: string;
   cancel_url: string;
@@ -104,6 +105,14 @@ describe('createCheckoutSession', () => {
       // trial_end だと Session 作成〜申込完了の時間差だけトライアルが短くなる
       expect(params().subscription_data.trial_period_days).toBe(5);
       expect(params().subscription_data).not.toHaveProperty('trial_end');
+    });
+
+    it('アカウント既定で Managed Payments が有効でも、税は Stripe に代行させない', async () => {
+      await createCheckoutSession(input);
+
+      // 有効なままだと automatic_tax[enabled]=true を強制され、
+      // 税込 Price + 手動 Tax Rate の構成では Checkout の作成自体が弾かれる
+      expect(params().managed_payments).toEqual({ enabled: false });
     });
 
     it('トライアル中でもカード登録を必須にする', async () => {

--- a/apps/web/server/services/billing/checkout.ts
+++ b/apps/web/server/services/billing/checkout.ts
@@ -9,6 +9,13 @@
 //   - automatic_tax は無効。税込 Price + 手動 Tax Rate で内訳を表示する
 //   - success URL への遷移だけを根拠に有料権限を付与してはならない
 //   - Portal Session URL は保存せず都度生成する
+//
+// Managed Payments について:
+//   Stripe アカウントの既定で Managed Payments が有効だと、Stripe が税を代行する
+//   前提になり automatic_tax[enabled]=true が必須になる。本設計は税込 Price +
+//   手動 Tax Rate なので噛み合わず、Checkout Session の作成が弾かれる。
+//   ダッシュボードの既定に依存しないよう、リクエスト側で明示的に無効化する
+//   (STRIPE_PORTAL_CONFIGURATION_ID を明示指定するのと同じ理由)。
 // -----------------------------------------------------------------------------
 import { randomUUID } from 'node:crypto';
 
@@ -85,6 +92,8 @@ export async function createCheckoutSession(input: {
     // quantity は常に 1。人数課金は行わない (§7.2.1)
     line_items: [{ price: priceIdFor(input.planCode), quantity: 1 }],
     automatic_tax: { enabled: false },
+    // アカウント既定で有効でも、この決済では Stripe に税を代行させない
+    managed_payments: { enabled: false },
     payment_method_collection: 'always',
     subscription_data: {
       // trial_end は使わない (§7.4.1)

--- a/docs/design/07-billing.md
+++ b/docs/design/07-billing.md
@@ -133,6 +133,7 @@ Product は Personal / Team それぞれに 1 件ずつ、計 2 件。実装で�
 - Price は `tax_behavior = inclusive`（税込）で作成する
 - JPY はゼロデシマル通貨のため、金額は整数の `unit_amount`（980 / 9800）で指定する
 - 請求書上に消費税の内訳を表示するため、Checkout の `subscription_data.default_tax_rates` に手動 Tax Rate（日本国内向け消費税 10%・内税）を指定する
+- Checkout では **`managed_payments.enabled = false` を明示的に渡す**。Stripe アカウントの既定で Managed Payments が有効だと Stripe が税を代行する前提になり、`automatic_tax.enabled = true` が必須になる。本設計は税込 Price + 手動 Tax Rate なので噛み合わず、**Checkout Session の作成自体が拒否される**。ダッシュボードの既定に依存しないよう、リクエスト側で無効化する（`STRIPE_PORTAL_CONFIGURATION_ID` を明示指定するのと同じ理由）
 
 > 自動税計算を使わないことと、内訳表示のために手動 Tax Rate を付与することは両立する。手動 Tax Rate は税込価格の内訳を示すためのものであり、課金総額を変えるものではない。
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -158,9 +158,28 @@ psql "$DIRECT_URL" \
    stripe prices retrieve <PRICE_ID> | grep tax_behavior
    ```
 
+   > ⚠️ **`tax_behavior` は一度 `inclusive` / `exclusive` を設定すると変更できない。**
+   > `exclusive` のまま作ってしまった Price は、内税 Tax Rate と組み合わせると
+   > Stripe が契約作成を拒否する（`tax_behavior that conflicts with the tax rates`）。
+   > その場合は Price を作り直し、旧 Price を非アクティブ化して使用禁止 Price に加えること。
+   > 作成直後の `unspecified` であれば `inclusive` へ更新できる。
+
 4. 手動 Tax Rate を 1 件作る：日本国内向け消費税 10%・**内税（inclusive）**
    - 自動税計算（Stripe Tax）は使わない。この Tax Rate は請求書に消費税の内訳を
      表示するためのもので、課金総額は変えない
+
+**A-2. Managed Payments を確認する**
+
+Stripe アカウントの既定で **Managed Payments が有効**だと、Stripe が税を代行する前提に
+なり `automatic_tax.enabled = true` が必須になる。本設計は税込 Price + 手動 Tax Rate なので
+噛み合わず、**Checkout Session の作成が拒否される**。
+
+アプリ側は `managed_payments.enabled = false` を明示的に渡してこれを回避するため、
+ダッシュボードの設定を変更する必要はない。ただし挙動を把握しておくこと。
+
+```
+https://dashboard.stripe.com/settings/managed-payments
+```
 
 **B. Customer Portal**
 


### PR DESCRIPTION
**Stripe テスト環境で E2E を実施して見つかった不具合の修正です。** これがないと Checkout が発行できません。

## 事象

`createCheckoutSession` が Stripe に拒否されます。

```
Managed Payments handles taxes for you.
automatic_tax[enabled] must be true when Managed Payments is enabled.
```

Stripe アカウントの既定で **Managed Payments が有効**だと、Stripe が税を代行する前提になり `automatic_tax.enabled = true` が必須になります。本設計は**税込 Price + 手動 Tax Rate**（§7.3.4 の確定要件）なので噛み合わず、**Checkout Session の作成自体が拒否されます**。

契約の直接作成（`POST /v1/subscriptions`）は通るため、**Checkout 経路だけが落ちます**。ユニットテストは Stripe を差し替えているので検出できず、実際に叩いて初めて出ました。

## 修正

リクエスト側で `managed_payments.enabled = false` を明示的に渡します。

ダッシュボードの設定を変更する手もありますが、**アカウント既定に依存させない**方針を採りました。`STRIPE_PORTAL_CONFIGURATION_ID` を明示指定してプラン変更の無効化を担保しているのと同じ理由で、後からダッシュボード側を触られても壊れないようにするためです。

## 確認

修正後、テストモードで両プランの Checkout Session が発行できることを確認しました。

```
personal: 発行OK trialApplied=true mode=subscription qty=1  automatic_tax=false
team:     発行OK trialApplied=true mode=subscription qty=1  automatic_tax=false
```

## ドキュメント

- 設計書 §7.3.4 に、この挙動と明示無効化の理由を追記
- Runbook（§2.10）に Managed Payments の確認手順を追加
- あわせて **`tax_behavior` は一度設定すると変更できない**ことを警告として追記しました。実際に E2E 中、`exclusive` で作られた Price が内税 Tax Rate と衝突して契約を作れず、Price の作り直しが必要になりました

🤖 Generated with [Claude Code](https://claude.com/claude-code)
