### PR TITLE
fix(api): カード情報が保存されず、お支払い方法が表示されない問題を直す

### DIFF
--- a/apps/web/server/services/billing/webhookHandlers.test.ts
+++ b/apps/web/server/services/billing/webhookHandlers.test.ts
@@ -226,6 +226,8 @@ describe('customer.subscription.*', () => {
       canceledAt: null,
       trialStart: null,
       trialEnd: null,
+      paymentMethodBrand: null,
+      paymentMethodLast4: null,
       ...over,
     };
   }
@@ -322,6 +324,30 @@ describe('customer.subscription.*', () => {
       type: 'subscription_canceled',
       organizationId: 'org-1',
     });
+  });
+
+  it('取得できたカードのブランドと下 4 桁だけを保存する (SR-BILL-02)', async () => {
+    const f = fakeTx();
+
+    await applyEvent(f.tx, event('customer.subscription.updated', {}), {
+      snapshot: snapshot({ paymentMethodBrand: 'visa', paymentMethodLast4: '4242' }),
+    });
+
+    expect(f.data()).toMatchObject({
+      defaultPaymentMethodBrand: 'visa',
+      defaultPaymentMethodLast4: '4242',
+    });
+    // 番号や fingerprint は保存しない
+    expect(JSON.stringify(f.data())).not.toMatch(/fingerprint|4242 4242/);
+  });
+
+  it('カードを取得できなければ既存の表示を消さない', async () => {
+    const f = fakeTx();
+
+    await applyEvent(f.tx, event('customer.subscription.updated', {}), { snapshot: snapshot() });
+
+    expect(f.data()).not.toHaveProperty('defaultPaymentMethodLast4');
+    expect(f.data()).not.toHaveProperty('defaultPaymentMethodBrand');
   });
 
   it('組織を特定できなければ何も書かない', async () => {
@@ -535,7 +561,7 @@ describe('prefetchSubscription', () => {
       event('customer.subscription.updated', payload),
     );
 
-    expect(retrieve).toHaveBeenCalledWith('sub_9');
+    expect(retrieve).toHaveBeenCalledWith('sub_9', { expand: ['default_payment_method'] });
     // ペイロードの incomplete ではなく、取り直した active を採用する
     expect(snapshot).toMatchObject({
       organizationId: 'org-1',
@@ -543,6 +569,32 @@ describe('prefetchSubscription', () => {
       status: 'active',
       currentPeriodEnd: new Date('2026-10-01T00:00:00Z'),
     });
+  });
+
+  it('既定の支払い方法を展開して取得し、ブランドと下 4 桁だけを持つ', async () => {
+    const retrieve = stubStripe({
+      ...payload,
+      status: 'active',
+      default_payment_method: {
+        id: 'pm_1',
+        card: { brand: 'visa', last4: '4242', fingerprint: 'fp_secret', exp_month: 12 },
+      },
+    });
+
+    const snapshot = await prefetchSubscription(event('customer.subscription.updated', payload));
+
+    expect(retrieve).toHaveBeenCalledWith('sub_9', { expand: ['default_payment_method'] });
+    expect(snapshot).toMatchObject({ paymentMethodBrand: 'visa', paymentMethodLast4: '4242' });
+    // fingerprint は取り出さない
+    expect(JSON.stringify(snapshot)).not.toContain('fp_secret');
+  });
+
+  it('既定の支払い方法が無ければ null にする', async () => {
+    stubStripe({ ...payload, status: 'active', default_payment_method: null });
+
+    const snapshot = await prefetchSubscription(event('customer.subscription.updated', payload));
+
+    expect(snapshot?.paymentMethodLast4).toBeNull();
   });
 
   it('Price ID からプランを判定する (ID は環境変数のみで管理する)', async () => {

--- a/apps/web/server/services/billing/webhookHandlers.ts
+++ b/apps/web/server/services/billing/webhookHandlers.ts
@@ -50,6 +50,10 @@ type SubscriptionSnapshot = {
   canceledAt: Date | null;
   trialStart: Date | null;
   trialEnd: Date | null;
+  /** 表示用のカード情報。**ブランドと下 4 桁のみ**保持する (PRD SR-BILL-02)。
+   *  カード番号・fingerprint は保存しない。取得できなければ null (既存値を保つ) */
+  paymentMethodBrand: string | null;
+  paymentMethodLast4: string | null;
 };
 
 const SUBSCRIPTION_EVENTS = new Set([
@@ -122,7 +126,10 @@ export async function prefetchSubscription(
 
   let subscription: Stripe.Subscription;
   try {
-    subscription = await getStripe().subscriptions.retrieve(subscriptionId);
+    // 既定の支払い方法も一緒に取る (カード表示用。追加の往復を避ける)
+    subscription = await getStripe().subscriptions.retrieve(subscriptionId, {
+      expand: ['default_payment_method'],
+    });
   } catch (err) {
     // 削除済みなどで取得できない場合は受信ペイロードで代替する
     console.warn('[stripe] subscription retrieve failed, falling back to payload:', err);
@@ -152,6 +159,26 @@ export async function prefetchSubscription(
     canceledAt: toDate(subscription.canceled_at),
     trialStart: toDate(subscription.trial_start),
     trialEnd: toDate(subscription.trial_end),
+    ...readCardForDisplay(subscription),
+  };
+}
+
+/**
+ * 表示用のカード情報を取り出す。
+ *
+ * **ブランドと下 4 桁だけ**を返す。カード番号や fingerprint は取得もしないし
+ * 保存もしない (PRD SR-BILL-02)。契約に既定の支払い方法が無い場合 (Checkout 直後など)
+ * は null を返し、呼び出し側が既存値を保つ。
+ */
+function readCardForDisplay(subscription: Stripe.Subscription): {
+  paymentMethodBrand: string | null;
+  paymentMethodLast4: string | null;
+} {
+  const pm = subscription.default_payment_method;
+  const card = pm && typeof pm === 'object' ? (pm as Stripe.PaymentMethod).card : undefined;
+  return {
+    paymentMethodBrand: card?.brand ?? null,
+    paymentMethodLast4: card?.last4 ?? null,
   };
 }
 
@@ -255,6 +282,13 @@ async function applySubscriptionSnapshot(
       trialStart: snapshot.trialStart,
       trialEnd: snapshot.trialEnd,
       ...(snapshot.trialStart ? { trialUsedAt: current.trialUsedAt ?? snapshot.trialStart } : {}),
+      // 取得できたときだけ更新する (一時的に取れなくても表示を消さない)
+      ...(snapshot.paymentMethodLast4
+        ? {
+            defaultPaymentMethodBrand: snapshot.paymentMethodBrand,
+            defaultPaymentMethodLast4: snapshot.paymentMethodLast4,
+          }
+        : {}),
       ...(promotesPendingPlan ? { pendingPlanCode: null, pendingPlanEffectiveAt: null } : {}),
       // 有効化されたら猶予をクリアする
       ...(active ? { gracePeriodEndsAt: null, lastPaymentFailedAt: null } : {}),


### PR DESCRIPTION
**Stripe テスト環境の E2E（項目 #14 Portal でのカード変更）で見つかった不具合の修正です。**

## 事象

`default_payment_method_brand` / `default_payment_method_last4` は、**カラムも DTO も画面表示コードもあるのに、どこからも書き込まれていませんでした。**

```
$ grep -rn "defaultPaymentMethod" apps/web/server/ packages/db/prisma/schema.prisma
  entitlement.ts:114   paymentMethod: subscription?.defaultPaymentMethodLast4   ← 読むだけ
  entitlement.ts:116     brand: subscription.defaultPaymentMethodBrand
  entitlement.ts:117     last4: subscription.defaultPaymentMethodLast4
  schema.prisma:453    defaultPaymentMethodBrand String?                        ← 定義だけ
  schema.prisma:454    defaultPaymentMethodLast4 String?
```

結果、`paymentMethod` は常に `null` になり、「お支払い方法」の行が出ません。Customer Portal でカードを変更しても画面には何も反映されないため、**#14 が確認できない**状態でした。

設計 §7.3 / PRD SR-BILL-02 の「カード情報はブランドと下 4 桁のみ表示用に保持する」が、実質未実装だったことになります。

## 修正

契約系イベントの `subscriptions.retrieve` で `default_payment_method` を展開し、**ブランドと下 4 桁だけ**をスナップショットへ入れて保存します。既に `retrieve` している経路に相乗りするので、API の往復は増えません。

**カード番号と fingerprint は取得も保存もしません。** `readCardForDisplay` が `card.brand` と `card.last4` 以外を触らない形にし、テストでも fingerprint が結果に混入しないことを検証しています。

取得できたときだけ更新します。Checkout 直後など一時的に取れない場合に、既存の表示を消さないためです。

## 確認

テスト環境で実際に決済を完了させたのち、契約イベントを再送して確認しました。

```
DB:    personal | trialing | visa | 4242
画面:  お支払い方法  visa •••• 4242
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
