### PR TITLE
test(web): Checkout 復帰後にポーリングで有効化される遷移を検証する

### DIFF
--- a/apps/web/src/features/billing/BillingPage.test.tsx
+++ b/apps/web/src/features/billing/BillingPage.test.tsx
@@ -263,6 +263,53 @@ describe('BillingPage (integration)', () => {
       expect(await screen.findByText(/お支払いの確認中です/)).toBeInTheDocument();
     });
 
+    it('Webhook が届くとポーリングで有効化され、反映待ちが消える', async () => {
+      // success URL への到達では有効化せず、Webhook 由来の契約状態だけを根拠にする
+      let activated = false;
+      server.use(
+        http.get('*/api/v1/billing/subscription', () =>
+          HttpResponse.json({
+            data: activated
+              ? {
+                  ...defaultBillingResponse,
+                  subscription: {
+                    ...defaultBillingResponse.subscription,
+                    planCode: 'personal',
+                    status: 'trialing',
+                    hasStripeCustomer: true,
+                  },
+                  entitlement: {
+                    ...defaultBillingResponse.entitlement,
+                    reason: 'trialing',
+                    planCode: 'personal',
+                    effectivePlanCode: 'personal',
+                    limits: { seatLimit: 1, projectLimit: 10 },
+                    message: 'Personal プランの無料トライアル中です。',
+                  },
+                }
+              : defaultBillingResponse,
+          }),
+        ),
+        http.get('*/api/v1/projects', () => HttpResponse.json({ data: [] })),
+      );
+      renderWithProviders(<BillingPage />, {
+        route: '/settings/billing?checkout=success&session_id=cs_1',
+      });
+
+      // Webhook 到着前は Free のまま
+      expect(await screen.findByText(/お支払いの確認中です/)).toBeInTheDocument();
+      expect(screen.getByText('Free プランを利用中です。')).toBeInTheDocument();
+
+      // Webhook が届いて契約が有効になる
+      activated = true;
+
+      await waitFor(
+        () => expect(screen.getByText('Personal プランの無料トライアル中です。')).toBeInTheDocument(),
+        { timeout: 5000 },
+      );
+      expect(screen.queryByText(/お支払いの確認中です/)).not.toBeInTheDocument();
+    });
+
     it('canceled で戻ると未完了の案内を出す', async () => {
       stubBilling();
       renderWithProviders(<BillingPage />, { route: '/settings/billing?checkout=canceled' });


### PR DESCRIPTION
Stripe テスト環境の E2E（項目 #7）で、テストが 1 段足りていないことに気づいたので足します。

## 足りていなかったもの

「success で戻った直後に**反映待ちを出す**」ところまでは検証していましたが、**そこから Webhook が届いて有効化されるまでの遷移**が未検証でした。

この遷移は SR-BILL-03（success URL への到達だけを根拠に有料権限を付与しない）の実効部分です。反映待ちを出すだけでは、契約状態が変わったときに画面が追従することを保証できません。

追加したテストは次を固定します。

1. Webhook 到着前は「お支払いの確認中です」を出しつつ、**表示は Free のまま**
2. 契約状態が `trialing` に変わると Personal の表示へ切り替わり、反映待ちが消える

## なぜブラウザの E2E で確認できなかったか

Browser ペインのタブは `document.visibilityState === 'hidden'` になり、TanStack Query は**非表示タブでは `refetchInterval` を止めます**。そのため実ブラウザではポーリングが走らず、この遷移を観測できませんでした。

実利用では Stripe から戻ってきたユーザーがタブを見ているので起きません。ただ、確認できない以上テスト側で担保しておくべきなので追加しています。

なお E2E では次を確認済みです。
- success URL に到達しても DB が `none` の間は Free のまま（権限を与えない）
- Webhook 由来で DB が `personal / trialing` になること（ブラウザの状態と無関係に反映される）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
