### PR TITLE
fix(web,api): 解約後に契約プランを表示し続け、再契約できない問題を直す

### DIFF
--- a/apps/web/server/services/billing/planChange.test.ts
+++ b/apps/web/server/services/billing/planChange.test.ts
@@ -63,6 +63,7 @@ beforeEach(() => {
   prismaMock.billingSubscription.findUnique.mockReset().mockResolvedValue({
     organizationId: 'org-1',
     planCode: 'personal',
+    status: 'active',
     stripeSubscriptionId: 'sub_1',
   });
   prismaMock.billingSubscription.update.mockReset().mockReturnValue({});
@@ -128,6 +129,7 @@ describe('Team → Personal (次回更新時)', () => {
     prismaMock.billingSubscription.findUnique.mockResolvedValue({
       organizationId: 'org-1',
       planCode: 'team',
+      status: 'active',
       stripeSubscriptionId: 'sub_1',
     });
     retrieve.mockResolvedValue({
@@ -183,6 +185,7 @@ describe('changePlan の前提', () => {
     prismaMock.billingSubscription.findUnique.mockResolvedValue({
       organizationId: 'org-1',
       planCode: 'team',
+      status: 'active',
       stripeSubscriptionId: 'sub_1',
     });
 
@@ -192,10 +195,28 @@ describe('changePlan の前提', () => {
     });
   });
 
+  it('解約済みの契約に対しては 409 にする (Stripe を呼んで 500 にしない)', async () => {
+    // stripe_subscription_id は解約後も残るため、状態も見ないと
+    // 既に終了した契約へ Stripe を呼びに行ってしまう
+    prismaMock.billingSubscription.findUnique.mockResolvedValue({
+      organizationId: 'org-1',
+      planCode: 'team',
+      status: 'canceled',
+      stripeSubscriptionId: 'sub_1',
+    });
+
+    await expect(cancelSubscription(actor)).rejects.toMatchObject({
+      code: 'NO_ACTIVE_SUBSCRIPTION',
+      status: 409,
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it('Stripe 契約が無ければ 409 (先に申し込みへ誘導する)', async () => {
     prismaMock.billingSubscription.findUnique.mockResolvedValue({
       organizationId: 'org-1',
       planCode: 'free',
+      status: 'none',
       stripeSubscriptionId: null,
     });
 
@@ -241,6 +262,7 @@ describe('解約', () => {
     prismaMock.billingSubscription.findUnique.mockResolvedValue({
       organizationId: 'org-1',
       planCode: 'free',
+      status: 'none',
       stripeSubscriptionId: null,
     });
 

--- a/apps/web/server/services/billing/planChange.ts
+++ b/apps/web/server/services/billing/planChange.ts
@@ -13,7 +13,12 @@
 //   表現するため、そもそも削除処理がコード上に存在しない。
 // -----------------------------------------------------------------------------
 import { prisma } from '@trakon/db';
-import { BILLING_PLANS, type BillingPlanCode } from '@trakon/shared';
+import {
+  BILLING_PLANS,
+  hasLiveSubscription,
+  type BillingPlanCode,
+  type SubscriptionStatus,
+} from '@trakon/shared';
 
 import { getServerEnv } from '../../lib/env.js';
 import { ApiException } from '../../lib/errors.js';
@@ -30,7 +35,12 @@ async function loadActiveSubscription(organizationId: string): Promise<Subscript
   const subscription = await prisma.billingSubscription.findUnique({
     where: { organizationId },
   });
-  if (!subscription?.stripeSubscriptionId) {
+  // stripe_subscription_id は解約後も残る。状態も見ないと、既に終了した契約に
+  // 対して Stripe を呼び 500 になる (テスト環境の E2E で実際に発生した)。
+  if (
+    !subscription?.stripeSubscriptionId ||
+    !hasLiveSubscription(subscription.status as SubscriptionStatus)
+  ) {
     throw new ApiException(
       'NO_ACTIVE_SUBSCRIPTION',
       409,

--- a/apps/web/src/app/SidebarLayout.tsx
+++ b/apps/web/src/app/SidebarLayout.tsx
@@ -26,11 +26,13 @@ export function SidebarLayout() {
     queryFn: () => projectsApi.list(),
   });
 
-  // サイドバーのプランバッジは契約状態から作る (ハードコードしない、§4.5)
-  const { subscription } = useEntitlement();
+  // サイドバーのプランバッジは契約状態から作る (ハードコードしない、§4.5)。
+  // 契約プランではなく**実効プラン**を出す。解約済みで Team と出し続けると、
+  // 実際には Free の上限が効いている状態と食い違う
+  const { entitlement } = useEntitlement();
   const planBadge =
-    subscription && subscription.planCode !== 'free'
-      ? { label: BILLING_PLANS[subscription.planCode].label, variant: 'brand' as const }
+    entitlement && entitlement.effectivePlanCode !== 'free'
+      ? { label: BILLING_PLANS[entitlement.effectivePlanCode].label, variant: 'brand' as const }
       : null;
 
   const signOut = async () => {

--- a/apps/web/src/features/billing/BillingPage.test.tsx
+++ b/apps/web/src/features/billing/BillingPage.test.tsx
@@ -298,6 +298,84 @@ describe('BillingPage (integration)', () => {
     });
   });
 
+  describe('解約済み（実効 Free に落ちた状態）', () => {
+    // 契約プランを出したままにすると「Team なのに Free の上限」という
+    // 矛盾した表示になり、同じプランへ申し込み直すこともできなくなる
+    const canceled = {
+      subscription: {
+        ...defaultBillingResponse.subscription,
+        planCode: 'team' as const,
+        status: 'canceled' as const,
+        hasStripeCustomer: true,
+        currentPeriodEnd: '2026-09-11T11:05:00.000Z',
+        trialEnd: '2026-09-11T11:05:00.000Z',
+      },
+      entitlement: {
+        ...defaultBillingResponse.entitlement,
+        reason: 'canceled' as const,
+        planCode: 'team' as const,
+        effectivePlanCode: 'free' as const,
+      },
+    };
+
+    it('現在のプランは契約プランではなく実効プランを出す', async () => {
+      stubBilling(canceled);
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      await screen.findByText('現在のプラン');
+      expect(screen.getByText('0 円 (税込)')).toBeInTheDocument();
+      expect(screen.queryByText('9,800 円 (税込)')).not.toBeInTheDocument();
+    });
+
+    it('同じプランへ申し込み直せる', async () => {
+      stubBilling(canceled);
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      const teamCard = await screen.findByTestId('plan-team');
+      expect(within(teamCard).getByRole('button', { name: '申し込む' })).toBeEnabled();
+      expect(within(teamCard).queryByText('利用中')).not.toBeInTheDocument();
+      // 「利用中」は実効プランの Free 側に付く
+      expect(within(screen.getByTestId('plan-free')).getByText('利用中')).toBeInTheDocument();
+    });
+
+    it('解約ボタンを出さない（押しても対象が無い）', async () => {
+      stubBilling(canceled);
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      await screen.findByText('現在のプラン');
+      expect(screen.queryByRole('button', { name: '解約する' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: '解約を取り消す' })).not.toBeInTheDocument();
+      // 過去の請求書は見られるので支払い管理の導線は残す
+      expect(screen.getByRole('button', { name: 'お支払い方法・請求書' })).toBeInTheDocument();
+    });
+
+    it('終了した契約の日付を出さない', async () => {
+      stubBilling(canceled);
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      await screen.findByText('現在のプラン');
+      expect(screen.queryByText('次回更新')).not.toBeInTheDocument();
+      expect(screen.queryByText('トライアル終了')).not.toBeInTheDocument();
+    });
+
+    it('申し込みは Checkout へ向かう（プラン変更ではない）', async () => {
+      stubBilling(canceled);
+      let checkoutCalled = false;
+      server.use(
+        http.post('*/api/v1/billing/checkout-session', () => {
+          checkoutCalled = true;
+          return HttpResponse.json({ data: { url: 'https://checkout.test/s', trialApplied: false } });
+        }),
+      );
+      renderWithProviders(<BillingPage />, { route: '/settings/billing' });
+
+      const teamCard = await screen.findByTestId('plan-team');
+      await userEvent.click(within(teamCard).getByRole('button', { name: '申し込む' }));
+
+      await waitFor(() => expect(checkoutCalled).toBe(true));
+    });
+  });
+
   describe('解約', () => {
     it('契約中なら解約ボタンを出す', async () => {
       stubBilling({

--- a/apps/web/src/features/billing/BillingPage.tsx
+++ b/apps/web/src/features/billing/BillingPage.tsx
@@ -5,7 +5,12 @@ import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
-import { BILLING_PLANS, SELECTABLE_BILLING_PLAN_CODES, type BillingPlanCode } from '@trakon/shared';
+import {
+  BILLING_PLANS,
+  SELECTABLE_BILLING_PLAN_CODES,
+  hasLiveSubscription,
+  type BillingPlanCode,
+} from '@trakon/shared';
 
 import { PageContainer } from '@/components/layout/PageContainer';
 import { PageHeader } from '@/components/layout/PageHeader';
@@ -150,13 +155,14 @@ export function BillingPage() {
             />
 
             <PlanComparison
-              current={query.data.subscription.planCode}
-              hasSubscription={Boolean(query.data.subscription.hasStripeCustomer)}
+              // 契約プランではなく**実効プラン**で「利用中」を決める。
+              // 解約済みは実効 Free なので、同じプランへ申し込み直せる (§7.6)
+              current={query.data.entitlement.effectivePlanCode}
+              hasSubscription={hasLiveSubscription(query.data.subscription.status)}
               canManage={query.data.orgRole === 'owner' || query.data.orgRole === 'admin'}
               disabled={anyPending || awaitingWebhook}
               onSelect={(plan) =>
-                query.data.subscription.hasStripeCustomer &&
-                query.data.subscription.status !== 'none'
+                hasLiveSubscription(query.data.subscription.status)
                   ? changePlanMut.mutate(plan)
                   : checkoutMut.mutate(plan)
               }
@@ -205,7 +211,10 @@ function CurrentPlanCard({
   disabled: boolean;
 }) {
   const { subscription, entitlement } = billing;
-  const spec = BILLING_PLANS[subscription.planCode];
+  // 契約プランではなく実効プランを出す。解約済み・支払い不能で契約プランを
+  // 出すと「Team なのに Free の上限」という矛盾した表示になる
+  const spec = BILLING_PLANS[entitlement.effectivePlanCode];
+  const live = hasLiveSubscription(subscription.status);
   const canManage = billing.orgRole === 'owner' || billing.orgRole === 'admin';
 
   return (
@@ -213,7 +222,7 @@ function CurrentPlanCard({
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="text-base">現在のプラン</CardTitle>
-          <Badge variant={subscription.planCode === 'free' ? 'secondary' : 'brand'}>
+          <Badge variant={entitlement.effectivePlanCode === 'free' ? 'secondary' : 'brand'}>
             {spec.label}
           </Badge>
         </div>
@@ -233,10 +242,12 @@ function CurrentPlanCard({
           <Row label="プロジェクト">
             {entitlement.usage.projectCount} / {entitlement.limits.projectLimit ?? '無制限'}
           </Row>
-          {subscription.trialEnd && (
+          {/* 終了した契約の日付は残っているだけなので出さない (解約後に
+              「次回更新」が出ると更新されるように読めてしまう) */}
+          {live && subscription.trialEnd && (
             <Row label="トライアル終了">{formatDateTime(subscription.trialEnd)}</Row>
           )}
-          {subscription.currentPeriodEnd && (
+          {live && subscription.currentPeriodEnd && (
             <Row label={subscription.cancelAtPeriodEnd ? '利用可能期限' : '次回更新'}>
               {formatDateTime(subscription.currentPeriodEnd)}
             </Row>
@@ -269,8 +280,7 @@ function CurrentPlanCard({
               お支払い方法・請求書
             </Button>
           )}
-          {subscription.hasStripeCustomer &&
-            subscription.status !== 'none' &&
+          {live &&
             (subscription.cancelAtPeriodEnd ? (
               <Button variant="outline" onClick={onResume} disabled={disabled || !canManage}>
                 解約を取り消す

--- a/packages/shared/src/constants/billing.test.ts
+++ b/packages/shared/src/constants/billing.test.ts
@@ -11,6 +11,7 @@ import {
   TRIAL_PERIOD_DAYS,
   TRIAL_PERIOD_HOURS,
   canManageBilling,
+  hasLiveSubscription,
 } from './billing.js';
 
 describe('課金プラン定義', () => {
@@ -76,6 +77,27 @@ describe('課金プラン定義', () => {
       expect(SUBSCRIPTION_STATUSES).toContain(s);
     }
     expect(new Set(SUBSCRIPTION_STATUSES).size).toBe(SUBSCRIPTION_STATUSES.length);
+  });
+});
+
+describe('hasLiveSubscription', () => {
+  it('Stripe 上に契約が残っている状態を true にする', () => {
+    for (const s of ['trialing', 'active', 'past_due', 'unpaid', 'incomplete', 'paused'] as const) {
+      expect(hasLiveSubscription(s)).toBe(true);
+    }
+  });
+
+  it('対象が無い状態を false にする', () => {
+    // ここで解約・プラン変更を呼ぶと Stripe 側に対象が無く失敗する
+    for (const s of ['none', 'canceled', 'incomplete_expired'] as const) {
+      expect(hasLiveSubscription(s)).toBe(false);
+    }
+  });
+
+  it('すべての状態を漏れなく分類している', () => {
+    for (const s of SUBSCRIPTION_STATUSES) {
+      expect(typeof hasLiveSubscription(s)).toBe('boolean');
+    }
   });
 });
 

--- a/packages/shared/src/constants/billing.ts
+++ b/packages/shared/src/constants/billing.ts
@@ -95,6 +95,26 @@ export const SUBSCRIPTION_STATUSES = [
 
 export type SubscriptionStatus = (typeof SUBSCRIPTION_STATUSES)[number];
 
+/**
+ * Stripe 上に「生きている契約」がある状態。
+ *
+ * ここに含まれない状態 (none / canceled / incomplete_expired) では、解約・
+ * 解約取り消し・プラン変更を呼んでも Stripe 側に対象が無く失敗する。
+ * 画面の導線と API の前提を同じ定義で判断するため shared に置く (設計書 §7.7)。
+ */
+export const LIVE_SUBSCRIPTION_STATUSES: readonly SubscriptionStatus[] = [
+  'trialing',
+  'active',
+  'past_due',
+  'unpaid',
+  'incomplete',
+  'paused',
+];
+
+export function hasLiveSubscription(status: SubscriptionStatus): boolean {
+  return LIVE_SUBSCRIPTION_STATUSES.includes(status);
+}
+
 /** 組織ロール。課金操作の可否を決める (プロジェクトロールとは別系統) */
 export const ORG_ROLES = ['owner', 'admin', 'member'] as const;
 


### PR DESCRIPTION
**Stripe テスト環境の E2E（項目 #17 再契約）で見つかった不具合の修正です。**

## 事象

契約が `canceled` になると `entitlement` は実効 Free へ落ちますが、画面は `subscription.planCode`（契約プラン）を出し続けていました。結果、こうなります。

- 「現在のプラン **Team** / 9,800 円」と「会員 **1/1**・プロジェクト **3/2**」（Free の上限）が同居
- 比較表で Team が「利用中」扱いになりボタンが消え、**同じプランへ申し込み直せない**（#17 が UI で不可能）
- 終了した契約の「次回更新」「トライアル終了」が残り、更新されるように読める
- 解約済みでも「解約する」が出て、押すと **500**（Stripe 側に対象が無い）

サイドバーのプランバッジも Team のままでした。

## 修正

**① 表示と比較表を `entitlement.effectivePlanCode` に統一**

実効プランこそがユーザーに効いている値です。`active` / `trialing` / 解約予約中は契約プランと一致するので表示は変わらず、`canceled` のときだけ Free に落ちます。`unpaid`（実効プランは維持したまま `read_only`）でも Team 表示のままです。

**② `hasLiveSubscription` を shared に定義**

「Stripe 上に生きている契約があるか」を 1 箇所に置き、**画面の導線と API の前提を同じ判断**に寄せました。`none` / `canceled` / `incomplete_expired` では解約・プラン変更を呼んでも Stripe 側に対象がありません。

**③ サーバー側でも状態を検証**

`loadActiveSubscription` が `stripeSubscriptionId` の有無しか見ていませんでした。**この ID は解約後も残る**ため、終了した契約へ Stripe を呼びに行って 500 になります。状態も検証して 409 `NO_ACTIVE_SUBSCRIPTION` を返します。

## 確認

修正後、解約済みの状態で「現在のプラン Free / 0 円」、Free に「利用中」、**Personal と Team の両方に「申し込む」**、解約ボタンと古い日付は非表示になることをブラウザで確認しました。

回帰テストとして、解約済み状態の表示・再契約導線・解約ボタン非表示・日付非表示・Checkout へ向かうこと（FE）と、解約済み契約への解約要求が Stripe を呼ばず 409 になること（BE）を追加しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
